### PR TITLE
Set default_max_budget to 0.0 in litellm_settings

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -419,6 +419,9 @@ litellm-helm:
     #     model: "anthropic/claude-3-7-sonnet-20250219"
     #     api_key: os.environ/ANTHROPIC_API_KEY
     litellm_settings:
+      # Set default max_budget to 0.0 globally (instead of unlimited/None)
+      # When budgets are created without specifying max_budget, they will default to 0.0
+      default_max_budget: 0.0
       num_retries: 3
       request_timeout: 600
       # Uncomment this if you want to use langfuse for tracing (and enable langfuse below)


### PR DESCRIPTION
## Summary
This PR sets the `default_max_budget` to `0.0` globally in the LiteLLM settings.

## Changes
- Added `default_max_budget: 0.0` to the `litellm_settings` section in `charts/openhands/values.yaml`

## Rationale
When budgets are created without specifying `max_budget`, they will now default to `0.0` instead of unlimited/None. This provides a safer default configuration for new users signing up.

## Configuration Added
```yaml
litellm_settings:
  # Set default max_budget to 0.0 globally (instead of unlimited/None)
  # When budgets are created without specifying max_budget, they will default to 0.0
  default_max_budget: 0.0
```

## Testing
This is a configuration change that adds a new LiteLLM setting parameter. The setting will be applied when the Helm chart is deployed.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)