### PR TITLE
Fix GHCR compatibility by lowercasing repository owner

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -95,12 +95,17 @@ jobs:
         with:
           version: 'latest'
           
-      - name: Extract chart version from Chart.yaml
-        id: chart_version
+      - name: Extract chart version and prepare repository
+        id: chart_info
         run: |
           VERSION=$(grep '^version:' ${{ matrix.chart.path }}/Chart.yaml | awk '{print $2}')
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "Using chart version: ${VERSION}"
+          
+          # Convert repository owner to lowercase for GHCR
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPO_OWNER=${REPO_OWNER}" >> $GITHUB_OUTPUT
+          echo "Using repository owner: ${REPO_OWNER}"
 
       - name: Publish ${{ matrix.chart.name }} chart to GHCR
         uses: appany/helm-oci-chart-releaser@v0.4.2
@@ -108,8 +113,8 @@ jobs:
           name: ${{ matrix.chart.name }}
           repository: ${{ matrix.chart.repository }}
           path: ${{ matrix.chart.path }}
-          registry: ghcr.io/${{ github.repository_owner }}
+          registry: ghcr.io/${{ steps.chart_info.outputs.REPO_OWNER }}
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'true'
-          tag: ${{ steps.chart_version.outputs.VERSION }}
+          tag: ${{ steps.chart_info.outputs.VERSION }}


### PR DESCRIPTION
This PR fixes the Helm chart publishing workflow by ensuring GHCR compatibility with lowercase repository names.

## Problem
GHCR requires lowercase repository names, but the GitHub repository owner might contain uppercase letters, causing errors like:
```
Run helm push image-loader-0.1.0.tgz oci://ghcr.io/All-Hands-AI/openhands-cloud-image-loader
Error: invalid_reference: invalid repository
Error: Process completed with exit code 1.
```

## Solution
This PR adds steps to convert the repository owner to lowercase for GHCR compatibility.

## Changes
- Renamed the step to "Extract chart version and prepare repository" to better reflect its purpose
- Added logic to convert the repository owner to lowercase
- Set the lowercase repository owner as an output variable
- Used the lowercase repository owner in the publishing step

## Benefits
- Compatibility with GHCR's requirement for lowercase repository names
- More reliable chart publishing
- Improved debugging capabilities with repository logging

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/716c9fa6c944400b9f9291c783272ff2)