### PR TITLE
Add maintenance tasks cron job from deploy PR #1473

### DIFF
--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.maintenanceTasks.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-maintenance-tasks
+  labels:
+    app: {{ .Release.Name }}-maintenance-tasks
+spec:
+  schedule: {{ .Values.maintenanceTasks.schedule | quote }}
+  concurrencyPolicy: {{ .Values.maintenanceTasks.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.maintenanceTasks.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.maintenanceTasks.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.maintenanceTasks.backoffLimit }}
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          name: maintenance-tasks
+          labels:
+            app: {{ .Release.Name }}-maintenance-tasks
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: maintenance-tasks
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              command: ["/bin/sh", "-c"]
+              workingDir: /app
+              args:
+                - |
+                  echo "Running maintenance tasks..."
+                  python -m run_maintenance_tasks
+              env:
+                {{- include "openhands.env" . | nindent 16 }}
+              resources:
+                {{- toYaml .Values.maintenanceTasks.resources | nindent 16 }}
+{{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -430,6 +430,21 @@ redis:
       memory: 512Mi
       cpu: 100m
 
+maintenanceTasks:
+  enabled: true
+  schedule: "0 6 * * *" # Run daily at 1AM Eastern Time (6AM UTC)
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  backoffLimit: 3
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
 runtime-api:
   enabled: false
   replicaCount: 1


### PR DESCRIPTION
## Summary

This PR adds the maintenance tasks cron job that was implemented in the deploy repository PR #1473. The cron job runs daily at 1AM Eastern Time (6AM UTC) to perform routine maintenance tasks.

## Changes Made

### 1. Added Maintenance Tasks CronJob Template
- **New file**: `charts/openhands/templates/maintenance-tasks-cronjob.yaml`
- **Kind**: `CronJob` (batch/v1)
- **Schedule**: `0 6 * * *` (1AM Eastern Time / 6AM UTC)
- **Features**:
  - Conditional rendering with `{{- if .Values.maintenanceTasks.enabled }}`
  - Proper resource limits and requests
  - Job history management (3 failed/successful jobs retained)
  - `concurrencyPolicy: Forbid` to prevent overlapping executions
  - `ttlSecondsAfterFinished: 3600` for job cleanup

### 2. Added Configuration to values.yaml
- Added `maintenanceTasks` section with the following configuration:
  - `enabled: true` - Enable the cron job by default
  - `schedule: "0 6 * * *"` - Run daily at 1AM Eastern Time (6AM UTC)
  - `concurrencyPolicy: Forbid` - Prevent overlapping executions
  - `failedJobsHistoryLimit: 3` - Keep 3 failed job records
  - `successfulJobsHistoryLimit: 3` - Keep 3 successful job records
  - `backoffLimit: 3` - Allow up to 3 retry attempts
  - Resource configuration:
    - Requests: 512Mi memory, 200m CPU
    - Limits: 1Gi memory, 500m CPU

## Behavior

**What it does**:
- Runs maintenance tasks automatically every day at 1AM Eastern Time
- Executes `python -m run_maintenance_tasks` in the OpenHands container
- Uses the same environment variables and configuration as the main application
- Can be easily enabled/disabled via the `maintenanceTasks.enabled` flag

**Benefits**:
- Automated maintenance task execution
- No longer depends on deployment processes
- Configurable schedule and resource limits
- Proper job history management and cleanup

## Configuration

The CronJob can be configured in `values.yaml`:

```yaml
maintenanceTasks:
  enabled: true
  schedule: "0 6 * * *" # Run daily at 1AM Eastern Time (6AM UTC)
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 3
  successfulJobsHistoryLimit: 3
  backoffLimit: 3
  resources:
    requests:
      memory: "512Mi"
      cpu: "200m"
    limits:
      memory: "1Gi"
      cpu: "500m"
```

## Testing

- ✅ Helm template validation (no syntax errors)
- ✅ CronJob generates correctly with proper schedule and configuration
- ✅ Can be disabled by setting `maintenanceTasks.enabled: false`

## Deployment Impact

- **Non-breaking**: Existing deployments will continue to work
- **Automatic**: The CronJob will be created on next deployment
- **Configurable**: Can be disabled in environment-specific values if needed

This implementation mirrors the changes from deploy repository PR #1473, providing automated maintenance task execution for the OpenHands Cloud deployment.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a5b3205ba36e461a9dad759799388e30)