### PR TITLE
Pin automation image to sha-36b5df4 in Replicated installer

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -236,6 +236,10 @@ spec:
     clickhouse:
       enabled: repl{{ ConfigOptionEquals "clickhouse_enabled" "1" }}
 
+    automation:
+      image:
+        tag: "sha-36b5df4"
+
     replicated:
       image:
         registry: images.r9.all-hands.dev


### PR DESCRIPTION
## Summary
- The Replicated installer requires all container images to resolve at packaging time. The automation chart defaults to `0.1.0` when no image tag is configured, but no release has been performed yet for the automation service so that tag doesn't exist. This pins the automation image to `sha-36b5df4`, which resolves to an actual published image.

## Test plan
- [x] Verify Replicated packaging completes without image resolution errors for the automation service