### PR TITLE
Add /oauth/device ingress route to integrations service

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.62.0
-version: 0.1.34
+version: 0.1.35
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -64,4 +64,11 @@ spec:
             name: openhands-integrations-service
             port:
               number: 3000
+      - path: /oauth/device
+        pathType: Prefix
+        backend:
+          service:
+            name: openhands-integrations-service
+            port:
+              number: 3000
 {{- end }}


### PR DESCRIPTION
## Description

This PR adds a new ingress route to handle OAuth device flow requests by routing `/oauth/device` paths to the integrations deployment.

### Changes Made:
- Added new ingress rule in `ingress-integrations.yaml` to route `/oauth/device` requests to `openhands-integrations-service`
- Uses `Prefix` pathType to match `/oauth/device` and any sub-paths (e.g., `/oauth/device/callback`)
- Bumped chart version from `0.1.34` to `0.1.35`

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

This change routes OAuth device flow requests to the integrations service, which is consistent with other OAuth and integration-related endpoints already handled by the same service. The change is backwards compatible and doesn't require any new configuration values.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/89904b8662024f7eb43546a12dd83fe0)