### PR TITLE
fix(automation): Add AUTOMATION_ROOT_PATH default for Swagger UI

### DIFF
--- a/charts/automation/templates/_env.yaml
+++ b/charts/automation/templates/_env.yaml
@@ -1,4 +1,7 @@
 {{- define "automation.env.defaults" }}
+# Root path for Swagger UI / OpenAPI spec (when mounted behind a proxy)
+- name: AUTOMATION_ROOT_PATH
+  value: "/api/automation"
 # OpenHands API base URL (for dispatching sandbox runs)
 {{- if .Values.openhandsApiUrl }}
 - name: AUTOMATION_OPENHANDS_API_BASE_URL


### PR DESCRIPTION
## Summary

Adds `AUTOMATION_ROOT_PATH=/api/automation` as a default environment variable in the automation subchart.

## Why

When the automation service is mounted at `/api/automation/` path, Swagger UI needs the `root_path` configured to correctly resolve the OpenAPI spec URL. Without this, visiting `/api/automation/docs` loads the wrong OpenAPI spec (`/openapi.json` instead of `/api/automation/openapi.json`).

## Related

- **OpenHands/automation#29** - Issue describing the bug
- **OpenHands/automation#30** - PR adding the `AUTOMATION_ROOT_PATH` config setting to the automation service

## Benefit

By setting this default in the subchart, all deployments automatically get the correct configuration without requiring changes to the deploy repo's values file.

---
*This PR was created by an AI assistant (OpenHands) on behalf of jpshackelford.*