### PR TITLE
Revert "Fix: Configure Prometheus multiprocess environment for uvicorn workers (#217)"

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.54.2
-version: 0.1.28
+version: 0.1.29
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -38,9 +38,6 @@ spec:
           configMap:
             name: keycloak-config-script
             defaultMode: 0755
-        - name: prometheus-multiproc
-          emptyDir:
-            medium: Memory
       initContainers:
       - name: keycloak-config
         imagePullPolicy: Always
@@ -90,7 +87,5 @@ spec:
           - name: user-waitlist
             mountPath: /app/user-waitlist
           {{- end }}
-          - name: prometheus-multiproc
-            mountPath: /tmp/prometheus-multiproc
         env:
         {{- include "openhands.env" . | nindent 8 }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -69,7 +69,6 @@ env:
   DISABLE_WAITLIST: "true"
   SANDBOX_REMOTE_RUNTIME_API_TIMEOUT: "60"
   RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.chuck-test.aws.all-hands.dev"
-  PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus-multiproc"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 


### PR DESCRIPTION
This PR reverts the changes made in commit ec79869a3cadefd050c9b9c5a84255c29cbcda54 (PR #217).

## Changes Reverted

- ❌ Removed `PROMETHEUS_MULTIPROC_DIR` environment variable from values.yaml
- ❌ Removed tmpfs volume (emptyDir with Memory medium) for multiprocess directory
- ❌ Removed volume mount at `/tmp/prometheus-multiproc` from deployment.yaml
- 📦 Bumped chart version from 0.1.28 to 0.1.29

## Original Commit

The original commit configured Prometheus multiprocess mode for uvicorn workers to address duplicate metrics issues. This revert removes all related infrastructure changes.

**Original commit**: https://github.com/All-Hands-AI/OpenHands-Cloud/commit/ec79869a3cadefd050c9b9c5a84255c29cbcda54

## Files Modified

- `charts/openhands/Chart.yaml` - Version bump
- `charts/openhands/templates/deployment.yaml` - Volume and mount removal
- `charts/openhands/values.yaml` - Environment variable removal

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a2a0199616da4125bb8a4f73fa483cb8)