### PR TITLE
Fix Makefile to restore Chart.yaml on helm package failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ $(BUILDDIR)/$1-$(VER).tgz : $(CHARTDIR)/$1 $(shell find $(CHARTDIR)/$1 -name '*.
 	@# sibling chart to use a local file:// reference instead. This lets
 	@# `helm package -u` resolve unpublished chart versions during local builds.
 	@cp $(CHARTDIR)/$1/Chart.yaml $(CHARTDIR)/$1/Chart.yaml.bak
-	@for dep in $$$$(yq -r '.dependencies[].name // ""' $(CHARTDIR)/$1/Chart.yaml); do \
+	@trap 'mv $(CHARTDIR)/$1/Chart.yaml.bak $(CHARTDIR)/$1/Chart.yaml' EXIT; \
+	for dep in $$$$(yq -r '.dependencies[].name // ""' $(CHARTDIR)/$1/Chart.yaml); do \
 		if [ -d $(CHARTDIR)/$$$$dep ]; then \
 			yq -i "(.dependencies[] | select(.name == \"$$$$dep\")).repository = \"file://../$$$$dep\"" $(CHARTDIR)/$1/Chart.yaml; \
 		fi; \
-	done
+	done; \
 	helm package -u $(CHARTDIR)/$1 -d $(BUILDDIR)/
-	@mv $(CHARTDIR)/$1/Chart.yaml.bak $(CHARTDIR)/$1/Chart.yaml
 RELEASE_FILES := $(RELEASE_FILES) $(BUILDDIR)/$1-$(VER).tgz
 charts:: $(BUILDDIR)/$1-$(VER).tgz
 endef


### PR DESCRIPTION
## Summary
- The chart build target rewrites `Chart.yaml` dependencies from remote registry references to local `file://` paths for `helm package`. Previously, the restore step (`mv .bak`) was a separate Make recipe line, so if `helm package` failed, `Chart.yaml` was left with `file://` references that could accidentally get committed.
- Consolidated the backup/rewrite/package/restore into a single shell invocation with `trap ... EXIT` so the original `Chart.yaml` is always restored, regardless of whether `helm package` succeeds or fails.

## Test plan
- Verified restore on failure by creating a fake `helm` script (`exit 1`) in a temp directory and prepending it to `PATH`, then running `make charts`:
  - Confirmed `Chart.yaml` checksum was identical before and after the failed build
  - Confirmed `runtime-api` dependency repository was restored from `file://../runtime-api` back to `oci://ghcr.io/all-hands-ai/helm-charts`
  - Confirmed no leftover `.bak` files remained
- Verified `make -n charts` dry-run output shows the correct `trap` and single-shell structure
- Ran `make release` end-to-end successfully