### PR TITLE
DRAFT: Use FQDN for REDIS_HOST to avoid DNS search-path issues

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -88,7 +88,7 @@
 {{- end }}
 {{- if .Values.redis.enabled }}
 - name: REDIS_HOST
-  value: {{ .Release.Name }}-redis-master
+  value: {{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc
 - name: REDIS_PORT
   value: "6379"
 - name: REDIS_PASSWORD


### PR DESCRIPTION
Summary
- Set REDIS_HOST to <release>-redis-master.<namespace>.svc in charts/openhands/templates/_env.yaml
- This avoids transient DNS resolution errors like Name or service not known in feature namespaces
- Aligns with Kubernetes DNS best practice to use FQDN for cross-pod connections

Context
- We observed feature env errors like redis.exceptions.ConnectionError: Name or service not known for host <release>-redis-master:6379.
- Using a short name can depend on the pod's search path; FQDN removes that ambiguity.
- Also aligns with fixes to Datadog redisdb check configuration so monitors stop firing for authentication and connection errors.

How to test in staging/feature
1) Trigger deploy workflow for deploy repo to feature (or staging) with this chart version once published, or use Helm arg override in deploy workflow:
   --set-string env.REDIS_HOST=<release>-redis-master.<namespace>.svc
2) After deploy completes, wait ~3 minutes for pods to restart and Redis to be ready.
3) Verify app logs: no more error_reading_from_redis or Name or service not known.
4) Verify Datadog logs (US5):
   - service:deploy env:feature status:error
   - kube_namespace:<your-feature-namespace>

Datadog references
- Autodiscovery examples (env var templating): https://docs.datadoghq.com/containers/guide/autodiscovery-examples/
- Redis integration: https://docs.datadoghq.com/integrations/redis/
- Basic AD (annotations): https://docs.datadoghq.com/getting_started/containers/autodiscovery/

Notes
- This PR is a minimal change to default chart behavior; env override remains possible via env.REDIS_HOST in values.
- Separate deploy repo PR adds Datadog AD annotations and sets FQDN override for feature deploys for immediate validation.


@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fcc6a2066d63469fbef3b059d9917544)