### PR TITLE
Make "Scan Docker Images" job run on main and filter by folder

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -4,6 +4,13 @@ env:
   REGISTRY: ghcr.io
 on:
   pull_request:
+    paths:
+      - 'charts/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
 jobs:
   discover_images:
     name: Discover Images


### PR DESCRIPTION
## Description

Update #230 so that docker scan runs on main, not just PR. Also filter to only run on changes to charts dir, like the other jobs do.

<!-- Provide a brief description of the changes in this PR -->

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [X] I have updated the `version` field in `Chart.yaml` for each modified chart
- [X] I have tested the chart upgrade path from the previous version
- [X] I have verified backwards compatibility with existing values.yaml configurations
- [X] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
