### PR TITLE
chore: release of 0.1.19 runtime-api chart to point to new openhands org instead of all-hands-ai

### DIFF
--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the Flask application
-version: 0.1.18 # Change this to trigger a new helm chart version being published
+version: 0.1.19 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: ghcr.io/all-hands-ai/runtime-api
+  repository: ghcr.io/openhands/runtime-api
   tag: sha-0c907c9
   pullPolicy: Always
 


### PR DESCRIPTION
## Description

This follow-on release of the chart is identical to 0.1.18 except that it points to the openhands org instead of all-hands-ai
