### PR TITLE
Add wildcard certs for the runtimes and fix runtime-api-sa

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -18,6 +18,16 @@ This Helm chart deploys the complete OpenHands stack, including all required dep
 See the [values.yaml](values.yaml) file for the full list of configurable parameters.
 Make sure to update all values marked with "REQUIRED" comments.
 
+### TLS and Certificate Configuration
+
+The chart supports two methods for TLS configuration:
+
+1. **Standard TLS**: Enable with `tls.enabled: true`. This uses a certificate with the name format `app-all-hands-{env}-tls`.
+
+2. **Wildcard Certificate**: Enable with `certificate.enabled: true`. This creates a cert-manager Certificate resource that can use a wildcard domain (e.g., `*.prod-runtime.all-hands.dev`). This is particularly useful for runtime environments where you need a wildcard certificate.
+
+For runtime environments, see the [values.runtime-example.yaml](values.runtime-example.yaml) file for an example configuration using a wildcard certificate.
+
 An [example-values.yaml](example-values.yaml) file is also provided as a starting point
 for your own configuration. This example file contains the minimum set of values you need
 to override when deploying the chart with the default included services

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -26,7 +26,9 @@ The chart supports two methods for TLS configuration:
 
 2. **Wildcard Certificate**: Enable with `certificate.enabled: true`. This creates a cert-manager Certificate resource that can use a wildcard domain (e.g., `*.prod-runtime.all-hands.dev`). This is particularly useful for runtime environments where you need a wildcard certificate.
 
-For runtime environments, see the [values.runtime-example.yaml](values.runtime-example.yaml) file for an example configuration using a wildcard certificate.
+3. **TLSStore for Traefik**: Enable with `tlsStore.enabled: true`. This creates a Traefik TLSStore resource that configures the default certificate for Traefik to use. When combined with a wildcard certificate, this allows Traefik to use the wildcard certificate for all TLS connections.
+
+For runtime environments, see the [values.runtime-example.yaml](values.runtime-example.yaml) file for an example configuration using a wildcard certificate and TLSStore.
 
 An [example-values.yaml](example-values.yaml) file is also provided as a starting point
 for your own configuration. This example file contains the minimum set of values you need

--- a/charts/openhands/templates/certificate.yaml
+++ b/charts/openhands/templates/certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certificate.name }}
+spec:
+  {{- with .Values.certificate.commonName }}
+  commonName: {{ . }}
+  {{- end }}
+  dnsNames:
+  {{- range $domain := .Values.certificate.domains }}
+  - {{ $domain | quote }}
+  {{- end }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: {{ .Values.certificate.issuer }}
+  secretName: {{ .Values.certificate.secretName }}
+  usages:
+  - digital signature
+  - key encipherment
+{{- end }}

--- a/charts/openhands/templates/certificate.yaml
+++ b/charts/openhands/templates/certificate.yaml
@@ -4,13 +4,15 @@ kind: Certificate
 metadata:
   name: {{ .Values.certificate.name }}
 spec:
-  {{- with .Values.certificate.commonName }}
-  commonName: {{ . }}
+  {{- if .Values.certificate.commonName }}
+  commonName: {{ .Values.certificate.commonName }}
   {{- end }}
   dnsNames:
-  {{- range $domain := .Values.certificate.domains }}
-  - {{ $domain | quote }}
-  {{- end }}
+{{- if .Values.certificate.domains }}
+{{- range .Values.certificate.domains }}
+  - {{ . | quote }}
+{{- end }}
+{{- end }}
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/charts/openhands/templates/ingress.yaml
+++ b/charts/openhands/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ .Values.ingress.annotations | toYaml | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.class }}
-  {{- if .Values.tls.enabled }}
+  {{- if or .Values.tls.enabled .Values.certificate.enabled }}
   tls:
   - hosts:
     {{- if .Values.ingress.prefixWithBranch }}
@@ -15,7 +15,11 @@ spec:
     {{- else }}
     - {{ .Values.ingress.host }}
     {{- end }}
+    {{- if .Values.certificate.enabled }}
+    secretName: {{ .Values.certificate.secretName }}
+    {{- else }}
     secretName: app-all-hands-{{ .Values.tls.env }}-tls
+    {{- end }}
   {{- end }}
   rules:
   {{- if .Values.ingress.prefixWithBranch }}

--- a/charts/openhands/templates/tlsstore.yaml
+++ b/charts/openhands/templates/tlsstore.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.tlsStore.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: {{ .Values.tlsStore.name }}
+spec:
+  defaultCertificate:
+    secretName: {{ .Values.tlsStore.secretName }}
+{{- end }}

