### PR TITLE
Update image tags to match deploy 0.47.0 release

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: 0.9.7
+appVersion: 0.47.0
 version: 0.1.1
 maintainers:
   - name: rbren

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -100,7 +100,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/all-hands-ai/deploy
-  tag: sha-4ec3e2f
+  tag: 0.47.0
 
 ingress:
   enabled: false
@@ -180,7 +180,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/all-hands-ai/runtime
-    tag: 35426a04d82956e8282f557c4ef75d022804a9f4-nikolaik
+    tag: 3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -422,7 +422,7 @@ runtime-api:
     enabled: false
   runtimeInSameCluster: true
   image:
-    tag: sha-530719c
+    tag: sha-77dd418
   imagePullSecrets: []
   resources:
     requests:
@@ -436,7 +436,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/all-hands-ai/runtime:35426a04d82956e8282f557c4ef75d022804a9f4-nikolaik"
+        image: "ghcr.io/all-hands-ai/runtime:3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik"
         working_dir: "/openhands/code/"
         environment: {}
         command:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/all-hands-ai/runtime-api
-  tag: latest
+  tag: sha-77dd418
   pullPolicy: Always
 
 imagePullSecrets:
@@ -115,7 +115,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/all-hands-ai/runtime:9e0fee189036e197d721ad359fd12bd02a1b1d09-nikolaik"
+      image: "ghcr.io/all-hands-ai/runtime:3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik"
       working_dir: "/openhands/code/"
       environment: {}
       command:


### PR DESCRIPTION
## Summary

This PR updates all image tags in the OpenHands-Cloud Helm charts to align with the versions specified in the deploy repository's 0.47.0 tag.

## Changes Made

### Image Tag Updates
- **Deploy image**: Updated from `sha-4ec3e2f` to `0.47.0`
- **Runtime image**: Updated from `35426a04d82956e8282f557c4ef75d022804a9f4-nikolaik` to `3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik`
- **Runtime API image**: Updated from `sha-530719c` to `sha-77dd418`

### Chart Updates
- **appVersion**: Updated from `0.9.7` to `0.47.0` in the openhands chart

### Files Modified
- `charts/openhands/values.yaml`: Updated deploy image tag, runtime image tag, runtime-api image tag, and warm runtime configuration
- `charts/runtime-api/values.yaml`: Updated runtime-api image tag and warm runtime configuration
- `charts/openhands/Chart.yaml`: Updated appVersion to match the release

## Version Alignment

These changes align with the versions specified in the deploy repository's 0.47.0 tag:
- **OPENHANDS_SHA**: `3c39b93f7e151f88e7b4274b80aafa604fcae092`
- **OPENHANDS_RUNTIME_IMAGE_TAG**: `3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik`
- **RUNTIME_API_SHA**: `77dd4185f7c1145542e5e88b700ba9e5653a6496`

## Testing

Please verify that:
- [ ] All image tags are valid and accessible
- [ ] The runtime configurations are properly updated
- [ ] The chart versions are consistent

## Impact

This update ensures that the OpenHands-Cloud deployment uses the latest stable versions from the 0.47.0 release, providing improved functionality and bug fixes.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/155dc4adbcce4d1793341f951c212d58)