### PR TITLE
Document browser automation infinite loop bug

### DIFF
--- a/docs/BUG_REPORT_BROWSER_LOOP.md
+++ b/docs/BUG_REPORT_BROWSER_LOOP.md
@@ -10,14 +10,15 @@ OpenHands agent gets stuck in an infinite loop when attempting to interact with 
 **Severity**: High  
 **Priority**: High  
 **Status**: Open  
-**Conversation ID**: `d8cd83132ad143f58c0b57ccb4b423a2`
+**Conversation IDs**: `d8cd83132ad143f58c0b57ccb4b423a2`, `957cd187d5a24a09b1c5a70594b143bc`
 
 ## Description
-The OpenHands agent enters infinite loops during browser automation tasks, manifesting in multiple ways:
+The OpenHands agent enters infinite loops during operation, manifesting in multiple ways:
 1. **Action-level loops**: Repeatedly attempting the same click action on dropdown elements without recognizing failure
 2. **Task-level loops**: Resetting completed tasks back to "todo" status and attempting to redo entire task sequences
+3. **Conversation-level loops**: The conversation flow itself gets stuck in repetitive patterns
 
-This issue has been observed across multiple dropdown types (limit dropdown, draft status dropdown) and extends to broader state management problems where the agent loses track of completed work.
+This issue has been observed across multiple dropdown types (limit dropdown, draft status dropdown), task management systems, and conversation flows, indicating fundamental problems with state management and loop detection throughout the OpenHands system.
 
 ## Steps to Reproduce
 
