### PR TITLE
PLTF-24 Image scan on latest tags

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -51,22 +51,10 @@ jobs:
         # This only reports, does not fail the build on CVE.
         with:
           image-ref: ${{ env.REGISTRY }}/${{ matrix.IMAGE }}
-          # trixie: sha-f1c75a7
-          # default: sha-07c8732
           format: 'sarif'
           output: 'trivy-results.sarif'
           timeout: '10m'
           scanners: 'vuln'  # Only scan vulnerabilities, not secrets/config
-      # - name: Customize SARIF with image flavor
-      #   shell: bash
-      #   run: |
-      #     IMAGE_WITH_TAG="all-hands-ai/enterprise-server:pr-11114"
-      #     IMAGE_WITHOUT_TAG="${IMAGE_WITH_TAG%%:*}"
-      #     # Modify the tool name to include the image flavor
-      #     jq --arg flavor "${{ env.IMAGE_WITHOUT_TAG }}" \
-      #       '.runs[0].tool.driver.name = "Trivy (" + $flavor + ")"' \
-      #       trivy-results-raw.sarif > trivy-results.sarif
-      #     echo "Modified tool name to: $(jq -r '.runs[0].tool.driver.name' trivy-results.sarif)"
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
This runs a trivy scan on the current docker images, publishing results to the GitHub security tab.

This partially meets the requirement of vulnerability scanning for SOC 2. Example findings:

https://github.com/All-Hands-AI/OpenHands-Cloud/security/code-scanning?query=pr%3A230+is%3Aopen

The images scanned:
* runtime (soon to become agent-server)
* runtime-api
* enterprise-server

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
