### PR TITLE
Disable runtime-api Prometheus monitoring

### DIFF
--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the Flask application
-version: 0.1.15 # Change this to trigger a new helm chart version being published
+version: 0.1.16 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -186,7 +186,7 @@ podStatusLogger:
   schedule: "*/5 * * * *" # Run every 5 minutes
 
 monitoring:
-  enabled: true
+  enabled: false  # Disabled to reduce unnecessary monitoring overhead
 
 datadog:
   enabled: false


### PR DESCRIPTION
## Problem

The runtime-api Prometheus monitoring is not actively used and adds unnecessary complexity. This complements the GKE monitoring changes (see All-Hands-AI/infra#671) to simplify the monitoring stack.

## Solution

Disable Prometheus monitoring in runtime-api Helm chart.

**Changes**:
- Set `monitoring.enabled = false` in `charts/runtime-api/values.yaml`

**Impact**:
- ✅ Reduces monitoring overhead
- ✅ Simplifies deployment (no PodMonitoring resources)
- ⚠️ Removes `/metrics` endpoint from runtime-api
- ⚠️ No custom application metrics exported to Prometheus

## Verification

After Helm upgrade:
```bash
kubectl get podmonitoring -n production | grep runtime-api
# Should return: No resources found
```

## Related

- Companion PR: All-Hands-AI/infra#671 (disables GKE metrics agent)

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4fad469f200d4345bde3969ebe441931)