### PR TITLE
Fix chart publishing by using native Helm commands

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -86,8 +86,8 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,11 +98,17 @@ jobs:
           echo "Updating dependencies for ${{ matrix.chart.name }}"
           helm dependency update ${{ matrix.chart.path }}
 
-      - name: Publish ${{ matrix.chart.name }} chart to GHCR
-        uses: appany/helm-oci-chart-releaser@v0.4.2
-        with:
-          name: ${{ matrix.chart.name }}
-          repository: ${{ matrix.chart.repository }}
-          path: ${{ matrix.chart.path }}
-          registry: ghcr.io/${{ github.repository_owner }}
-          tag: auto
+      - name: Package and Push Helm Chart
+        run: |
+          # Package the chart
+          helm package ${{ matrix.chart.path }}
+          
+          # Get chart name and version from the packaged file
+          CHART_PACKAGE=$(ls *.tgz | head -1)
+          CHART_NAME="${{ matrix.chart.name }}"
+          CHART_VERSION=$(helm show chart ${{ matrix.chart.path }} | grep "version:" | awk '{print $2}')
+          
+          echo "Publishing $CHART_NAME chart version $CHART_VERSION to GHCR"
+          
+          # Push to GHCR
+          helm push $CHART_PACKAGE oci://ghcr.io/${{ github.repository_owner }}/${{ matrix.chart.repository }}

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -86,29 +86,14 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - name: Publish ${{ matrix.chart.name }} chart to GHCR
+        uses: appany/helm-oci-chart-releaser@v0.4.2
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Update ${{ matrix.chart.name }} dependencies
-        run: |
-          echo "Updating dependencies for ${{ matrix.chart.name }}"
-          helm dependency update ${{ matrix.chart.path }}
-
-      - name: Package and Push Helm Chart
-        run: |
-          # Package the chart
-          helm package ${{ matrix.chart.path }}
-          
-          # Get chart name and version from the packaged file
-          CHART_PACKAGE=$(ls *.tgz | head -1)
-          CHART_NAME="${{ matrix.chart.name }}"
-          CHART_VERSION=$(helm show chart ${{ matrix.chart.path }} | grep "version:" | awk '{print $2}')
-          
-          echo "Publishing $CHART_NAME chart version $CHART_VERSION to GHCR"
-          
-          # Push to GHCR
-          helm push $CHART_PACKAGE oci://ghcr.io/${{ github.repository_owner }}/${{ matrix.chart.repository }}
+          name: ${{ matrix.chart.name }}
+          repository: ${{ matrix.chart.repository }}
+          path: ${{ matrix.chart.path }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          registry_username: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          update_dependencies: 'true'
+          tag: auto


### PR DESCRIPTION
This PR fixes the Helm chart publishing workflow by providing authentication credentials directly to the third-party action.## ProblemThe current workflow uses a third-party action (`appany/helm-oci-chart-releaser`) for publishing charts, but it's failing with authentication errors because we're not providing the credentials directly to the action:```Run appany/helm-oci-chart-releaser@v0.4.2Run echo  | helm registry login -u  --password-stdin ghcr.io/All-Hands-AIError: inappropriate ioctl for devicePassword: Error: Process completed with exit code 1.```## SolutionThis PR fixes the workflow by:1. Providing the registry credentials directly to the `appany/helm-oci-chart-releaser` action2. Setting `update_dependencies: 'true'` to ensure dependencies are updated before publishing## Changes- Removed the separate login step and dependency update step- Added registry credentials directly to the chart publishing action- Enabled automatic dependency updates in the actionAfter this change, charts will be published reliably to GHCR when changes are merged to the main branch.