### PR TITLE
Replicated: Default Bitbucket DC to Not Enabled

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -324,7 +324,7 @@ spec:
           title: Enable Bitbucket Data Center Authentication
           help_text: Enable Bitbucket Data Center OAuth for user authentication
           type: bool
-          default: "1"
+          default: "0"
         - name: bitbucket_data_center_domain
           title: Bitbucket Data Center Domain
           help_text: Domain of your Bitbucket Data Center instance


### PR DESCRIPTION
## Description

All auth providers should be disabled by default, with the user opting in to each one.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
