### PR TITLE
PLTF-309: updated replicated with openhands fix for max budget none

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-855ef7b'
+      tag: 'sha-2224127'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## Description

There is an updated fix for max budget none which is an improvement for the fix for the out of funds error https://github.com/OpenHands/OpenHands/pull/13482

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Can continue to have a conversation without the out of funds error:
<img width="911" height="813" alt="Screenshot 2026-03-19 at 12 45 00 PM" src="https://github.com/user-attachments/assets/f5bb7810-ef06-4a83-9416-c01c37dad3c7" />

Can pull/push/create a PR on a github repo:
<img width="866" height="809" alt="Screenshot 2026-03-19 at 12 48 56 PM" src="https://github.com/user-attachments/assets/ce2495c9-3dff-402d-a057-c4f4a3eb94cc" />
<img width="949" height="729" alt="Screenshot 2026-03-19 at 12 49 02 PM" src="https://github.com/user-attachments/assets/a4b0a3d4-52f3-484e-83f4-f9c93f25efd3" />
