### PR TITLE
feat(charts): Add V1 conversation API settings to openhands chart

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 0.62.0
-version: 0.1.35
+version: 0.1.36
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -365,4 +365,28 @@
       name: linear-app
       key: client-secret
 {{- end }}
+# V1 Conversation API Settings
+# These control the availability and default behavior of V1 conversations
+{{- if .Values.v1Conversations }}
+{{- if .Values.v1Conversations.enableV1Routes }}
+# Server-level switch: when "0", V1 API routes are disabled entirely
+- name: ENABLE_V1
+  value: {{ if eq .Values.v1Conversations.enableV1Routes "false" }}"0"{{ else }}"1"{{ end }}
+{{- end }}
+{{- if .Values.v1Conversations.defaultV1Enabled }}
+# Default v1_enabled setting for new users (affects frontend conversation creation)
+- name: V1_ENABLED
+  value: {{ .Values.v1Conversations.defaultV1Enabled | quote }}
+{{- end }}
+{{- if .Values.v1Conversations.enableV1GithubResolver }}
+# Enable V1 conversations for GitHub resolver integration
+- name: ENABLE_V1_GITHUB_RESOLVER
+  value: {{ .Values.v1Conversations.enableV1GithubResolver | quote }}
+{{- end }}
+{{- if .Values.v1Conversations.enableV1SlackResolver }}
+# Enable V1 conversations for Slack resolver integration
+- name: ENABLE_V1_SLACK_RESOLVER
+  value: {{ .Values.v1Conversations.enableV1SlackResolver | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -72,6 +72,38 @@ env:
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
+# V1 Conversation API Settings
+# OpenHands supports two conversation APIs: V0 (legacy) and V1 (new).
+# These settings control the availability and default behavior of V1 conversations.
+v1Conversations:
+  # ENABLE_V1: Server-level switch that controls whether V1 API routes (/api/v1/*) are mounted.
+  # When "true", the V1 API endpoints are available for clients that want to use them.
+  # When "false", V1 API routes are completely disabled at the server level.
+  # Default: "true" (V1 routes are available)
+  enableV1Routes: "true"
+
+  # V1_ENABLED: Default setting for new users that determines if their conversations use V1 API.
+  # This sets the initial value of v1_enabled in user settings for new users.
+  # When "1", new users will have V1 conversations enabled by default.
+  # When "0" or unset, new users will use V0 (legacy) conversations by default.
+  # Note: For SaaS deployments, this can be overridden per-user in the database.
+  # Default: "0" (new users start with V0 conversations)
+  defaultV1Enabled: "0"
+
+  # ENABLE_V1_GITHUB_RESOLVER: Controls whether GitHub integration uses V1 conversations.
+  # When "true", GitHub issues/PRs resolved by OpenHands will use V1 conversation API.
+  # When "false", GitHub resolver uses V0 (legacy) conversation API.
+  # Requires both this flag AND the user's v1_enabled setting to be true.
+  # Default: "false" (GitHub resolver uses V0)
+  enableV1GithubResolver: "false"
+
+  # ENABLE_V1_SLACK_RESOLVER: Controls whether Slack integration uses V1 conversations.
+  # When "true", Slack messages handled by OpenHands will use V1 conversation API.
+  # When "false", Slack resolver uses V0 (legacy) conversation API.
+  # Requires both this flag AND the user's v1_enabled setting to be true.
+  # Default: "false" (Slack resolver uses V0)
+  enableV1SlackResolver: "false"
+
 filestore:
   ephemeral: false
   bucket: openhands-sessions


### PR DESCRIPTION
## Summary

This PR adds configurable settings for V1 conversation API feature flags to the OpenHands Helm chart. These settings prepare the charts for upcoming OpenHands releases (1.0.0+) that include V1 conversation support.

## Changes

### New Configuration Options (`values.yaml`)

Added a new `v1Conversations` section with the following settings:

| Setting | Environment Variable | Default | Description |
|---------|---------------------|---------|-------------|
| `enableV1Routes` | `ENABLE_V1` | `"true"` | Server-level switch that controls whether V1 API routes (`/api/v1/*`) are mounted |
| `defaultV1Enabled` | `V1_ENABLED` | `"0"` | Default setting for new users - determines if their conversations use V1 API |
| `enableV1GithubResolver` | `ENABLE_V1_GITHUB_RESOLVER` | `"false"` | Controls whether GitHub integration uses V1 conversations |
| `enableV1SlackResolver` | `ENABLE_V1_SLACK_RESOLVER` | `"false"` | Controls whether Slack integration uses V1 conversations |

### Default Behavior

With these defaults:
- **V1 API routes are available** (`ENABLE_V1=1`) - clients can use V1 endpoints if they choose
- **All conversations start as V0** (`V1_ENABLED=0`) - new users default to legacy V0 conversations
- **Integrations use V0** - GitHub and Slack resolvers use V0 conversation API

This provides a safe upgrade path where V1 is available but not enabled by default.

## Code References (from OpenHands repo)

These settings map to the following code in OpenHands:

1. **`ENABLE_V1`** - [`openhands/server/config/server_config.py:41`](https://github.com/All-Hands-AI/OpenHands/blob/1.0.0/openhands/server/config/server_config.py#L41)
   ```python
   enable_v1: bool = os.getenv('ENABLE_V1') != '0'
   ```

2. **`V1_ENABLED`** - [`openhands/storage/data_models/settings.py:54`](https://github.com/All-Hands-AI/OpenHands/blob/1.0.0/openhands/storage/data_models/settings.py#L54)
   ```python
   v1_enabled: bool | None = Field(default=bool(os.getenv('V1_ENABLED') == '1'))
   ```

3. **`ENABLE_V1_GITHUB_RESOLVER`** / **`ENABLE_V1_SLACK_RESOLVER`** - [`enterprise/integrations/utils.py:80-85`](https://github.com/All-Hands-AI/OpenHands/blob/1.0.0/enterprise/integrations/utils.py#L80-L85)
   ```python
   ENABLE_V1_GITHUB_RESOLVER = os.getenv('ENABLE_V1_GITHUB_RESOLVER', 'false').lower() == 'true'
   ENABLE_V1_SLACK_RESOLVER = os.getenv('ENABLE_V1_SLACK_RESOLVER', 'false').lower() == 'true'
   ```

## Chart Version

Bumps chart version from `0.1.35` to `0.1.36`.

## Testing

To enable V1 conversations for all new users, override in your values:

```yaml
v1Conversations:
  defaultV1Enabled: "1"
```

To enable V1 for GitHub resolver:

```yaml
v1Conversations:
  enableV1GithubResolver: "true"
```


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c4e740cc01ff407fb9c8ba85ecdcad49)