### PR TITLE
Fix model proxy configuration for Replicated

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -21,7 +21,7 @@ spec:
       - name: '{{repl ImagePullSecretName }}'
 
     env:
-      LLM_DEFAULT_MODEL: 'prod/claude-sonnet-4-20250514'
+      LITELLM_DEFAULT_MODEL: 'litellm_proxy/claude-sonnet-4-5-20250929'
       LLM_BASE_URL: "http://openhands-litellm:4000"
       REQUIRE_PAYMENT: 0
       ENABLE_BILLING: false
@@ -130,9 +130,9 @@ spec:
           OR_APP_NAME: "OpenHands"
           OR_SITE_URL: "https://docs.all-hands.dev"
         model_list:
-          - model_name: "prod/claude-sonnet-4-20250514"
+          - model_name: "claude-sonnet-4-5-20250929"
             litellm_params:
-              model: "anthropic/claude-sonnet-4-20250514"
+              model: "anthropic/claude-sonnet-4-5-20250929"
               api_key: os.environ/ANTHROPIC_API_KEY
 
     langfuse:


### PR DESCRIPTION
## Description

A couple things were breaking the default model from being configured correctly:
1. `LLM_DEFAULT_MODEL` was updated to `LITELLM_DEFAULT_MODEL`.
2. `LITELLM_DEFAULT_MODEL` should be formatted like `litellm_proxy/<model_name>` where `<model_name>` matches the `model_name` defined in the `model_list`.

I removed the `prod` prefix because that's an artifact from our infrastructure, where we configure 2 names for certain models, one with `<model_name>` and another with `prod/<model_name>`.

`claude-sonnet-4-5-20250929` is the most recent sonnet model available in v1.79.1, the current LiteLLM version in the helm charts.

We _should_ be fine to upgrade to v1.81.14 and set the default to Sonnet 4.6, but I'll do that as a separate change.

Closes [PLTF-308: \[BUG\] Default model should be a Claude model for Anthropic LLM provider](https://linear.app/all-hands-ai/issue/PLTF-308/bug-default-model-should-be-a-claude-model-for-anthropic-llm-provider)

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
