### PR TITLE
Fix conditional secret exports for GitHub and GitLab integrations

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -122,6 +122,7 @@
     secretKeyRef:
       name: keycloak-admin
       key: admin-password
+{{- if .Values.github.enabled }}
 - name: GITHUB_APP_PRIVATE_KEY
   valueFrom:
     secretKeyRef:
@@ -147,6 +148,8 @@
     secretKeyRef:
       name: github-app
       key: client-secret
+{{- end }}
+{{- if .Values.gitlab.enabled }}
 - name: GITLAB_APP_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -157,6 +160,7 @@
     secretKeyRef:
       name: gitlab-app
       key: client-secret
+{{- end }}
 {{- if .Values.bitbucket.enabled }}
 - name: BITBUCKET_APP_CLIENT_ID
   valueFrom:


### PR DESCRIPTION
## Problem
When GitHub and GitLab integrations are disabled in `values.yaml` (`github.enabled: false`, `gitlab.enabled: false`), the container still tries to load their secrets, causing "secret not found" errors.

## Solution
- Wrap GitHub secrets with `{{- if .Values.github.enabled }}` conditional
- Wrap GitLab secrets with `{{- if .Values.gitlab.enabled }}` conditional
- Bitbucket secrets were already correctly conditional

## Changes
- Modified `charts/openhands/templates/_env.yaml` to only export integration secrets when their respective toggles are enabled
- Prevents deployment failures when integrations are disabled but secrets don't exist

## Testing
- Validated conditional logic with custom test script
- All GitHub/GitLab/Bitbucket secrets are properly wrapped in their respective conditionals

Fixes the issue where disabled integrations still required secrets to exist in the cluster.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/35d18ce8691b40ca8e13f77afc9bd29d)