### PR TITLE
Add code review skill and automated PR review workflow

### DIFF
--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -1,0 +1,131 @@
+---
+name: code-review
+description: Repo-specific code review guidelines for All-Hands-AI/OpenHands-Cloud. Provides Helm chart-specific review rules in addition to the default code review skill.
+triggers:
+- /codereview
+---
+
+# All-Hands-AI/OpenHands-Cloud Code Review Guidelines
+
+You are an expert code reviewer for the **All-Hands-AI/OpenHands-Cloud** repository. This repository contains Helm charts for deploying OpenHands services (openhands, runtime-api, automation, etc.) and related CI/CD workflows. Be direct but constructive.
+
+## Review Decisions
+
+You have permission to **APPROVE** or **COMMENT** on PRs. Do not use REQUEST_CHANGES.
+
+### Default approval policy
+
+**Default to APPROVE**: If your review finds no issues at "important" level or higher, approve the PR. Minor suggestions or nitpicks alone are not sufficient reason to withhold approval.
+
+### When to APPROVE
+
+- Configuration changes following existing chart patterns
+- Documentation-only changes
+- CI/workflow changes (publish, preview, validate)
+- Simple additions following established chart conventions
+- Chart version bumps in dedicated release PRs
+
+### When to COMMENT
+
+- Issues that need attention (bugs, security, missing patterns)
+- Suggestions for improvement
+- Questions about design decisions
+
+## Core Principles
+
+### 1. Follow Established Chart Patterns
+
+When adding or modifying charts, follow patterns already proven in existing charts (e.g., the `openhands` chart). Do not invent new approaches when a working pattern exists.
+
+**Example**: The `openhands` chart has a pattern for de-duplicating environment variables that lets consumers override defaults and lets maintainers add new env vars without breaking existing deployments. New charts must follow this same pattern.
+
+### 2. Consumer-Friendly Configuration
+
+Chart values must be self-explanatory. Never require consumers to understand internal naming conventions or deployment-specific context to use a toggle.
+
+❌ Avoid opaque toggles:
+```yaml
+# What does this mean to someone outside the team?
+useSharedPostgres: true
+```
+
+✅ Use descriptive, behavior-oriented configuration:
+```yaml
+database:
+  host: "postgres.example.com"
+  createDatabaseUser: true
+```
+
+### 3. Explicit Over Implicit
+
+Let consumers set values directly rather than constructing them via conditional template logic. Avoid building hostnames or connection strings from internal naming conventions.
+
+❌ Avoid:
+```yaml
+# Constructs hostname from internal conventions
+useSharedPostgres: true
+# Template logic: if useSharedPostgres → host = "shared-postgres.namespace.svc.cluster.local"
+```
+
+✅ Prefer:
+```yaml
+# Consumer sets the actual value; no hidden logic
+database:
+  host: "shared-postgres.namespace.svc.cluster.local"
+```
+
+### 4. Cloud Provider Agnosticism
+
+Do not create hard dependencies on a single cloud provider. Provide abstractions that let consumers choose their own storage, database, or infrastructure backend.
+
+**Example**: The `openhands` chart supports minio, S3, and other backends. New charts should similarly avoid hard-coding dependencies on GCS, AWS, or any specific provider without offering alternatives.
+
+### 5. Design for Scale
+
+Consider multi-replica deployments from the start, even if initially running a single replica.
+
+- Avoid patterns that break at scale (e.g., per-pod local storage emulators where each replica sees different data)
+- If a component must be single-replica, break it into its own Deployment with `replicas: 1` hardcoded, keeping the main deployment scalable
+- Prefer real cloud storage over emulators for inspectability and debugging
+
+### 6. Override-Friendly Defaults
+
+Use patterns that make it easy for chart consumers to override defaults. Environment variable de-duplication is critical: consumers should be able to set env vars in their site values without conflicts from chart defaults.
+
+**Check for**: Can a consumer override every default value without forking the chart or patching templates?
+
+## Helm Chart-Specific Checks
+
+### Environment Variables
+- **De-duplication**: Follow the openhands chart's env var de-duplication pattern so consumers can override defaults
+- **Naming**: Third-party/SDK env vars (e.g., `DD_*`, `STORAGE_EMULATOR_HOST`) keep their canonical names; application-owned env vars use a service-specific prefix (e.g., `AUTOMATION_*`)
+- **No collisions**: Ensure env var names won't collide when multiple services run in the same pod
+
+### values.yaml
+- Toggles must describe behavior, not internal conventions
+- Avoid conditional logic that requires knowledge of internal deployment patterns
+- Provide sensible defaults that work out of the box
+- Document non-obvious values with comments
+
+### Templates
+- Follow patterns from existing charts (especially `openhands`)
+- Keep conditional logic minimal; prefer explicit consumer-provided values
+- Init containers and sidecar patterns should be well-documented
+
+### Chart.yaml
+- Dependencies should be conditional where possible
+- Version constraints should be explicit
+
+## What NOT to Comment On
+
+- Minor style preferences that don't affect functionality
+- Praise for code that follows best practices (just approve)
+- Obvious or self-explanatory configuration
+- Third-party env var naming (these follow external conventions)
+
+## Communication Style
+
+- Be direct and concise
+- Ask questions to understand use cases before suggesting changes
+- Suggest alternatives, not mandates
+- Approve quickly when charts follow established patterns

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -1,0 +1,50 @@
+---
+name: PR Review by OpenHands
+
+on:
+    # Use pull_request so workflow changes can be validated in PRs.
+    # This workflow requires secrets, so the job only runs for same-repo PRs.
+    # It runs when:
+    #   1. A new PR is opened (non-draft), OR
+    #   2. A draft PR is marked as ready for review, OR
+    #   3. A maintainer adds the 'review-this' label, OR
+    #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
+    # Adding labels and requesting reviewers still requires write access.
+    pull_request:
+        types: [opened, ready_for_review, labeled, review_requested]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    pr-review:
+        # Run when one of the following conditions is met:
+        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
+        #   3. 'review-this' label is added, OR
+        #   4. openhands-agent or all-hands-bot is requested as a reviewer
+        # Note: FIRST_TIME_CONTRIBUTOR and NONE PRs require manual trigger via label/reviewer request.
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository && (
+                (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+                (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+                github.event.label.name == 'review-this' ||
+                github.event.requested_reviewer.login == 'openhands-agent' ||
+                github.event.requested_reviewer.login == 'all-hands-bot'
+            )
+        concurrency:
+            group: pr-review-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Run PR Review
+              uses: OpenHands/extensions/plugins/pr-review@main
+              with:
+                  llm-model: litellm_proxy/claude-sonnet-4-5-20250929
+                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  review-style: roasted
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
+                  lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Adds a repository-specific code review skill and an automated PR review workflow, as requested in [PR #464 comment](https://github.com/All-Hands-AI/OpenHands-Cloud/pull/464).

## Changes

### `.agents/skills/code-review.md`

Repository-specific code review guidelines distilled from @jlav's review feedback on PR #464. The skill uses the `/codereview` trigger to override the default review behavior with Helm chart-specific principles:

1. **Follow Established Chart Patterns** — Reuse proven patterns from existing charts (e.g., the `openhands` chart's env var de-duplication) rather than inventing new approaches
2. **Consumer-Friendly Configuration** — Values must be self-explanatory; toggles should describe behavior, not internal naming conventions
3. **Explicit Over Implicit** — Let consumers set values directly rather than constructing them via conditional template logic
4. **Cloud Provider Agnosticism** — Support multiple storage/infrastructure backends; don't hard-code dependencies on a single cloud provider
5. **Design for Scale** — Consider multi-replica deployments from the start; avoid patterns that break at scale
6. **Override-Friendly Defaults** — Use env var de-duplication patterns so consumers can override defaults without conflicts

Also includes Helm chart-specific checks for environment variables, `values.yaml`, templates, and `Chart.yaml`.

### `.github/workflows/pr-review-by-openhands.yml`

Automated PR review workflow matching the [software-agent-sdk workflow](https://github.com/OpenHands/software-agent-sdk/blob/main/.github/workflows/pr-review-by-openhands.yml). Triggers on:
- New non-draft PRs opened by non-first-time contributors
- Draft PRs marked as ready for review
- `review-this` label added
- `openhands-agent` or `all-hands-bot` requested as reviewer

Uses the `OpenHands/extensions/plugins/pr-review@main` composite action with roasted review style.

## Related

- PR #464 review feedback from @jlav
- [OpenHands code review docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review)