### PR TITLE
Add GitHub Action to automatically tag chart versions on merge to main

### DIFF
--- a/.github/workflows/tag-chart-versions.yml
+++ b/.github/workflows/tag-chart-versions.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'charts/**'
 
+concurrency:
+  group: tag-charts
+  cancel-in-progress: false
+
 jobs:
   tag-charts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Closes: #266.

This PR adds a new GitHub Action workflow that automatically creates git tags when helm chart versions are updated and merged to main.

## Features
- **Trigger**: Runs on pushes to `main` that modify files in the `charts/` directory
- **Tag Format**: `<chart-name>/<version-number>` (e.g., `openhands/0.2.0`, `runtime-api/0.1.20`)
- **Idempotent**: Only creates new tags when they don't already exist - if a tag exists for the current version, it's skipped