### PR TITLE
Add clarifying comment about chart dependencies in validate-replicated workflow

### DIFF
--- a/.github/workflows/validate-replicated.yml
+++ b/.github/workflows/validate-replicated.yml
@@ -41,22 +41,14 @@ jobs:
           # For PR validation, we need to use file:// dependencies instead of OCI
           # because the updated chart versions don't exist in the registry yet.
           #
+          # Note: openhands-secrets and image-loader are NOT dependencies of any chart.
+          # They are standalone Replicated HelmChart resources (see replicated/secrets.yaml
+          # and replicated/image-loader.yaml). Only runtime-api is a dependency of openhands.
+          #
           # Check if runtime-api is a dependency in openhands chart and update it to use local path
           if yq -e '.dependencies[] | select(.name == "runtime-api")' charts/openhands/Chart.yaml > /dev/null 2>&1; then
             echo "Updating openhands chart to use local runtime-api dependency"
             yq -i '(.dependencies[] | select(.name == "runtime-api")).repository = "file://../runtime-api"' charts/openhands/Chart.yaml
-          fi
-
-          # Check if openhands-secrets is a dependency in openhands chart and update it to use local path
-          if yq -e '.dependencies[] | select(.name == "openhands-secrets")' charts/openhands/Chart.yaml > /dev/null 2>&1; then
-            echo "Updating openhands chart to use local openhands-secrets dependency"
-            yq -i '(.dependencies[] | select(.name == "openhands-secrets")).repository = "file://../openhands-secrets"' charts/openhands/Chart.yaml
-          fi
-
-          # Check if image-loader is a dependency in openhands chart and update it to use local path
-          if yq -e '.dependencies[] | select(.name == "image-loader")' charts/openhands/Chart.yaml > /dev/null 2>&1; then
-            echo "Updating openhands chart to use local image-loader dependency"
-            yq -i '(.dependencies[] | select(.name == "image-loader")).repository = "file://../image-loader"' charts/openhands/Chart.yaml
           fi
 
       - name: Lint Replicated release


### PR DESCRIPTION
## Description

This PR adds a clarifying comment to the validate-replicated GitHub Actions workflow explaining why only `runtime-api` needs local path handling for PR validation.

## Investigation Summary

After reviewing the chart structure, I found:

1. **`openhands-secrets` and `image-loader` are NOT dependencies of any chart**
   - They are standalone Replicated HelmChart resources deployed separately via `replicated/secrets.yaml` and `replicated/image-loader.yaml`
   - Their `Chart.yaml` files have no `dependencies:` section

2. **Only `runtime-api` is a dependency** of the `openhands` chart that needs local path handling

3. The original checks for `openhands-secrets` and `image-loader` were unnecessary because:
   - `helm package -u` only fetches dependencies listed in Chart.yaml
   - Since these charts aren't dependencies of any chart, there's nothing to fetch from registries

## Changes

- Removed unnecessary `openhands-secrets` and `image-loader` dependency checks
- Added clarifying comment explaining the chart structure

## Related

- Follow-up to #475 (PLTF-328)
- Addresses review comment from @jlav