### PR TITLE
Add ingress base ConfigMap support to runtime-api chart

### DIFF
--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -5,6 +5,10 @@
 {{- end }}
 - name: RUNTIME_DEAD_SECONDS
   value: {{ printf "%.0f" .Values.cleanup.dead_seconds | quote }}
+{{- if .Values.ingressBase.enabled }}
+- name: INGRESS_BASE
+  value: "/ingress-base/base-ingress.yaml"
+{{- end }}
 # Datadog environment variables
 - name: DD_AGENT_HOST
   value: "datadog-agent.all-hands-system.svc.cluster.local"

--- a/charts/runtime-api/templates/deployment.yaml
+++ b/charts/runtime-api/templates/deployment.yaml
@@ -23,11 +23,16 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.warmRuntimes.enabled }}
       volumes:
+      {{- if .Values.warmRuntimes.enabled }}
         - name: warm-runtimes-config
           configMap:
             name: {{ .Values.warmRuntimes.configMapName }}
+      {{- end }}
+      {{- if .Values.ingressBase.enabled }}
+        - name: ingress-base-config
+          configMap:
+            name: {{ include "runtime-api.fullname" . }}-ingress-base
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -60,8 +65,14 @@ spec:
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.warmRuntimes.enabled }}
+          {{- if or .Values.warmRuntimes.enabled .Values.ingressBase.enabled }}
           volumeMounts:
+          {{- if .Values.warmRuntimes.enabled }}
             - name: warm-runtimes-config
               mountPath: /config
+          {{- end }}
+          {{- if .Values.ingressBase.enabled }}
+            - name: ingress-base-config
+              mountPath: /ingress-base
+          {{- end }}
           {{- end }}

--- a/charts/runtime-api/templates/ingress-base-configmap.yaml
+++ b/charts/runtime-api/templates/ingress-base-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.ingressBase.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "runtime-api.fullname" . }}-ingress-base
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
+data:
+  base-ingress.yaml: |
+{{- .Values.ingressBase.content | nindent 4 }}
+{{- end }}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -102,6 +102,27 @@ ingress:
   pathType: Prefix
   tls: true
 
+# Base ingress configuration for runtime ingress inheritance
+ingressBase:
+  enabled: false
+  # YAML content of the base ingress that runtime ingresses will inherit from
+  # Only metadata (labels and annotations) will be inherited, not the spec
+  content: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: base-ingress
+      labels:
+        app: runtime-api
+        environment: production
+        team: platform
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+    spec:
+      rules: []
+
 autoscaling:
   enabled: true
   minReplicas: 3


### PR DESCRIPTION
## Summary

This PR adds support for the new `INGRESS_BASE` environment variable in the runtime-api Helm chart by creating a ConfigMap that contains a base ingress YAML file for runtime ingress inheritance.

## Changes

### New Configuration Section
- **Added `ingressBase` section to `values.yaml`** with:
  - `enabled: false` (disabled by default)
  - `content` field containing example base ingress YAML

### New Template
- **Created `ingress-base-configmap.yaml`** that:
  - Creates a ConfigMap when `ingressBase.enabled=true`
  - Contains the base ingress YAML content from values
  - Uses proper Helm labels and naming conventions

### Updated Deployment
- **Modified `deployment.yaml`** to:
  - Mount the ingress base ConfigMap as a volume at `/ingress-base`
  - Handle volume mounting for both warm runtimes and ingress base
  - Only create volumes/mounts when the respective features are enabled

### Updated Environment Variables
- **Modified `_env.yaml`** to:
  - Set `INGRESS_BASE=/ingress-base/base-ingress.yaml` when enabled
  - Point to the mounted ConfigMap file

## Usage

To enable ingress base inheritance:

```yaml
ingressBase:
  enabled: true
  content: |
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
      name: base-ingress
      labels:
        app: runtime-api
        environment: production
        team: platform
      annotations:
        kubernetes.io/ingress.class: nginx
        nginx.ingress.kubernetes.io/ssl-redirect: "true"
        cert-manager.io/cluster-issuer: letsencrypt-prod
    spec:
      rules: []
```

## Behavior

When enabled:
1. Creates a ConfigMap containing the base ingress YAML
2. Mounts the ConfigMap to `/ingress-base` in the runtime-api pod
3. Sets `INGRESS_BASE` environment variable to the mounted file path
4. Runtime ingresses will inherit labels and annotations from the base ingress

## Testing

- ✅ Helm template renders correctly when `ingressBase.enabled=true`
- ✅ No ingress-base resources created when `ingressBase.enabled=false`
- ✅ ConfigMap contains proper YAML content
- ✅ Environment variable points to correct file path
- ✅ Volume mounts work alongside existing warm runtimes feature

## Related

This PR works in conjunction with the runtime-api code changes that implement the `INGRESS_BASE` functionality for inheriting labels, annotations, and ingress class from a base ingress file.