### PR TITLE
Replace All-Hands-AI references with OpenHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ in your own Kubernetes cluster. These charts are also used to drive
 the official, public version of OpenHands Cloud at
 [app.all-hands.dev](https://app.all-hands.dev).
 
-You may also want to check out the MIT-licensed [OpenHands](https://github.com/All-Hands-AI/OpenHands)
+You may also want to check out the MIT-licensed [OpenHands](https://github.com/OpenHands/OpenHands)
 
 Issues in this repository are for the OpenHands Cloud app and
 for the Helm charts here. Issues with OpenHands itself should be
-opened in the [core OpenHands repository](github.com/All-Hands-AI/OpenHands).
+opened in the [core OpenHands repository](github.com/OpenHands/OpenHands).
 
 # Installation
 

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/all-hands-ai/runtime
+  repository: ghcr.io/openhands/runtime
   tag: 0.9.6-nikolaik
   pullPolicy: Always
 

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -21,7 +21,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.3.0
 - name: runtime-api
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.9
 digest: sha256:0eb3fcb98ec8a1aa3d6c2ba5e317942cbc2030a35440836ad6aec63de0dfb11e
 generated: "2025-08-21T14:15:03.196589052Z"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: runtime-api
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.15
     condition: runtime-api.enabled

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -253,7 +253,7 @@ Now we can install the helm chart.
 
 ```bash
 helm dependency update
-helm upgrade --install openhands --namespace openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands -f site-values.yaml
+helm upgrade --install openhands --namespace openhands oci://ghcr.io/openhands/helm-charts/openhands -f site-values.yaml
 ```
 
 This installation won't complete successfully the first time because we need to set up LiteLLM.
@@ -316,7 +316,7 @@ env:
 Finally, upgrade the release:
 
 ```bash
-helm upgrade --install openhands --namespace openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands -f site-values.yaml
+helm upgrade --install openhands --namespace openhands oci://ghcr.io/openhands/helm-charts/openhands -f site-values.yaml
 ```
 
 You should now be able to see OpenHands running with:
@@ -368,7 +368,7 @@ litellm-helm:
 Upgrade the release:
 
 ```bash
-helm upgrade --install openhands --namespace openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands -f site-values.yaml
+helm upgrade --install openhands --namespace openhands oci://ghcr.io/openhands/helm-charts/openhands -f site-values.yaml
 ```
 
 ## Hardening

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -122,7 +122,7 @@ gitlabWebhookInstallation:
       cpu: 200m
 
 image:
-  repository: ghcr.io/all-hands-ai/enterprise-server
+  repository: ghcr.io/openhands/enterprise-server
   tag: sha-bd51673
 
 ingress:
@@ -227,7 +227,7 @@ resendSync:
 
 runtime:
   image:
-    repository: ghcr.io/all-hands-ai/runtime
+    repository: ghcr.io/openhands/runtime
     tag: 135d3aea09780748db552d0c73f1f1c795191ed8-nikolaik
   runAsRoot: true
 
@@ -538,7 +538,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/all-hands-ai/runtime:135d3aea09780748db552d0c73f1f1c795191ed8-nikolaik"
+        image: "ghcr.io/openhands/runtime:135d3aea09780748db552d0c73f1f1c795191ed8-nikolaik"
         working_dir: "/openhands/code/"
         environment: {}
         command:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: ghcr.io/all-hands-ai/runtime-api
+  repository: ghcr.io/openhands/runtime-api
   tag: sha-07c8732
   pullPolicy: Always
 
@@ -146,7 +146,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/all-hands-ai/runtime:3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik"
+      image: "ghcr.io/openhands/runtime:3c39b93f7e151f88e7b4274b80aafa604fcae092-nikolaik"
       working_dir: "/openhands/code/"
       environment: {}
       command:


### PR DESCRIPTION
This PR replaces all occurrences of 'All-Hands-AI' with 'OpenHands' or 'openhands' while preserving case patterns.

## Changes made:
- `All-Hands-AI` → `OpenHands`
- `all-hands-ai` → `openhands`
- `ALL-HANDS-AI` → `OPENHANDS`
- Other case variations handled appropriately

This is part of the organization rebranding effort.

## Files changed:
- 7 files were modified

## Review notes:
- All changes are simple string replacements
- Case patterns are preserved
- No functional changes to code logic