### PR TITLE
Set allowInsecureImages for bitnamilegacy

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.54.2
-version: 0.1.19
+version: 0.1.20
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -586,3 +586,9 @@ runtime-api:
     MEMORY_LIMIT: "3072Mi"
     CPU_REQUEST: "500m"
     EPHEMERAL_STORAGE_SIZE: "10Gi"
+
+global:
+  security:
+    # This allows using the bitnamilegacy image repo.
+    # See: https://github.com/bitnami/containers/issues/83267
+    allowInsecureImages: true

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the Flask application
-version: 0.1.13 # Change this to trigger a new helm chart version being published
+version: 0.1.14 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -187,3 +187,9 @@ monitoring:
 datadog:
   enabled: false
   env: "dev"
+
+global:
+  security:
+    # This allows using the bitnamilegacy image repo.
+    # See: https://github.com/bitnami/containers/issues/83267
+    allowInsecureImages: true


### PR DESCRIPTION
## Description

In order to use the Bitnami legacy images, we need to set `allowInsecureImages`, because these charts have only specific repos allow-listed.

See: https://github.com/bitnami/containers/issues/83267

Here is the error we get without this:

```
ERROR: Original containers have been substituted for unrecognized ones. Deploying this chart with non-standard containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Unrecognized images:
  - docker.io/bitnamilegacy/keycloak:26.1.5-debian-12-r0

If you are sure you want to proceed with non-standard containers, you can skip container image verification by setting the global parameter 'global.security.allowInsecureImages' to true.
Further information can be obtained at https://github.com/bitnami/charts/issues/30850
```

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
