### PR TITLE
Fix webhook 401s in Replicated deployments by adding missing env vars

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 1.5.0
-version: 0.3.3
+version: 0.3.4
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -429,6 +429,10 @@
 {{- end }}
 - name: OH_APP_MODE
   value: "saas"
+- name: OH_APP_CONVERSATION_INFO_KIND
+  value: server.utils.saas_app_conversation_info_injector.SaasAppConversationInfoServiceInjector
+- name: CONVERSATION_MANAGER_CLASS
+  value: server.saas_nested_conversation_manager.SaasNestedConversationManager
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Description

Replicated (enterprise) deployments were returning 401 on webhook callbacks to
`/api/v1/webhooks/events/{conversation_id}` and `/api/v1/webhooks/conversations`
despite valid `X-Session-API-Key` authentication.

**Root cause:** The `valid_conversation` check compares
`app_conversation_info.created_by_user_id` against `sandbox_info.created_by_user_id`.
Without `SaasAppConversationInfoServiceInjector` configured, the base
`SQLAppConversationInfoService._to_info()` always returns `created_by_user_id=None`,
causing `None != '<actual_user_id>'` to raise `AuthError` (converted to 401).

**Fix:** Add the missing environment variables to the chart defaults:

- `OH_APP_CONVERSATION_INFO_KIND` — Selects `SaasAppConversationInfoServiceInjector`,
  which joins conversation metadata with the SaaS user/org table to populate
  `created_by_user_id`. Without it, the base service always returns `None`.
- `CONVERSATION_MANAGER_CLASS` — Selects `SaasNestedConversationManager`, which handles
  SaaS-specific conversation lifecycle.

These were already set in production via values overrides but missing from the chart
defaults, which meant Replicated deployments fell back to OSS behavior.

Able to start a conversation after this change, and I no longer see the 401 errors in the logs:
<img width="1274" height="1215" alt="image" src="https://github.com/user-attachments/assets/b86c7fac-ab0f-42c2-9d68-c3e8e121ecfb" />

You can also see the conversation titles are working, which were never working before.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

No breaking changes — these are additive defaults that can still be overridden via `.Values.env`.
Chart version bumped from 0.3.3 to 0.3.4.