### PR TITLE
Add Replicated HelmChart manifest for automation chart

### DIFF
--- a/replicated/automation.yaml
+++ b/replicated/automation.yaml
@@ -1,0 +1,11 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: automation
+spec:
+  chart:
+    name: automation
+  releaseName: automation
+  exclude: true
+  weight: 25
+  forceConflicts: true


### PR DESCRIPTION
## Summary
- Adds the missing Replicated `HelmChart` manifest (`replicated/automation.yaml`) for the automation chart introduced in #464
- Without this manifest, the Replicated linter fails with: `Could not find helm chart manifest for archive 'build/automation-0.1.0.tgz'`
- Follows the same pattern as other chart manifests (runtime-api, image-loader) with `exclude: true` and `forceConflicts: true`

## Test plan
- [x] CI `replicated release lint` passes without the `helm-chart-missing` error