### PR TITLE
Extract chart version from Chart.yaml for publishing

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -94,6 +94,13 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 'latest'
+          
+      - name: Extract chart version from Chart.yaml
+        id: chart_version
+        run: |
+          VERSION=$(grep '^version:' ${{ matrix.chart.path }}/Chart.yaml | awk '{print $2}')
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Using chart version: ${VERSION}"
 
       - name: Publish ${{ matrix.chart.name }} chart to GHCR
         uses: appany/helm-oci-chart-releaser@v0.4.2
@@ -105,4 +112,4 @@ jobs:
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'true'
-          tag: auto
+          tag: ${{ steps.chart_version.outputs.VERSION }}


### PR DESCRIPTION
This PR improves the Helm chart publishing workflow by extracting the chart version from Chart.yaml instead of using the auto tag.

## Problem
The current workflow uses `tag: auto` for publishing charts, which may not work correctly in all environments and can lead to inconsistent versioning.

## Solution
This PR adds a step to extract the chart version directly from the Chart.yaml file and use it explicitly in the publishing step.

## Changes
- Added a new step to extract the chart version from Chart.yaml using grep and awk
- Set the extracted version as an output variable
- Used the extracted version in the publishing step instead of 'auto'

## Benefits
- More reliable and consistent chart versioning
- Better traceability between chart source and published artifacts
- Explicit version control rather than relying on auto-detection
- Improved debugging capabilities with version logging

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/716c9fa6c944400b9f9291c783272ff2)