### PR TITLE
Update replicated openhands chart version to 0.2.10

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   chart:
     name: openhands
-    chartVersion: 0.2.9
+    chartVersion: 0.2.10
   releaseName: openhands
   namespace: openhands
   weight: 10


### PR DESCRIPTION
## Description

Saw the following error on `make release` for replicated:
```
RULE                    TYPE     FILENAME    LINE    MESSAGE
helm-archive-missing    error                            Could not find helm archive for chart 'openhands' version '0.2.9'              
helm-chart-missing      error                            Could not find helm chart manifest for archive 'build/openhands-0.2.10.tgz'    
```

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