@@ -35,10 +36,17 @@ This issue has been observed across multiple dropdown types (limit dropdown, dra
 4. Observe the agent resetting all completed tasks back to "todo" status
 5. Watch as agent attempts to redo all previously completed work
 
+### Conversation-Level Loops:
+1. Start a conversation with OpenHands agent
+2. Engage in complex task execution or browser automation
+3. Observe the conversation flow getting stuck in repetitive patterns
+4. Notice the agent repeating similar responses or actions cyclically
+
 **Confirmed Affected Elements:**
 - Limit dropdown (attempting to select "12 PRs")
 - Draft Status dropdown (attempting to select "Only Drafts")
 - Task tracking system (resetting completed tasks to todo)
+- Conversation flow (repetitive patterns in conversation ID: 957cd187d5a24a09b1c5a70594b143bc)
 
 ## Expected Behavior
 - Agent should successfully click on dropdown options
@@ -47,6 +55,8 @@ This issue has been observed across multiple dropdown types (limit dropdown, dra
 - Agent should provide meaningful error messages when actions fail repeatedly
 - Completed tasks should remain marked as "done" and not be reset to "todo"
 - Agent should maintain state consistency and not lose track of completed work
+- Conversation flow should progress logically without getting stuck in repetitive patterns
+- Agent should recognize when it's repeating the same responses or actions
 
 ## Actual Behavior
 - Agent repeatedly attempts the same click action without success
@@ -57,6 +67,8 @@ This issue has been observed across multiple dropdown types (limit dropdown, dra
 - Completed tasks are reset back to "todo" status unexpectedly
 - Agent loses track of previously completed work and attempts to redo tasks
 - State management fails across session continuations
+- Conversation flow gets stuck in repetitive patterns
+- Agent repeats similar responses or actions without recognizing the loop
 
 ## Evidence
 
@@ -134,20 +146,28 @@ then
 > ⏳ 5. todo - Make repo dropdown automatically update webpage and close dropdown when selected
 ```
 
+### Instance 4: Conversation Loop
+```
+Conversation ID: 957cd187d5a24a09b1c5a70594b143bc
+Evidence: Screenshot attached showing conversation getting stuck in a loop
+Description: The conversation itself began exhibiting loop behavior, with the agent getting stuck in repetitive patterns during the conversation flow.
+```
+
 **Pattern Analysis**: The evidence shows multiple types of loop behavior:
 1. **Action-level loops**: Agent gets stuck repeating the same click action on dropdown elements
 2. **Task-level loops**: Agent resets completed tasks back to "todo" status and attempts to redo entire task sequences
-3. **State management failure**: Agent loses track of completed work and reverts to initial state
+3. **Conversation-level loops**: The conversation flow itself gets stuck in repetitive patterns
+4. **State management failure**: Agent loses track of completed work and reverts to initial state
 
-This confirms the issue extends beyond individual browser actions to broader state management and task tracking problems.
+This confirms the issue extends beyond individual browser actions to fundamental problems with conversation flow, state management, and task tracking across the entire OpenHands system.
 
 ## Impact Assessment
-- **User Experience**: Severe - Users must manually intervene to stop loops and lose completed work
-- **Resource Usage**: High - Continuous failed attempts and redundant task execution consume computational resources
-- **Reliability**: Critical - Makes browser automation unreliable and causes loss of work progress
-- **Productivity**: High - Blocks task completion, requires manual intervention, and forces users to redo completed work
-- **Scope**: Systemic - Affects browser interactions, task management, and state persistence across the entire system
-- **Data Integrity**: High - Loss of task completion state leads to work duplication and confusion
+- **User Experience**: Severe - Users must manually intervene to stop loops, lose completed work, and experience frustrating conversation loops
+- **Resource Usage**: High - Continuous failed attempts, redundant task execution, and repetitive conversation patterns consume computational resources
+- **Reliability**: Critical - Makes browser automation, task management, and conversation flow unreliable
+- **Productivity**: High - Blocks task completion, requires manual intervention, forces users to redo completed work, and wastes time in repetitive conversations
+- **Scope**: Systemic - Affects browser interactions, task management, conversation flow, and state persistence across the entire OpenHands system
+- **Data Integrity**: High - Loss of task completion state and conversation context leads to work duplication and confusion
 
 ## Root Cause Analysis
 
@@ -182,6 +202,12 @@ This confirms the issue extends beyond individual browser actions to broader sta
    - State not properly restored after system events
    - Race conditions in state updates
 
+7. **Conversation Flow Management Issues**
+   - Lack of conversation context tracking and loop detection
+   - Insufficient conversation state management
+   - No mechanisms to prevent repetitive conversation patterns
+   - Poor conversation history analysis and pattern recognition
+
 ## Suggested Fixes
 
 ### Immediate (Short-term)
@@ -203,6 +229,11 @@ This confirms the issue extends beyond individual browser actions to broader sta
    - Implement robust task state persistence across sessions
    - Add state validation and recovery mechanisms
    - Ensure task completion status is properly saved and restored
+
+5. **Conversation Loop Detection**
+   - Add conversation pattern recognition to detect repetitive responses
+   - Implement conversation history analysis to prevent loops
+   - Add conversation flow monitoring and intervention mechanisms
 
 ### Long-term (Architectural)
 1. **Robust Action Framework**
@@ -226,12 +257,20 @@ This confirms the issue extends beyond individual browser actions to broader sta
    - Add comprehensive logging and monitoring for state changes
    - Develop state recovery mechanisms for system failures
 
+5. **Advanced Conversation Management**
+   - Design intelligent conversation flow management system
+   - Implement sophisticated loop detection across all conversation types
+   - Add conversation context preservation and analysis
+   - Develop adaptive conversation strategies to prevent repetitive patterns
+
 ## Workarounds
 1. **Manual Intervention**: Users can pause the agent and manually complete actions
 2. **Alternative UI Paths**: Use keyboard navigation or alternative UI elements when available
 3. **Task Restructuring**: Break down tasks to avoid problematic dropdown interactions
 4. **Session Management**: Regularly save task progress and be prepared to restore state manually
 5. **Frequent Monitoring**: Monitor agent behavior closely to catch loops early before significant resource waste
+6. **Conversation Reset**: Restart conversations when repetitive patterns are detected
+7. **Context Clarification**: Provide explicit context and instructions to break conversation loops
 
 ## Testing Recommendations
 1. Create automated tests for dropdown interactions
@@ -242,6 +281,9 @@ This confirms the issue extends beyond individual browser actions to broader sta
 6. Test session continuations and state persistence
 7. Create tests for task completion state across system events
 8. Implement loop detection testing and validation
+9. Develop conversation flow testing and loop detection
+10. Test conversation pattern recognition and intervention mechanisms
+11. Create automated tests for conversation context preservation
 
 ## Related Issues
 - Browser automation reliability
@@ -252,6 +294,9 @@ This confirms the issue extends beyond individual browser actions to broader sta
 - Session continuity and state recovery
 - Agent memory and state synchronization
 - Loop detection and prevention mechanisms
+- Conversation flow management and context preservation
+- Conversation pattern recognition and loop prevention
+- Agent conversation state tracking and analysis
 
 ## Next Steps
 1. Investigate browser automation framework configuration
@@ -262,6 +307,10 @@ This confirms the issue extends beyond individual browser actions to broader sta
 6. Add task completion state persistence mechanisms
 7. Implement loop detection and prevention systems
 8. Develop comprehensive state recovery procedures
+9. Design and implement conversation flow management system
+10. Add conversation pattern recognition and loop detection
+11. Develop conversation context preservation mechanisms
+12. Create comprehensive conversation testing and monitoring systems
 
 ---
 

--- a/docs/BUG_REPORT_BROWSER_LOOP.md
+++ b/docs/BUG_REPORT_BROWSER_LOOP.md
@@ -1,0 +1,148 @@
+# Bug Report: OpenHands Browser Automation Infinite Loop
+
+## Summary
+OpenHands agent gets stuck in an infinite loop when attempting to interact with dropdown menu elements in browser automation tasks, specifically when trying to click on dropdown options.
+
+## Bug Details
+
+**Bug ID**: Browser-Loop-001  
+**Date Reported**: 2025-10-22  
+**Severity**: High  
+**Priority**: High  
+**Status**: Open  
+**Conversation ID**: `d8cd83132ad143f58c0b57ccb4b423a2`
+
+## Description
+The OpenHands agent enters an infinite loop when attempting to click on dropdown menu options during browser automation. The agent repeatedly attempts the same click action without recognizing that the action is failing or not producing the expected result.
+
+## Steps to Reproduce
+1. Start OpenHands agent with browser automation capabilities
+2. Navigate to a page with a dropdown menu (in this case, a "limit" dropdown for PR display)
+3. Open the dropdown menu successfully
+4. Attempt to click on a specific dropdown option (e.g., "12 PRs")
+5. Observe the agent getting stuck in a loop
+
+## Expected Behavior
+- Agent should successfully click on the dropdown option
+- If the click fails, agent should recognize the failure and try alternative approaches
+- Agent should have a maximum retry limit to prevent infinite loops
+- Agent should provide meaningful error messages when actions fail repeatedly
+
+## Actual Behavior
+- Agent repeatedly attempts the same click action
+- Each attempt triggers a condensation request
+- Agent does not recognize that the action is failing
+- Loop continues indefinitely until manually paused by user
+- No error handling or alternative strategies are employed
+
+## Evidence
+```
+Conversation log excerpt:
+> Perfect! I can see that the limit dropdown is now open and showing the options. Let me select "12 PRs" to test the automatic update functionality:
+> *Browsing completed*
+> 
+> *CONDENSATION_REQUEST*
+> 
+> *Condensation*
+> 
+> I can see the limit dropdown is open and showing the options. Let me try clicking on "12 PRs" option:
+> *Browsing completed*
+> 
+> *CONDENSATION_REQUEST*
+> 
+> [Pattern repeats multiple times...]
+> 
+> *Pause button pressed. Agent is stopped. The action has not been executed.*
+```
+
+## Impact Assessment
+- **User Experience**: Severe - Users must manually intervene to stop the agent
+- **Resource Usage**: High - Continuous failed attempts consume computational resources
+- **Reliability**: Critical - Makes browser automation unreliable for dropdown interactions
+- **Productivity**: High - Blocks task completion and requires manual intervention
+
+## Root Cause Analysis
+
+### Potential Causes
+1. **Element Selection Issues**
+   - Dropdown option element may not be properly identified
+   - Element may be present in DOM but not clickable (covered by other elements, disabled, etc.)
+   - Timing issues where element is not fully rendered/interactive
+
+2. **Action Verification Failure**
+   - Agent may not be properly verifying if the click action succeeded
+   - No feedback mechanism to detect failed interactions
+   - Lack of state change detection after click attempts
+
+3. **Retry Logic Deficiency**
+   - Missing or inadequate retry limits
+   - No exponential backoff or alternative strategies
+   - Failure to recognize when an action is consistently failing
+
+4. **Browser Automation Framework Issues**
+   - Underlying browser automation tool may not be handling dropdown interactions correctly
+   - JavaScript events may not be properly triggered
+   - Browser state may not be accurately reflected to the agent
+
+## Suggested Fixes
+
+### Immediate (Short-term)
+1. **Implement Retry Limits**
+   - Add maximum retry count for browser actions (e.g., 3-5 attempts)
+   - Implement timeout mechanisms for individual actions
+
+2. **Enhanced Error Detection**
+   - Add verification steps after each click attempt
+   - Check for expected state changes (dropdown closure, page updates, etc.)
+   - Implement element interaction validation
+
+3. **Alternative Strategies**
+   - Try different click methods (JavaScript click, keyboard navigation, etc.)
+   - Implement fallback approaches for dropdown interactions
+   - Add keyboard-based navigation as backup
+
+### Long-term (Architectural)
+1. **Robust Action Framework**
+   - Develop a comprehensive action verification system
+   - Implement state-based action validation
+   - Add intelligent retry strategies with different approaches
+
+2. **Enhanced Browser Integration**
+   - Improve browser automation framework integration
+   - Add better element interaction detection
+   - Implement more reliable dropdown handling
+
+3. **Agent Self-Awareness**
+   - Add loop detection mechanisms
+   - Implement pattern recognition for repeated failed actions
+   - Develop adaptive behavior for persistent failures
+
+## Workarounds
+1. **Manual Intervention**: Users can pause the agent and manually complete the action
+2. **Alternative UI Paths**: Use keyboard navigation or alternative UI elements when available
+3. **Task Restructuring**: Break down tasks to avoid problematic dropdown interactions
+
+## Testing Recommendations
+1. Create automated tests for dropdown interactions
+2. Test with various dropdown types and configurations
+3. Implement stress testing for browser automation loops
+4. Add monitoring for repetitive action patterns
+
+## Related Issues
+- Browser automation reliability
+- Agent retry logic
+- User interface interaction patterns
+- Resource consumption during failed operations
+
+## Next Steps
+1. Investigate browser automation framework configuration
+2. Implement retry limits and timeout mechanisms
+3. Develop comprehensive testing suite for browser interactions
+4. Create monitoring system for detecting infinite loops
+
+---
+
+**Reporter**: OpenHands System  
+**Assignee**: TBD  
+**Labels**: bug, browser-automation, infinite-loop, high-priority  
+**Milestone**: TBD

--- a/docs/BUG_REPORT_BROWSER_LOOP.md
+++ b/docs/BUG_REPORT_BROWSER_LOOP.md
@@ -13,31 +13,50 @@ OpenHands agent gets stuck in an infinite loop when attempting to interact with 
 **Conversation ID**: `d8cd83132ad143f58c0b57ccb4b423a2`
 
 ## Description
-The OpenHands agent enters an infinite loop when attempting to click on dropdown menu options during browser automation. The agent repeatedly attempts the same click action without recognizing that the action is failing or not producing the expected result. This issue has been observed across multiple dropdown types (limit dropdown, draft status dropdown), indicating a systemic problem with dropdown interaction handling.
+The OpenHands agent enters infinite loops during browser automation tasks, manifesting in multiple ways:
+1. **Action-level loops**: Repeatedly attempting the same click action on dropdown elements without recognizing failure
+2. **Task-level loops**: Resetting completed tasks back to "todo" status and attempting to redo entire task sequences
+
+This issue has been observed across multiple dropdown types (limit dropdown, draft status dropdown) and extends to broader state management problems where the agent loses track of completed work.
 
 ## Steps to Reproduce
+
+### Action-Level Loops:
 1. Start OpenHands agent with browser automation capabilities
 2. Navigate to a page with dropdown menus (observed on PR management interface)
 3. Open any dropdown menu successfully (e.g., "limit" dropdown or "draft status" dropdown)
 4. Attempt to click on a specific dropdown option (e.g., "12 PRs" or "Only Drafts")
 5. Observe the agent getting stuck in a loop
 
-**Confirmed Affected Dropdowns:**
+### Task-Level Loops:
+1. Start OpenHands agent with task tracking enabled
+2. Complete a series of tasks successfully (all marked as "done")
+3. Continue the session or trigger a state refresh
+4. Observe the agent resetting all completed tasks back to "todo" status
+5. Watch as agent attempts to redo all previously completed work
+
+**Confirmed Affected Elements:**
 - Limit dropdown (attempting to select "12 PRs")
 - Draft Status dropdown (attempting to select "Only Drafts")
+- Task tracking system (resetting completed tasks to todo)
 
 ## Expected Behavior
-- Agent should successfully click on the dropdown option
-- If the click fails, agent should recognize the failure and try alternative approaches
-- Agent should have a maximum retry limit to prevent infinite loops
+- Agent should successfully click on dropdown options
+- If clicks fail, agent should recognize failure and try alternative approaches
+- Agent should have maximum retry limits to prevent infinite loops
 - Agent should provide meaningful error messages when actions fail repeatedly
+- Completed tasks should remain marked as "done" and not be reset to "todo"
+- Agent should maintain state consistency and not lose track of completed work
 
 ## Actual Behavior
-- Agent repeatedly attempts the same click action
+- Agent repeatedly attempts the same click action without success
 - Each attempt triggers a condensation request
-- Agent does not recognize that the action is failing
-- Loop continues indefinitely until manually paused by user
+- Agent does not recognize that actions are failing
+- Loops continue indefinitely until manually paused by user
 - No error handling or alternative strategies are employed
+- Completed tasks are reset back to "todo" status unexpectedly
+- Agent loses track of previously completed work and attempts to redo tasks
+- State management fails across session continuations
 
 ## Evidence
 
@@ -91,14 +110,44 @@ Conversation log excerpt:
 > [Pattern repeats multiple times...]
 ```
 
-**Pattern Analysis**: Both instances show identical behavior - the agent successfully opens dropdowns and can see the options, but gets stuck in infinite loops when attempting to click on specific dropdown options. This confirms the issue is systemic across different dropdown types, not isolated to a single UI element.
+### Instance 3: Task Reset Loop
+```
+Conversation log excerpt:
+> *Agent updated the plan*
+> 
+> Task List (5 items)
+> ✅ 1. done - Move the limit dropdown to be parallel with Community PRs title but justified to the right
+> ✅ 2. done - Make limit dropdown automatically update the community PR table when changed
+> ✅ 3. done - Move reviewers assigned filter to the far right of the filter bar
+> ✅ 4. done - Check that the repo filter at the top actually works
+> ✅ 5. done - Make repo dropdown automatically update webpage and close dropdown when selected
+
+then
+
+> *Agent updated the plan*
+> 
+> Task List (5 items)
+> ⏳ 1. todo - Move limit dropdown to be parallel with Community PRs title but justified to the right
+> ⏳ 2. todo - Make limit dropdown automatically update the Community PR table when changed
+> ⏳ 3. todo - Move reviewers assigned filter to the far right of the filter bar
+> ⏳ 4. todo - Check that the repo filter at the top actually works
+> ⏳ 5. todo - Make repo dropdown automatically update webpage and close dropdown when selected
+```
+
+**Pattern Analysis**: The evidence shows multiple types of loop behavior:
+1. **Action-level loops**: Agent gets stuck repeating the same click action on dropdown elements
+2. **Task-level loops**: Agent resets completed tasks back to "todo" status and attempts to redo entire task sequences
+3. **State management failure**: Agent loses track of completed work and reverts to initial state
+
+This confirms the issue extends beyond individual browser actions to broader state management and task tracking problems.
 
 ## Impact Assessment
-- **User Experience**: Severe - Users must manually intervene to stop the agent
-- **Resource Usage**: High - Continuous failed attempts consume computational resources
-- **Reliability**: Critical - Makes browser automation unreliable for dropdown interactions across multiple UI elements
-- **Productivity**: High - Blocks task completion and requires manual intervention
-- **Scope**: Systemic - Affects multiple dropdown types, indicating widespread dropdown interaction issues
+- **User Experience**: Severe - Users must manually intervene to stop loops and lose completed work
+- **Resource Usage**: High - Continuous failed attempts and redundant task execution consume computational resources
+- **Reliability**: Critical - Makes browser automation unreliable and causes loss of work progress
+- **Productivity**: High - Blocks task completion, requires manual intervention, and forces users to redo completed work
+- **Scope**: Systemic - Affects browser interactions, task management, and state persistence across the entire system
+- **Data Integrity**: High - Loss of task completion state leads to work duplication and confusion
 
 ## Root Cause Analysis
 
@@ -123,6 +172,16 @@ Conversation log excerpt:
    - JavaScript events may not be properly triggered
    - Browser state may not be accurately reflected to the agent
 
+5. **State Management Failures**
+   - Task completion state is not properly persisted across sessions
+   - State synchronization issues between different system components
+   - Memory or storage corruption causing state resets
+
+6. **Session Management Problems**
+   - Improper handling of session continuations or condensation events
+   - State not properly restored after system events
+   - Race conditions in state updates
+
 ## Suggested Fixes
 
 ### Immediate (Short-term)
@@ -140,6 +199,11 @@ Conversation log excerpt:
    - Implement fallback approaches for dropdown interactions
    - Add keyboard-based navigation as backup
 
+4. **State Persistence Improvements**
+   - Implement robust task state persistence across sessions
+   - Add state validation and recovery mechanisms
+   - Ensure task completion status is properly saved and restored
+
 ### Long-term (Architectural)
 1. **Robust Action Framework**
    - Develop a comprehensive action verification system
@@ -156,28 +220,48 @@ Conversation log excerpt:
    - Implement pattern recognition for repeated failed actions
    - Develop adaptive behavior for persistent failures
 
+4. **Comprehensive State Management**
+   - Design robust state management system with proper persistence
+   - Implement state synchronization across all system components
+   - Add comprehensive logging and monitoring for state changes
+   - Develop state recovery mechanisms for system failures
+
 ## Workarounds
-1. **Manual Intervention**: Users can pause the agent and manually complete the action
+1. **Manual Intervention**: Users can pause the agent and manually complete actions
 2. **Alternative UI Paths**: Use keyboard navigation or alternative UI elements when available
 3. **Task Restructuring**: Break down tasks to avoid problematic dropdown interactions
+4. **Session Management**: Regularly save task progress and be prepared to restore state manually
+5. **Frequent Monitoring**: Monitor agent behavior closely to catch loops early before significant resource waste
 
 ## Testing Recommendations
 1. Create automated tests for dropdown interactions
 2. Test with various dropdown types and configurations
 3. Implement stress testing for browser automation loops
 4. Add monitoring for repetitive action patterns
+5. Develop comprehensive state management testing
+6. Test session continuations and state persistence
+7. Create tests for task completion state across system events
+8. Implement loop detection testing and validation
 
 ## Related Issues
 - Browser automation reliability
 - Agent retry logic
 - User interface interaction patterns
 - Resource consumption during failed operations
+- Task state management and persistence
+- Session continuity and state recovery
+- Agent memory and state synchronization
+- Loop detection and prevention mechanisms
 
 ## Next Steps
 1. Investigate browser automation framework configuration
 2. Implement retry limits and timeout mechanisms
 3. Develop comprehensive testing suite for browser interactions
 4. Create monitoring system for detecting infinite loops
+5. Design and implement robust state management system
+6. Add task completion state persistence mechanisms
+7. Implement loop detection and prevention systems
+8. Develop comprehensive state recovery procedures
 
 ---
 

--- a/docs/BUG_REPORT_BROWSER_LOOP.md
+++ b/docs/BUG_REPORT_BROWSER_LOOP.md
@@ -13,14 +13,18 @@ OpenHands agent gets stuck in an infinite loop when attempting to interact with 
 **Conversation ID**: `d8cd83132ad143f58c0b57ccb4b423a2`
 
 ## Description
-The OpenHands agent enters an infinite loop when attempting to click on dropdown menu options during browser automation. The agent repeatedly attempts the same click action without recognizing that the action is failing or not producing the expected result.
+The OpenHands agent enters an infinite loop when attempting to click on dropdown menu options during browser automation. The agent repeatedly attempts the same click action without recognizing that the action is failing or not producing the expected result. This issue has been observed across multiple dropdown types (limit dropdown, draft status dropdown), indicating a systemic problem with dropdown interaction handling.
 
 ## Steps to Reproduce
 1. Start OpenHands agent with browser automation capabilities
-2. Navigate to a page with a dropdown menu (in this case, a "limit" dropdown for PR display)
-3. Open the dropdown menu successfully
-4. Attempt to click on a specific dropdown option (e.g., "12 PRs")
+2. Navigate to a page with dropdown menus (observed on PR management interface)
+3. Open any dropdown menu successfully (e.g., "limit" dropdown or "draft status" dropdown)
+4. Attempt to click on a specific dropdown option (e.g., "12 PRs" or "Only Drafts")
 5. Observe the agent getting stuck in a loop
+
+**Confirmed Affected Dropdowns:**
+- Limit dropdown (attempting to select "12 PRs")
+- Draft Status dropdown (attempting to select "Only Drafts")
 
 ## Expected Behavior
 - Agent should successfully click on the dropdown option
@@ -36,6 +40,8 @@ The OpenHands agent enters an infinite loop when attempting to click on dropdown
 - No error handling or alternative strategies are employed
 
 ## Evidence
+
+### Instance 1: Limit Dropdown Loop
 ```
 Conversation log excerpt:
 > Perfect! I can see that the limit dropdown is now open and showing the options. Let me select "12 PRs" to test the automatic update functionality:
@@ -55,11 +61,44 @@ Conversation log excerpt:
 > *Pause button pressed. Agent is stopped. The action has not been executed.*
 ```
 
+### Instance 2: Draft Status Dropdown Loop
+```
+Conversation log excerpt:
+> Great! I can see the Draft Status dropdown is open and showing the three options:
+> • All PRs (currently selected)
+> • Only Drafts
+> • No Drafts (Final)
+> Now let me test selecting "Only Drafts" to see if it automatically updates the table:
+> *Browsing completed*
+> 
+> *CONDENSATION_REQUEST*
+> 
+> *Condensation*
+> 
+> I can see the Draft Status dropdown is open and showing the three options. Let me try clicking on "Only Drafts" option:
+> 
+> *Browsing completed*
+> 
+> *CONDENSATION_REQUEST*
+> 
+> *Condensation*
+> 
+> I can see the Draft Status dropdown is open and showing the three options. Let me try clicking on "Only Drafts" option:
+> *Browsing completed*
+> 
+> *CONDENSATION_REQUEST*
+> 
+> [Pattern repeats multiple times...]
+```
+
+**Pattern Analysis**: Both instances show identical behavior - the agent successfully opens dropdowns and can see the options, but gets stuck in infinite loops when attempting to click on specific dropdown options. This confirms the issue is systemic across different dropdown types, not isolated to a single UI element.
+
 ## Impact Assessment
 - **User Experience**: Severe - Users must manually intervene to stop the agent
 - **Resource Usage**: High - Continuous failed attempts consume computational resources
-- **Reliability**: Critical - Makes browser automation unreliable for dropdown interactions
+- **Reliability**: Critical - Makes browser automation unreliable for dropdown interactions across multiple UI elements
 - **Productivity**: High - Blocks task completion and requires manual intervention
+- **Scope**: Systemic - Affects multiple dropdown types, indicating widespread dropdown interaction issues
 
 ## Root Cause Analysis
 

--- a/docs/BUG_TRACKING.md
+++ b/docs/BUG_TRACKING.md
@@ -1,0 +1,94 @@
+# Bug Tracking Documentation
+
+This directory contains bug reports and tracking documentation for OpenHands Cloud issues.
+
+## Bug Report Index
+
+### Active Bugs
+
+| Bug ID | Title | Severity | Date | Status | File |
+|--------|-------|----------|------|--------|------|
+| Browser-Loop-001 | Browser Automation Infinite Loop | High | 2025-10-22 | Open | [BUG_REPORT_BROWSER_LOOP.md](./BUG_REPORT_BROWSER_LOOP.md) |
+
+### Resolved Bugs
+*No resolved bugs documented yet*
+
+## Bug Report Template
+
+When documenting new bugs, please use the following structure:
+
+```markdown
+# Bug Report: [Brief Title]
+
+## Summary
+Brief description of the issue
+
+## Bug Details
+- **Bug ID**: Unique identifier
+- **Date Reported**: YYYY-MM-DD
+- **Severity**: Critical/High/Medium/Low
+- **Priority**: High/Medium/Low
+- **Status**: Open/In Progress/Resolved/Closed
+- **Conversation ID**: (if applicable)
+
+## Description
+Detailed description of the bug
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+3. etc.
+
+## Expected Behavior
+What should happen
+
+## Actual Behavior
+What actually happens
+
+## Evidence
+Code snippets, logs, screenshots, etc.
+
+## Impact Assessment
+- User Experience impact
+- Resource Usage impact
+- Reliability impact
+- Productivity impact
+
+## Root Cause Analysis
+Potential causes and analysis
+
+## Suggested Fixes
+Short-term and long-term solutions
+
+## Workarounds
+Temporary solutions
+
+## Testing Recommendations
+How to test fixes
+
+## Related Issues
+Links to related problems
+
+## Next Steps
+Action items
+```
+
+## Severity Levels
+
+- **Critical**: System crashes, data loss, security vulnerabilities
+- **High**: Major functionality broken, infinite loops, resource exhaustion
+- **Medium**: Minor functionality issues, performance problems
+- **Low**: Cosmetic issues, minor inconveniences
+
+## Priority Levels
+
+- **High**: Needs immediate attention, blocks critical functionality
+- **Medium**: Should be addressed in next release cycle
+- **Low**: Can be addressed when time permits
+
+## Status Definitions
+
+- **Open**: Bug reported and confirmed
+- **In Progress**: Actively being worked on
+- **Resolved**: Fix implemented and tested
+- **Closed**: Issue resolved and verified by reporter


### PR DESCRIPTION
## Summary
This PR documents a critical browser automation bug where OpenHands gets stuck in infinite loops when attempting to click dropdown options.

## Bug Details
- **Bug ID**: Browser-Loop-001
- **Severity**: High
- **Issue**: Agent repeatedly attempts same click action without recognizing failure
- **Scope**: Systemic issue affecting multiple dropdown types

## Evidence Documented
1. **Limit Dropdown Loop**: Agent stuck trying to select "12 PRs" option
2. **Draft Status Dropdown Loop**: Agent stuck trying to select "Only Drafts" option

Both instances show identical behavior pattern, confirming this is a widespread dropdown interaction issue.

## Documentation Added
- `docs/BUG_REPORT_BROWSER_LOOP.md`: Comprehensive bug report with root cause analysis and suggested fixes
- `docs/BUG_TRACKING.md`: Bug tracking system with template for future issues

## Impact
- **User Experience**: Severe - requires manual intervention
- **Resource Usage**: High - continuous failed attempts
- **Reliability**: Critical - makes browser automation unreliable for dropdown interactions

## Next Steps
Development team should prioritize implementing retry limits and enhanced error detection for browser automation actions.

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0834d5fe5f4f423ea32d190fc28caf1d)