### PR TITLE
Remove OPENHANDS_EXPERIMENT_MANAGER_CLS from Helm charts

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -15,8 +15,6 @@
   value: {{ .Values.appConfig.OPENHANDS_MCP_CONFIG_CLS }}
 - name: OPENHANDS_CONVERSATION_VALIDATOR_CLS
   value: {{ .Values.appConfig.OPENHANDS_CONVERSATION_VALIDATOR_CLS }}
-- name: OPENHANDS_EXPERIMENT_MANAGER_CLS
-  value: {{ .Values.appConfig.OPENHANDS_EXPERIMENT_MANAGER_CLS }}
 - name: LOG_JSON # Configure structured logging for Google Cloud
   value: '1'
 - name: LOG_JSON_LEVEL_KEY

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -14,7 +14,6 @@ appConfig:
   OPENHANDS_GITLAB_SERVICE_CLS: "integrations.gitlab.gitlab_service.SaaSGitLabService"
   OPENHANDS_BITBUCKET_SERVICE_CLS: "integrations.bitbucket.bitbucket_service.SaaSBitBucketService"
   OPENHANDS_MCP_CONFIG_CLS: "server.mcp.mcp_config.SaaSOpenHandsMCPConfig"
-  OPENHANDS_EXPERIMENT_MANAGER_CLS: "experiments.experiment_manager.SaaSExperimentManager"
   POSTHOG_CLIENT_KEY: "1234abcd"
 
 commonRoomSync:


### PR DESCRIPTION
This PR removes all instances of `OPENHANDS_EXPERIMENT_MANAGER_CLS` from the Helm charts as requested.

Changes made:
1. Removed the environment variable definition from `charts/openhands/values.yaml`
2. Removed the environment variable setup from `charts/openhands/templates/_env.yaml`

These changes will ensure that the deprecated experiment manager class is no longer referenced in the Helm deployment.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1c8042ece482468eb092dd2a549ca6f5)