### PR TITLE
Add runtime-wildcard certificate support to openhands chart

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -18,6 +18,16 @@ This Helm chart deploys the complete OpenHands stack, including all required dep
 See the [values.yaml](values.yaml) file for the full list of configurable parameters.
 Make sure to update all values marked with "REQUIRED" comments.
 
+### TLS and Certificate Configuration
+
+The chart supports two methods for TLS configuration:
+
+1. **Standard TLS**: Enable with `tls.enabled: true`. This uses a certificate with the name format `app-all-hands-{env}-tls`.
+
+2. **Wildcard Certificate**: Enable with `certificate.enabled: true`. This creates a cert-manager Certificate resource that can use a wildcard domain (e.g., `*.prod-runtime.all-hands.dev`). This is particularly useful for runtime environments where you need a wildcard certificate.
+
+For runtime environments, see the [values.runtime-example.yaml](values.runtime-example.yaml) file for an example configuration using a wildcard certificate.
+
 An [example-values.yaml](example-values.yaml) file is also provided as a starting point
 for your own configuration. This example file contains the minimum set of values you need
 to override when deploying the chart with the default included services

--- a/charts/openhands/templates/certificate.yaml
+++ b/charts/openhands/templates/certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certificate.name }}
+spec:
+  {{- with .Values.certificate.commonName }}
+  commonName: {{ . }}
+  {{- end }}
+  dnsNames:
+  {{- range $domain := .Values.certificate.domains }}
+  - {{ $domain | quote }}
+  {{- end }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: {{ .Values.certificate.issuer }}
+  secretName: {{ .Values.certificate.secretName }}
+  usages:
+  - digital signature
+  - key encipherment
+{{- end }}

--- a/charts/openhands/templates/ingress.yaml
+++ b/charts/openhands/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ .Values.ingress.annotations | toYaml | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.class }}
-  {{- if .Values.tls.enabled }}
+  {{- if or .Values.tls.enabled .Values.certificate.enabled }}
   tls:
   - hosts:
     {{- if .Values.ingress.prefixWithBranch }}
@@ -15,7 +15,11 @@ spec:
     {{- else }}
     - {{ .Values.ingress.host }}
     {{- end }}
+    {{- if .Values.certificate.enabled }}
+    secretName: {{ .Values.certificate.secretName }}
+    {{- else }}
     secretName: app-all-hands-{{ .Values.tls.env }}-tls
+    {{- end }}
   {{- end }}
   rules:
   {{- if .Values.ingress.prefixWithBranch }}

--- a/charts/openhands/values.runtime-example.yaml
+++ b/charts/openhands/values.runtime-example.yaml
@@ -1,0 +1,22 @@
+# Example values file for a runtime environment with wildcard certificate
+ingress:
+  enabled: true
+  host: "example.prod-runtime.all-hands.dev"
+  class: traefik
+  annotations:
+    # No need for cert-manager annotation as we're using the wildcard certificate
+    # that's already created and managed by the infrastructure
+
+# Enable the wildcard certificate
+certificate:
+  enabled: true
+  name: runtime-wildcard
+  secretName: runtime-wildcard-tls
+  issuer: google-clouddns
+  domains:
+  - "*.prod-runtime.all-hands.dev"
+  commonName: "*.prod-runtime.all-hands.dev"
+
+# No need to enable TLS separately as it's handled by the certificate
+tls:
+  enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -242,6 +242,15 @@ tavily:
 tls:
   enabled: false
 
+certificate:
+  enabled: false
+  name: runtime-wildcard
+  secretName: runtime-wildcard-tls
+  issuer: google-clouddns
+  # domains:
+  # - "*.prod-runtime.all-hands.dev"
+  # commonName: "*.prod-runtime.all-hands.dev"
+
 uvicorn:
   workers: 3
 


### PR DESCRIPTION
This PR adds support for runtime-wildcard certificates in the OpenHands chart, similar to what's done in the infra repository.

## Changes

- Added a new `certificate.yaml` template that creates a cert-manager Certificate resource
- Updated the `values.yaml` file to include certificate configuration options
- Modified the ingress template to use the wildcard certificate when enabled
- Created an example values file (`values.runtime-example.yaml`) for runtime environments
- Updated the README with documentation about the new certificate feature

## Usage

To use a wildcard certificate in a runtime environment:

1. Enable the certificate with `certificate.enabled: true`
2. Configure the certificate domains and common name (e.g., `*.prod-runtime.all-hands.dev`)
3. Set the certificate issuer (e.g., `google-clouddns`)
4. The ingress will automatically use the certificate's secret name

This implementation allows for using wildcard certificates in runtime environments without having to create them manually or through separate infrastructure.