### PR TITLE
Add documentation recommending provided LiteLLM over bring your own

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -260,6 +260,12 @@ This installation won't complete successfully the first time because we need to 
 
 > [!NOTE]
 > This process will be automated in the near future.
+>
+> [!IMPORTANT]
+> We recommend using the provided LiteLLM instance rather than bringing your
+> own. The provided LiteLLM instance uses an admin key for automated user
+> management, which is the most extensively tested scenario. Our automation
+> relies on this admin key to create and delete users automatically.
 
 To set up LiteLLM, first use port-forward to connect:
 
@@ -269,7 +275,7 @@ kubectl port-forward svc/openhands-litellm 4000:4000 -n openhands
 
 Next, create a new Team in LiteLLM:
 
-- Navigate to http://localhost:4000/ui in your browser.
+- Navigate to <http://localhost:4000/ui> in your browser.
 - login using the username `admin` password $GLOBAL_SECRET (set above).
 - go to Teams -> Create New Team.
 - Name it whatever you want.

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -45,12 +45,20 @@ postgresql:
   enabled: true
 
 litellm:
-  # Set this to true if you are using your own litellm instance
+  # Set this to true if you are using your own litellm instance 
+  #
+  # NOTE: We recommend using the provided LiteLLM instance for simplicity and
+  # because it is the most extensively tested scenario. Our automation uses an
+  # admin key to do user management for the LiteLLM instance.
   enabled: false
   url: "https://llm-proxy.example.com"
 
 litellm-helm:
-  # Set this to false if you are using your own litellm instance
+  # Set this to false if you are using your own litellm instance 
+  #
+  # NOTE: We recommend using the provided LiteLLM instance (enabled: true) for
+  # simplicity and because it is the most extensively tested scenario. Our
+  # automation uses an admin key to do user management for the LiteLLM instance.
   enabled: true
   ingress:
     enabled: false
@@ -69,7 +77,12 @@ litellm-helm:
         "OR_APP_NAME": "OpenHands",
         "OR_SITE_URL": "https://docs.all-hands.dev",
       }
-    # Needs to be updated with your models. If you bring your own litellm, then just point at that!
+    # Needs to be updated with your models. If you bring your own litellm, then
+    # just point at that!
+    #
+    # NOTE: We recommend using the provided LiteLLM instance for simplicity and
+    # because it is the most extensively tested scenario.
+    #
     # model_list:
     # - model_name: "prod/claude-3-5-sonnet-20241022"
     #   litellm_params:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -374,6 +374,9 @@ langfuse:
 
 litellm-helm:
   # Set this to false if you are using your own litellm instance
+  # NOTE: We recommend using the provided LiteLLM instance (enabled: true) for simplicity
+  # and because it is the most extensively tested scenario. Our automation uses an admin key
+  # to do user management for the LiteLLM instance.
   enabled: false
   masterkeySecretName: lite-llm-api-key
   masterkeySecretKey: lite-llm-api-key


### PR DESCRIPTION
## Overview

This PR adds clear documentation and comments throughout the OpenHands Cloud Helm chart to recommend using the provided LiteLLM instance rather than bringing your own.

## Changes Made

### 📚 README.md
- Added a prominent  callout explaining our recommendation
- Clarified that the provided LiteLLM uses an admin key for automated user management
- Emphasized it's the most extensively tested scenario

### ⚙️ values.yaml
- Added detailed comments where  is set to false for bring your own option
- Explained the benefits of using the provided instance

### 📋 example-values.yaml
- Added recommendations in multiple locations where bring your own LiteLLM is mentioned
- Improved comment formatting for better readability
- Added notes in the model_list section
