### PR TITLE
Install PostgreSQL via Replicated before openhands chart

### DIFF
--- a/charts/openhands-postgresql/Chart.lock
+++ b/charts/openhands-postgresql/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.5.38
+digest: sha256:29f8628ea14dc0fdc065ba9dd9e351baeb83808777e75493847d4079f354d5b5
+generated: "2026-03-25T09:41:07.469564-04:00"

--- a/charts/openhands-postgresql/Chart.yaml
+++ b/charts/openhands-postgresql/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: openhands-postgresql
+description: Standalone PostgreSQL for OpenHands (deployed before the main chart)
+version: 0.1.0
+dependencies:
+  - name: postgresql
+    version: 15.x.x
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/openhands-postgresql/templates/initdb-configmap.yaml
+++ b/charts/openhands-postgresql/templates/initdb-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oh-psql-scripts-configmap
+data:
+  init.sql: |
+    CREATE DATABASE litellm;
+    GRANT ALL PRIVILEGES ON DATABASE litellm TO {{ .Values.postgresql.auth.username }};
+    CREATE DATABASE keycloak;
+    GRANT ALL PRIVILEGES ON DATABASE keycloak TO {{ .Values.postgresql.auth.username }};
+    CREATE DATABASE openhands;
+    GRANT ALL PRIVILEGES ON DATABASE openhands TO {{ .Values.postgresql.auth.username }};
+    CREATE DATABASE postgres_langfuse;
+    GRANT ALL PRIVILEGES ON DATABASE postgres_langfuse TO {{ .Values.postgresql.auth.username }};
+    CREATE DATABASE bitnami_keycloak;
+    GRANT ALL PRIVILEGES ON DATABASE bitnami_keycloak TO {{ .Values.postgresql.auth.username }};
+    CREATE DATABASE runtime_api_db;
+    GRANT ALL PRIVILEGES ON DATABASE runtime_api_db TO {{ .Values.postgresql.auth.username }};

--- a/charts/openhands-postgresql/values.yaml
+++ b/charts/openhands-postgresql/values.yaml
@@ -1,0 +1,18 @@
+postgresql:
+  auth:
+    username: postgres
+    existingSecret: postgres-password
+  primary:
+    initdb:
+      scriptsConfigMap: oh-psql-scripts-configmap
+    persistence:
+      enabled: true
+  service:
+    ports:
+      postgresql: 5432
+  image:
+    repository: bitnamilegacy/postgresql
+
+global:
+  security:
+    allowInsecureImages: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -143,6 +143,9 @@ spec:
       replicaCount: 1
       autoscaling:
         enabled: false
+      postgresql:
+        enabled: false
+        postMigrate: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/runtime-api'
       imagePullSecrets:
@@ -212,8 +215,11 @@ spec:
     sandbox:
       apiHostname: 'http://openhands-runtime-api:5000'
     postgresql:
-      enabled: repl{{ ConfigOptionEquals "postgres_type" "embedded_postgres" }}
-      postMigrate: true
+      enabled: false
+    migrationJob:
+      enabled: true
+      initContainer:
+        enabled: false
     redis:
       enabled: true
       image:
@@ -249,15 +255,12 @@ spec:
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
       recursiveMerge: true
       values:
-        postgresql:
+        externalDatabase:
           enabled: true
-          auth:
-            username: '{{repl ConfigOption "postgres_username"}}'
-            password: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
-            postgresPassword: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
-            database: '{{repl ConfigOption "postgres_database"}}'
-          persistence:
-            enabled: true
+          host: oh-main-postgresql
+          database: '{{repl ConfigOption "postgres_database"}}'
+          username: '{{repl ConfigOption "postgres_username"}}'
+          password: '{{repl ConfigOption "postgres_password"}}'
     - when: '{{repl ConfigOptionEquals "postgres_type" "external_postgres" }}'
       recursiveMerge: true
       values:
@@ -284,16 +287,6 @@ spec:
           privateKey: |
             {{repl ConfigOptionData "github_app_private_key" | nindent 12}}
 
-    - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
-      recursiveMerge: true
-      values:
-        postgresql:
-          image:
-            repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
-        keycloak:
-          postgresql:
-            image:
-              repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
     - when: '{{repl ConfigOptionEquals "langfuse_enabled" "1" }}'
       recursiveMerge: true
       values:
@@ -362,9 +355,6 @@ spec:
           keycloakConfigCli:
             image:
               repository: '{{repl LocalRegistryNamespace }}/keycloak-config-cli'
-        postgresql:
-          image:
-            repository: '{{repl LocalRegistryNamespace }}/postgresql'
         redis:
           image:
             repository: '{{repl LocalRegistryNamespace }}/redis'
@@ -444,8 +434,6 @@ spec:
     litellm-helm:
       enabled: true
     minio:
-      enabled: true
-    postgresql:
       enabled: true
     redis:
       enabled: true

--- a/replicated/postgresql.yaml
+++ b/replicated/postgresql.yaml
@@ -1,0 +1,33 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: openhands-postgresql
+spec:
+  chart:
+    name: openhands-postgresql
+  releaseName: oh-main
+  namespace: openhands
+  weight: 5
+  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
+  exclude: '{{repl ConfigOptionEquals "postgres_type" "external_postgres" }}'
+  values:
+    postgresql:
+      auth:
+        username: '{{repl ConfigOption "postgres_username"}}'
+        password: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
+        postgresPassword: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
+        database: '{{repl ConfigOption "postgres_database"}}'
+      image:
+        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
+
+  optionalValues:
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        postgresql:
+          image:
+            repository: '{{repl LocalRegistryNamespace }}/postgresql'
+
+  builder:
+    postgresql:
+      enabled: true


### PR DESCRIPTION
## Summary
Fixes #472

Instead of deploying PostgreSQL as a subchart of openhands (which causes a Helm lifecycle deadlock with `--wait`), install it as a separate Replicated chart that completes before the openhands chart starts.

### Root cause
When PostgreSQL is a subchart, its migration must run as a `post-install` hook. But `--wait` blocks before post-install hooks fire, and the runtime-api app crashes on startup because tables don't exist yet. This creates a deadlock.

### Fix
- **New `openhands-postgresql` chart** (weight 5): Deploys PostgreSQL with all required databases via initdb, fully ready before openhands starts
- **Updated `replicated/openhands.yaml`** (weight 10): Disables the postgresql subchart, treats embedded PG as an external database, sets `runtime-api.postgresql.postMigrate=false` so migrations run as pre-install hooks

### Deployment order
1. `openhands-secrets` (weight 1) — creates `postgres-password` secret
2. `openhands-postgresql` (weight 5) — deploys PostgreSQL, `--wait` ensures it's fully ready
3. `openhands` (weight 10) — DB is already up, migrations run as pre-install hooks

## Changes
- **`charts/openhands-postgresql/`**: New wrapper chart around bitnami/postgresql with initdb configmap
- **`replicated/postgresql.yaml`**: Replicated HelmChart config (weight 5, excluded for external PG)
- **`replicated/openhands.yaml`**: Disable postgresql subchart, configure externalDatabase for embedded case, set runtime-api postMigrate=false, clean up builder/optionalValues

## Test plan
- [ ] `helm lint` passes for openhands-postgresql chart
- [ ] `helm template oh-main charts/openhands-postgresql` produces service named `oh-main-postgresql`
- [ ] `helm template` for openhands with new values: no PostgreSQL StatefulSet, migrations are pre-install hooks, DB_HOST is `oh-main-postgresql`
- [ ] Deploy to Replicated test environment and verify no CrashLoopBackOff