--- a/charts/openhands/values.runtime-example.yaml
+++ b/charts/openhands/values.runtime-example.yaml
@@ -14,7 +14,7 @@ certificate:
   secretName: runtime-wildcard-tls
   issuer: google-clouddns
   domains:
-  - "*.prod-runtime.all-hands.dev"
+    - "*.prod-runtime.all-hands.dev"
   commonName: "*.prod-runtime.all-hands.dev"
 
 # Enable the TLSStore for Traefik to use the wildcard certificate as default

--- a/charts/openhands/values.runtime-example.yaml
+++ b/charts/openhands/values.runtime-example.yaml
@@ -17,6 +17,12 @@ certificate:
   - "*.prod-runtime.all-hands.dev"
   commonName: "*.prod-runtime.all-hands.dev"
 
+# Enable the TLSStore for Traefik to use the wildcard certificate as default
+tlsStore:
+  enabled: true
+  name: default
+  secretName: runtime-wildcard-tls
+
 # No need to enable TLS separately as it's handled by the certificate
 tls:
   enabled: false

--- a/charts/openhands/values.runtime-example.yaml
+++ b/charts/openhands/values.runtime-example.yaml
@@ -1,0 +1,22 @@
+# Example values file for a runtime environment with wildcard certificate
+ingress:
+  enabled: true
+  host: "example.prod-runtime.all-hands.dev"
+  class: traefik
+  annotations:
+    # No need for cert-manager annotation as we're using the wildcard certificate
+    # that's already created and managed by the infrastructure
+
+# Enable the wildcard certificate
+certificate:
+  enabled: true
+  name: runtime-wildcard
+  secretName: runtime-wildcard-tls
+  issuer: google-clouddns
+  domains:
+  - "*.prod-runtime.all-hands.dev"
+  commonName: "*.prod-runtime.all-hands.dev"
+
+# No need to enable TLS separately as it's handled by the certificate
+tls:
+  enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -247,8 +247,10 @@ certificate:
   name: runtime-wildcard
   secretName: runtime-wildcard-tls
   issuer: google-clouddns
+  domains: []
+  # Example domains configuration:
   # domains:
-  # - "*.prod-runtime.all-hands.dev"
+  #   - "*.prod-runtime.all-hands.dev"
   # commonName: "*.prod-runtime.all-hands.dev"
 
 tlsStore:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -251,6 +251,11 @@ certificate:
   # - "*.prod-runtime.all-hands.dev"
   # commonName: "*.prod-runtime.all-hands.dev"
 
+tlsStore:
+  enabled: false
+  name: default
+  secretName: runtime-wildcard-tls
+
 uvicorn:
   workers: 3
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -242,6 +242,15 @@ tavily:
 tls:
   enabled: false
 
+certificate:
+  enabled: false
+  name: runtime-wildcard
+  secretName: runtime-wildcard-tls
+  issuer: google-clouddns
+  # domains:
+  # - "*.prod-runtime.all-hands.dev"
+  # commonName: "*.prod-runtime.all-hands.dev"
+
 uvicorn:
   workers: 3
 

--- a/charts/runtime-api/templates/migrate-db.job.yaml
+++ b/charts/runtime-api/templates/migrate-db.job.yaml
@@ -5,11 +5,7 @@ metadata:
   labels:
     {{- include "runtime-api.labels" . | nindent 4 }}
   annotations:
-  {{- if not (or .Values.postgresql.enabled .Values.postgresql.postMigrate) }}
-    "helm.sh/hook": "pre-install,pre-upgrade"
-  {{- else }}
     "helm.sh/hook": "post-install,post-upgrade"
-  {{- end }}
     "helm.sh/hook-weight": "-5"
   {{- if .Values.postgresql.isFeatureDeploy }}
     "helm.sh/hook-delete-policy": "hook-succeeded"

--- a/charts/runtime-api/templates/serviceaccount.yaml
+++ b/charts/runtime-api/templates/serviceaccount.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
     {{- include "runtime-api.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-10"
     {{- range $key, $value := .Values.serviceAccount.annotations }}
     "{{ $key }}": "{{ $value }}"
     {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
The runtime wildcard certs are needed for https to the runtime URLs.

The runtime-api-sa service account had helm hook which caused it to be recreated every helm install. This caused problem for any pod that uses runtime-api-sa as they would get a 401 because they still use the old service account UID.
