### PR TITLE
Add GitLab events ingress route

### DIFF
--- a/charts/openhands/templates/ingress.yaml
+++ b/charts/openhands/templates/ingress.yaml
@@ -32,6 +32,13 @@ spec:
             name: openhands-integrations-service
             port:
               number: 3000
+      - path: /integration/gitlab/events
+        pathType: Exact
+        backend:
+          service:
+            name: openhands-integrations-service
+            port:
+              number: 3000
       - path: /slack
         pathType: Prefix
         backend:


### PR DESCRIPTION
This PR adds a new ingress route for `/integration/gitlab/events` with the exact same parameters as the existing GitHub events route.

Changes:
- Added a new ingress path for `/integration/gitlab/events` with `pathType: Exact`
- Points to the same backend service `openhands-integrations-service` on port `3000`
- Positioned right after the GitHub events route in the configuration

This will enable GitLab webhook integration similar to the existing GitHub integration.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/953f2ebf3a8842c796f15cff3aa4ac94)