### PR TITLE
Add GitHub Action to publish Helm charts to GHCR

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -1,0 +1,55 @@
+name: Publish Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+jobs:
+  publish-charts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    strategy:
+      matrix:
+        chart:
+          - name: runtime-api
+            path: charts/runtime-api
+            repository: openhands-cloud-runtime-api
+          - name: image-loader
+            path: charts/image-loader
+            repository: openhands-cloud-image-loader
+          - name: openhands
+            path: charts/openhands
+            repository: openhands-cloud
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Helm Chart
+        uses: appany/helm-oci-chart-releaser@v0.4.2
+        with:
+          name: ${{ matrix.chart.name }}
+          repository: ${{ matrix.chart.repository }}
+          path: ${{ matrix.chart.path }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          tag: auto


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically publishes Helm charts to GitHub Container Registry (GHCR) when changes are merged to the main branch.

## Features:
- Publishes all three Helm charts (runtime-api, image-loader, and openhands) to GHCR
- Uses the appany/helm-oci-chart-releaser@v0.4.2 action for publishing
- Configures the GHCR repository names as requested:
  - openhands-cloud-runtime-api
  - openhands-cloud-image-loader
  - openhands-cloud (for the "openhands" chart)
- Triggers on pushes to the main branch that modify files in the charts directory
- Deduplicates logic by using GitHub Actions matrix strategy

## How it works:
The workflow uses a matrix strategy to iterate through the three charts, which allows for maximum code reuse while maintaining the ability to customize each chart's publishing parameters.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/716c9fa6c944400b9f9291c783272ff2)