### PR TITLE
chore(helm): bump runtime-api dependency in openhands chart to 0.1.11

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 20.3.0
 - name: runtime-api
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.7
-digest: sha256:b4fe3e40bb1225adb233696a80606ba459962a7547516605f09c4bc17c61a05e
-generated: "2025-08-12T23:07:08.317456238-04:00"
+  version: 0.1.11
+digest: sha256:314fb5c6cc007992a66710f9466dd489bffc6f7d6533cf9e3e3806041fd2646b
+generated: "2025-08-18T17:57:50.991671693Z"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.47.0
-version: 0.1.12
+version: 0.1.13
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,5 +38,5 @@ dependencies:
     condition: redis.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.9
+    version: 0.1.11
     condition: runtime-api.enabled


### PR DESCRIPTION
## Description
Bump the runtime-api dependency in the openhands Helm chart to the latest version.

Changes:
- Update charts/openhands/Chart.yaml runtime-api dependency from 0.1.9 to 0.1.11 (matches charts/runtime-api/Chart.yaml currently in repo)
- Bump openhands chart version from 0.1.12 to 0.1.13
- Regenerate Chart.lock via `helm dependency update`

## Helm Chart Checklist
- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version (helm lint/template pass locally; dependency update works)
- [x] I have verified backwards compatibility with existing values.yaml configurations (no values changes)
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (n/a)

## Additional Notes
- Ran `helm dependency update`, `helm lint`, and `helm template` to verify the chart renders and dependencies resolve.


@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5781fb6204824090afb3ad30f6939076)