### PR TITLE
Datadog disabled

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.54.2
-version: 0.1.27
+version: 0.1.28
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/integration-events-deployment.yaml
+++ b/charts/openhands/templates/integration-events-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         command: ["/bin/sh"]
         args:
           - "-c"
-          - "exec ddtrace-run uvicorn saas_server:app --host 0.0.0.0 --port 3000 --workers {{ .Values.integrationEvents.uvicorn.workers | default 2 }}"
+          - "exec {{- if .Values.datadog.enabled }} ddtrace-run {{- end }} uvicorn saas_server:app --host 0.0.0.0 --port 3000 --workers {{ .Values.integrationEvents.uvicorn.workers | default 2 }}"
         ports:
         - containerPort: 3000
         resources:

--- a/charts/openhands/templates/mcp-events-deployment.yaml
+++ b/charts/openhands/templates/mcp-events-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         command: ["/bin/sh"]
         args: 
           - "-c"
-          - "exec ddtrace-run uvicorn saas_server:app --host 0.0.0.0 --port 3000 --workers {{ .Values.mcpEvents.uvicorn.workers | default 2 }}"
+          - "exec {{- if .Values.datadog.enabled }} ddtrace-run {{- end }} uvicorn saas_server:app --host 0.0.0.0 --port 3000 --workers {{ .Values.mcpEvents.uvicorn.workers | default 2 }}"
         ports:
         - containerPort: 3000
         resources:


### PR DESCRIPTION
When datadog is disabled, we should not use it in the integrations and mcp pods.