### PR TITLE
Split ingress configuration into separate ingress objects

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.47.0
-version: 0.1.10
+version: 0.1.11
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -2,9 +2,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: openhands-ingress
+  name: openhands-integrations-ingress
   annotations:
+    {{- if .Values.ingress.integrations.annotations }}
+    {{ .Values.ingress.integrations.annotations | toYaml | nindent 4 }}
+    {{- else }}
     {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.class }}
   {{- if .Values.tls.enabled }}
@@ -44,20 +48,6 @@ spec:
         backend:
           service:
             name: openhands-integrations-service
-            port:
-              number: 3000
-      - path: /mcp/mcp
-        pathType: Prefix
-        backend:
-          service:
-            name: openhands-mcp-service
-            port:
-              number: 3000
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: openhands-service
             port:
               number: 3000
 {{- end }}

--- a/charts/openhands/templates/ingress-mcp.yaml
+++ b/charts/openhands/templates/ingress-mcp.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openhands-mcp-ingress
+  annotations:
+    {{- if .Values.ingress.mcp.annotations }}
+    {{ .Values.ingress.mcp.annotations | toYaml | nindent 4 }}
+    {{- else }}
+    {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- if .Values.tls.enabled }}
+  tls:
+  - hosts:
+    {{- if .Values.ingress.prefixWithBranch }}
+    - {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
+    {{- else }}
+    - {{ .Values.ingress.host }}
+    {{- end }}
+    secretName: app-all-hands-{{ .Values.tls.env }}-tls
+  {{- end }}
+  rules:
+  {{- if .Values.ingress.prefixWithBranch }}
+  - host: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
+  {{- else }}
+  - host: {{ .Values.ingress.host }}
+  {{- end }}
+    http:
+      paths:
+      - path: /mcp/mcp
+        pathType: Prefix
+        backend:
+          service:
+            name: openhands-mcp-service
+            port:
+              number: 3000
+{{- end }}

--- a/charts/openhands/templates/ingress-root.yaml
+++ b/charts/openhands/templates/ingress-root.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openhands-root-ingress
+  annotations:
+    {{- if .Values.ingress.root.annotations }}
+    {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}
+    {{- else }}
+    {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- if .Values.tls.enabled }}
+  tls:
+  - hosts:
+    {{- if .Values.ingress.prefixWithBranch }}
+    - {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
+    {{- else }}
+    - {{ .Values.ingress.host }}
+    {{- end }}
+    secretName: app-all-hands-{{ .Values.tls.env }}-tls
+  {{- end }}
+  rules:
+  {{- if .Values.ingress.prefixWithBranch }}
+  - host: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
+  {{- else }}
+  - host: {{ .Values.ingress.host }}
+  {{- end }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: openhands-service
+            port:
+              number: 3000
+{{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -129,10 +129,30 @@ ingress:
   # REQUIRED: Update to a hostname in a DNS domain you own
   # host: "app.example.com"
   class: traefik
+  # Legacy annotations field - kept for backward compatibility
   annotations:
     {}
     # UPDATE: if you use cert-manager, enter your clusterIssuer may not match.
     # cert-manager.io/cluster-issuer: letsencrypt-production
+  
+  # Separate annotations for each ingress
+  root:
+    annotations:
+      {}
+      # Example: Add specific annotations for the root ingress
+      # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  
+  integrations:
+    annotations:
+      {}
+      # Example: Add specific annotations for integrations ingress
+      # nginx.ingress.kubernetes.io/rate-limit: "100"
+  
+  mcp:
+    annotations:
+      {}
+      # Example: Add specific annotations for MCP ingress
+      # nginx.ingress.kubernetes.io/auth-type: basic
 
 integrationEvents:
   deployment:


### PR DESCRIPTION
## Overview

This PR splits the single `ingress.yaml` file into three separate ingress objects, allowing for granular control over ingress annotations per service.

## Changes

### New Ingress Objects
- **`ingress-root.yaml`**: Handles the root path (`/`) routing to `openhands-service`
- **`ingress-integrations.yaml`**: Handles integration paths routing to `openhands-integrations-service`:
  - `/integration/github/events` (Exact match)
  - `/integration/gitlab/events` (Exact match) 
  - `/slack` (Prefix match)
- **`ingress-mcp.yaml`**: Handles MCP paths routing to `openhands-mcp-service`:
  - `/mcp/mcp` (Prefix match)

### Values.yaml Updates
- Added separate annotation sections: `ingress.root.annotations`, `ingress.integrations.annotations`, `ingress.mcp.annotations`
- Maintains backward compatibility with the legacy `ingress.annotations` field
- Each ingress falls back to legacy annotations if specific annotations are not provided

## Benefits

1. **Granular Control**: Each service can have its own specific ingress annotations
2. **Security**: Apply different authentication/authorization rules per service  
3. **Performance**: Configure different rate limiting, timeouts, and body sizes per service
4. **Maintenance**: Easier to manage and troubleshoot individual services

## Same Host Support

✅ **Yes, all three ingresses can be hosted on the same host.** Kubernetes ingress controllers handle multiple ingress resources targeting the same host by merging the path rules appropriately. The path routing ensures no conflicts since each ingress handles different path patterns.

## Backward Compatibility

✅ **Fully backward compatible.** Existing deployments will continue to work without any changes. The legacy `ingress.annotations` field is still supported and used as a fallback.

## Example Usage

```yaml
ingress:
  enabled: true
  host: "app.example.com"
  class: nginx
  
  # Root ingress annotations (for main OpenHands app)
  root:
    annotations:
      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
  
  # Integration ingress annotations (for webhooks)
  integrations:
    annotations:
      nginx.ingress.kubernetes.io/rate-limit: "100"
  
  # MCP ingress annotations (for MCP service)
  mcp:
    annotations:
      nginx.ingress.kubernetes.io/auth-type: basic
```

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/09a2695552b14710a0ba688bd08b3cea)