### PR TITLE
Add daily maintenance tasks cron job from deploy PR #1473

### DIFF
--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.maintenanceTasks.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-maintenance-tasks
+  labels:
+    app: {{ .Release.Name }}-maintenance-tasks
+spec:
+  schedule: {{ .Values.maintenanceTasks.schedule | quote }}
+  concurrencyPolicy: {{ .Values.maintenanceTasks.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.maintenanceTasks.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.maintenanceTasks.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.maintenanceTasks.backoffLimit }}
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          name: maintenance-tasks
+          labels:
+            app: {{ .Release.Name }}-maintenance-tasks
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: maintenance-tasks
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              command: ["/bin/sh", "-c"]
+              workingDir: /app
+              args:
+                - |
+                  echo "Running maintenance tasks..."
+                  python -m run_maintenance_tasks
+              env:
+                {{- include "openhands.env" . | nindent 16 }}
+              resources:
+                {{- toYaml .Values.maintenanceTasks.resources | nindent 16 }}
+{{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -430,6 +430,21 @@ redis:
       memory: 512Mi
       cpu: 100m
 
+maintenanceTasks:
+  enabled: true
+  schedule: "0 6 * * *" # Run daily at 1AM Eastern Time (6AM UTC)
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  backoffLimit: 3
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
 runtime-api:
   enabled: false
   replicaCount: 1


### PR DESCRIPTION
## Summary

This PR adds the maintenance tasks cron job from [All-Hands-AI/deploy PR #1473](https://github.com/All-Hands-AI/deploy/pull/1473) to the OpenHands-Cloud repository.

## Changes Made

1. Added a new template file `maintenance-tasks-cronjob.yaml` that creates a CronJob for running maintenance tasks
2. Added configuration in `values.yaml` for the maintenance tasks cron job

## Details

The maintenance tasks cron job runs daily at 1AM Eastern Time (6AM UTC) and executes the `run_maintenance_tasks` Python module. The job is configured with the following settings:

- Schedule: `0 6 * * *` (daily at 1AM ET / 6AM UTC)
- Concurrency Policy: `Forbid` (prevents overlapping executions)
- Resource Requests: 512Mi memory, 200m CPU
- Resource Limits: 1Gi memory, 500m CPU
- Job History: 3 failed/successful jobs retained

## Testing

The changes have been tested by verifying that the template and values are correctly formatted and follow the same pattern as other cron jobs in the repository.

## Related PRs

- [All-Hands-AI/deploy PR #1473](https://github.com/All-Hands-AI/deploy/pull/1473) - Original PR that converts the maintenance tasks job to a cron job

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a5b3205ba36e461a9dad759799388e30)