### PR TITLE
Add VolumeSnapshotClass documentation for PVC snapshot support

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -539,6 +539,44 @@ volumeBindingMode: WaitForFirstConsumer
 EOF
 ```
 
+### VolumeSnapshotClass Configuration (Optional)
+
+To enable PVC snapshots for cost optimization (snapshotting paused runtime PVCs instead of keeping them active), you need to create a VolumeSnapshotClass. This is optional but recommended for production deployments to reduce storage costs.
+
+```bash
+# For AWS EKS
+kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: ebs-snapshot-class
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
+EOF
+
+# For GKE
+kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: pd-snapshot-class
+driver: pd.csi.storage.gke.io
+deletionPolicy: Delete
+parameters:
+  storage-locations: us-central1  # Replace with your cluster's region
+EOF
+```
+
+Then configure the runtime-api to use the snapshot class:
+
+```yaml
+runtime-api:
+  env:
+    VOLUME_SNAPSHOT_CLASS: "pd-snapshot-class"  # or "ebs-snapshot-class" for AWS
+```
+
+> **Note:** The VolumeSnapshot CRDs must be installed in your cluster. Most managed Kubernetes services (GKE, EKS) include these by default. If not, see the [Kubernetes VolumeSnapshot documentation](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+
 ## Upgrading
 
 To upgrade the chart:


### PR DESCRIPTION
## Summary

Adds documentation for configuring a VolumeSnapshotClass alongside the existing StorageClass documentation. This enables the PVC snapshot feature for cost optimization.

## Changes

Updated `charts/openhands/README.md` to add a new section "VolumeSnapshotClass Configuration (Optional)" that includes:

- Explanation of why VolumeSnapshotClass is useful (cost optimization by snapshotting paused runtime PVCs)
- kubectl examples for both AWS EKS and GKE
- Configuration example showing how to set `VOLUME_SNAPSHOT_CLASS` environment variable
- Note about VolumeSnapshot CRD requirements

## Context

This documentation supports the upcoming runtime-api feature that will:
1. Snapshot PVCs of runtimes that have been paused for extended periods
2. Delete the PVCs to save storage costs
3. Restore PVCs from snapshots when runtimes are resumed

## Related PRs

- Infrastructure PR (VolumeSnapshotClass for All-Hands-AI clusters): https://github.com/All-Hands-AI/infra/pull/1055
- Runtime API PR (snapshot implementation): https://github.com/OpenHands/runtime-api/pull/410