### PR TITLE
PLTF-327: use enterprise server image with node v24

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 1.5.0
-version: 0.2.14
+version: 0.2.15
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -109,7 +109,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: sha-3c5023a
+  tag: sha-94b45c6
 
 ingress:
   enabled: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,6 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-855ef7b'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## Description

Uses the enterprise image built off of https://github.com/OpenHands/OpenHands/pull/13507 with the NodeJS v24 LTS upgrade

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Tested in https://github.com/All-Hands-AI/OpenHands-Cloud/pull/468 with a Replicated install (see https://github.com/OpenHands/OpenHands/pull/13507 for screenshots)