### PR TITLE
Increase keycloak memory limit to 2Gi

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -58,7 +58,16 @@ spec:
     keycloak:
       enabled: true
       url: 'http://keycloak'
-      resourcesPreset: small
+      resourcesPreset: none
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+          ephemeral-storage: 50Mi
+        limits:
+          cpu: 750m
+          memory: 2Gi
+          ephemeral-storage: 2Gi
       ingress:
         enabled: true
         ingressClassName: traefik


### PR DESCRIPTION
## Summary
Keycloak sometimes gets OOMKilled during first-time startup when running liquibase database migrations against the `bitnami_keycloak` database. The Bitnami `small` resourcesPreset sets a 768Mi memory limit, which is insufficient for this operation.

This PR switches from `resourcesPreset: small` to explicit resource definitions, keeping requests unchanged (500m CPU, 512Mi memory) but raising the memory limit from 768Mi to 2Gi. After migrations run, the existing resource requests are sufficient.

## Context
Observed during testing on a fresh external PostgreSQL install. Keycloak would OOMKill during schema initialization, corrupt the quarkus cache in its emptyDir volume, and then crash-loop with a `java.io.EOFException`. It eventually self-healed after 3 restarts (once migrations completed in earlier attempts), but the extended crash-loop delays the overall deployment.

## Test plan
- [x] Deploy to a test instance with a fresh external PostgreSQL database
- [x] Verify keycloak starts without OOMKill on first attempt
- [x] Verify keycloak resource requests remain at 512Mi memory
- [x] Verify keycloak resource limits are 2Gi memory