### PR TITLE
PLTF-76: Add Terraform lint PR check

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'terraform/**'
+      - '.github/workflows/terraform-lint.yml'
 
 jobs:
   terraform-lint:


### PR DESCRIPTION
Human: Follow up on #455 to add PR checks to the new terraform. In general we want all code to have some kind of automated validation. Choosing not to include formatting checks for now.

## Description

Adds a GitHub Actions workflow that lints Terraform code on pull requests touching `terraform/**`.

### Checks performed

| Step | Tool | Purpose |
|------|------|---------|
| Validate | `terraform init -backend=false` + `terraform validate` | Catches syntax and configuration errors |
| Static analysis | `tflint` | Catches provider-specific issues and best-practice violations |

### Design notes

- **Matrix strategy** — each Terraform root module directory is a matrix entry (`terraform/aws` today). Adding a new cloud/module is a one-line addition.
- **No cloud credentials required** — `terraform init` runs with `-backend=false` and validate does not need a real provider connection.
- Uses `hashicorp/setup-terraform@v3` and `terraform-linters/setup-tflint@v4` for reproducible tool versions.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@raymyers can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/37395988-b78b-4770-9878-3ba55388f8e4)