### PR TITLE
Add helm lint to chart testing process

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -45,6 +45,15 @@ jobs:
           echo "Testing ${{ matrix.chart.name }} chart with default values"
           echo "Updating dependencies for ${{ matrix.chart.name }}"
           helm dependency update ${{ matrix.chart.path }}
+          
+          echo "Running helm lint for ${{ matrix.chart.name }}"
+          helm lint ${{ matrix.chart.path }}
+          if [ $? -ne 0 ]; then
+            echo "Helm lint test failed for ${{ matrix.chart.name }}"
+            exit 1
+          fi
+          echo "Helm lint test passed for ${{ matrix.chart.name }}"
+          
           echo "Running helm template for ${{ matrix.chart.name }}"
           helm template ${{ matrix.chart.path }} --debug
           if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR enhances the Helm chart testing process by adding `helm lint` to the workflow.

## Problem
The current workflow only runs `helm template` to test the charts, which validates that the templates can be rendered but doesn't check for best practices or potential issues in the chart structure.

## Solution
This PR adds `helm lint` to the testing process, which performs a series of tests to verify that the chart follows best practices and is well-formed.

## Changes
- Added `helm lint` step before the `helm template` step
- Added proper error handling and logging for the lint step
- Maintained the existing dependency update and template testing steps

## Benefits
- More thorough testing of Helm charts
- Earlier detection of issues in chart structure and metadata
- Better adherence to Helm best practices
- Improved reliability of chart publishing

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/716c9fa6c944400b9f9291c783272ff2)