### PR TITLE
Add Jira integration events route to ingress

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.54.2
-version: 0.1.25
+version: 0.1.26
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -43,6 +43,13 @@ spec:
             name: openhands-integrations-service
             port:
               number: 3000
+      - path: /integration/jira/events
+        pathType: Exact
+        backend:
+          service:
+            name: openhands-integrations-service
+            port:
+              number: 3000
       - path: /api/billing/stripe-webhook
         pathType: Exact
         backend:


### PR DESCRIPTION
## Description

This PR adds support for Jira integration events by adding a new route `/integration/jira/events` to the ingress-integrations.yaml Helm template. The route follows the same pattern as the existing GitHub and GitLab integration routes, routing requests to the `openhands-integrations-service` on port 3000.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (incremented from 0.1.25 to 0.1.26)
- [x] I have tested the chart upgrade path from the previous version (backwards compatible change)
- [x] I have verified backwards compatibility with existing values.yaml configurations (no breaking changes)
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values (not applicable - no breaking changes or new values)

## Additional Notes

- The new route uses `pathType: Exact` for precise matching, consistent with other integration event routes
- No additional configuration is required in values.yaml as it uses the existing integrations service
- This change enables Jira webhook events to be properly routed through the Kubernetes ingress to the integrations service

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4e5988a3f40542d499ab2bbe0970f8fb)