### PR TITLE
Fix chart publishing condition to ensure charts are published on merge to main

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -58,9 +58,8 @@ jobs:
   publish-charts:
     runs-on: ubuntu-latest
     needs: test-charts
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(join(github.event.commits.*.modified, ' '), 'charts/')) || 
-      github.event_name == 'workflow_dispatch'
+    # Publish on pushes to main or manual triggers
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR fixes an issue with the Helm chart publishing workflow where charts were not being published when merging PRs to the main branch.

## Problem
The current workflow uses `github.event.commits.*.modified` to check if files in the charts directory were modified. However, this approach is unreliable when merging PRs, especially with squash merges or PRs with multiple commits.

## Solution
This PR simplifies the publishing condition to always publish charts when there's a push to the main branch or when manually triggered via workflow_dispatch. This ensures that charts are always published when changes are merged to main.

## Changes
- Removed the check for modified files in the charts directory
- Added a clearer comment explaining when charts are published
- Kept the manual trigger option via workflow_dispatch

After this change, charts will be published automatically whenever changes are merged to the main branch, regardless of which files were modified.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/716c9fa6c944400b9f9291c783272ff2)