### PR TITLE
Add securityContext and runAsUser options for all pods in Helm charts

### DIFF
--- a/charts/image-loader/templates/daemonset.yaml
+++ b/charts/image-loader/templates/daemonset.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         {{- include "image-loader.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/image-loader/templates/node-overprovisioner.yaml
+++ b/charts/image-loader/templates/node-overprovisioner.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/component: node-overprovisioner
     spec:
       priorityClassName: {{ .Values.nodeOverprovisioner.priorityClassName | default "node-overprovisioner-priority" }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -13,6 +13,11 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# Security context settings for all pods
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+
 nodeSelector:
   sysbox-install: "yes"
 

--- a/charts/openhands/templates/common-room-sync-cronjob.yaml
+++ b/charts/openhands/templates/common-room-sync-cronjob.yaml
@@ -18,6 +18,10 @@ spec:
           labels:
             app: {{ .Release.Name }}-common-room-sync
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
+++ b/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
@@ -19,6 +19,10 @@ spec:
           labels:
             app: {{ .Release.Name | trunc 27 }}-enrich-user-interaction
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/templates/gitlab-webhook-verify-cronjob.yaml
+++ b/charts/openhands/templates/gitlab-webhook-verify-cronjob.yaml
@@ -18,6 +18,10 @@ spec:
           labels:
             app: {{ .Release.Name }}-install-hooks
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/templates/integration-events-deployment.yaml
+++ b/charts/openhands/templates/integration-events-deployment.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/templates/keycloak-config-job.yaml
+++ b/charts/openhands/templates/keycloak-config-job.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -20,6 +20,10 @@ spec:
           labels:
             app: {{ .Release.Name }}-maintenance-tasks
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: Never
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/templates/mcp-events-deployment.yaml
+++ b/charts/openhands/templates/mcp-events-deployment.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/templates/migrate-db.job.yaml
+++ b/charts/openhands/templates/migrate-db.job.yaml
@@ -17,6 +17,10 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       restartPolicy: Never
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
+++ b/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
@@ -18,6 +18,10 @@ spec:
           labels:
             app: {{ .Release.Name }}-proactive-convo-clean
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/templates/resend-sync-cronjob.yaml
+++ b/charts/openhands/templates/resend-sync-cronjob.yaml
@@ -18,6 +18,10 @@ spec:
           labels:
             app: {{ .Release.Name }}-resend-sync
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -57,6 +57,11 @@ deployment:
     limits:
       memory: 3Gi
 
+# Security context settings for all pods
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+
 env:
   DISABLE_WAITLIST: "true"
   SANDBOX_REMOTE_RUNTIME_API_TIMEOUT: "60"

--- a/charts/runtime-api/templates/cleanup-cronjob.yaml
+++ b/charts/runtime-api/templates/cleanup-cronjob.yaml
@@ -11,6 +11,10 @@ spec:
     spec:
       template:
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/runtime-api/templates/create-db-user-job.yaml
+++ b/charts/runtime-api/templates/create-db-user-job.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: create-user
         image: postgres:14

--- a/charts/runtime-api/templates/db-cleanup-cronjob.yaml
+++ b/charts/runtime-api/templates/db-cleanup-cronjob.yaml
@@ -14,6 +14,10 @@ spec:
     spec:
       template:
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/runtime-api/templates/deployment.yaml
+++ b/charts/runtime-api/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
         {{- include "runtime-api.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/runtime-api/templates/migrate-db.job.yaml
+++ b/charts/runtime-api/templates/migrate-db.job.yaml
@@ -25,6 +25,10 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       restartPolicy: OnFailure
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/runtime-api/templates/pod-status-logger-cronjob.yaml
+++ b/charts/runtime-api/templates/pod-status-logger-cronjob.yaml
@@ -12,6 +12,10 @@ spec:
     spec:
       template:
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
+++ b/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
@@ -15,6 +15,10 @@ spec:
           labels:
             {{- include "runtime-api.selectorLabels" . | nindent 12 }}
         spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           restartPolicy: OnFailure
           {{- with .Values.imagePullSecrets }}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -43,6 +43,11 @@ resources:
     cpu: 1
     memory: 4Gi
 
+# Security context settings for all pods
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Description
This PR adds securityContext and runAsUser options for all pods in the Helm charts to enhance security by ensuring pods run with a non-root user.

## Changes
- Added securityContext settings with runAsUser: 1000 and runAsNonRoot: true to values.yaml files in all three charts:
  - openhands
  - image-loader
  - runtime-api
- Updated all pod specifications in templates to include the securityContext settings:
  - Deployments
  - Jobs
  - CronJobs
  - DaemonSets

## Security Impact
This change improves the security posture of the application by:
- Ensuring pods run with a non-root user (UID 1000)
- Explicitly preventing pods from running as root with runAsNonRoot: true

## Testing
These changes should be tested in a non-production environment to ensure all pods start correctly with the new security context settings.