### PR TITLE
fix: add category to SARIF upload for proper alert lifecycle

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -71,8 +71,8 @@ jobs:
           echo "name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload Trivy results to GitHub Security tab
-        # Only upload to code scanning on push to main to avoid PRs interfering with alert lifecycle
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Only upload to code scanning on push/dispatch to main to avoid PRs interfering with alert lifecycle
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Problem

The Trivy scan workflow is accumulating 4600+ open security findings in GitHub Code Scanning because alerts from previous scans are never being closed when image versions change.

> **Note:** While [22 alerts show as "closed/fixed"](https://github.com/All-Hands-AI/OpenHands-Cloud/security/code-scanning?query=is%3Aclosed+branch%3Amain), these were closed because the **same image tag** was rescanned and the vulnerability was resolved upstream (e.g., CVE withdrawn or base image patched). The problem is that when **image tags change** (e.g., `sha-4ea3e4b` → `sha-5f064fa`), old alerts become orphaned because the category includes the full image tag.

## Root Cause

Two issues with the `upload-sarif` action configuration:

1. **Missing stable `category` parameter** — The implicit category includes the full image reference with version tag. When image versions change, GitHub treats each as a separate analysis category, leaving alerts from old versions permanently open.

2. **Uploading SARIF on PRs** — PR scans were uploading to code scanning, which could interfere with alert tracking on the main branch.

### Why Alerts Accumulate (Current Behavior)

| Scenario | Category | Result |
|----------|----------|--------|
| Same tag rescanned | `IMAGE:runtime:sha-4ea3e4b` → `IMAGE:runtime:sha-4ea3e4b` | ✅ Alerts close when fixed |
| New tag deployed | `IMAGE:runtime:sha-4ea3e4b` → `IMAGE:runtime:sha-5f064fa` | ❌ Old alerts **orphaned**, new alerts created |

## Solution

### 1. Add unique, stable category per image

Extract just the image name (without tag/version) for a stable category:

| Full Image Reference | Category |
|---------------------|----------|
| `openhands/runtime-api:0.44.0` | `trivy-runtime-api` |
| `openhands/enterprise-server:0.44.0` | `trivy-enterprise-server` |
| `openhands/runtime:0.44.0` | `trivy-runtime` |

### 2. Only upload SARIF on push/dispatch to main

| Event | Trivy Scan | Upload to Code Scanning |
|-------|-----------|------------------------|
| PR | ✅ Runs (results in workflow logs) | ❌ Skipped |
| Push to main | ✅ Runs | ✅ Uploads |
| Manual dispatch | ✅ Runs | ✅ Uploads |

### 3. Added workflow_dispatch trigger

Allows manual testing from the Actions tab.

---

## ✅ Verified: Category Parameter is Required

I forked this repo to run only the runtime-api scan without the category parameter. I then updated to a newer version of runtime-api and found NO security alerts closed:
<img width="1169" height="596" alt="Screenshot 2026-04-06 at 11 42 38 AM" src="https://github.com/user-attachments/assets/7300ba03-3576-4b4d-bb32-97a164716d9b" />

I forked this repo again (a fresh fork) to run only the runtime-api scan with the category parameter. I then updated to a newer version of runtime-api and found some security alerts closed:
<img width="1166" height="592" alt="Screenshot 2026-04-06 at 10 43 31 AM" src="https://github.com/user-attachments/assets/bee38c8b-9624-43b6-8cc3-21060c300861" />

Testing confirmed that the `category` parameter is **essential** for alert lifecycle management:

| Scenario | Category param | Alerts closed? |
|----------|----------------|----------------|
| Single image, WITH category | ✅ Yes | ✅ **11 closed** |
| Single image, WITHOUT category | ❌ No | ❌ **0 closed** |

Without the category, GitHub treats each SARIF upload for an updated image tag as a separate analysis.

---

## ⚠️ Critical Finding: Multi-Image Scanning Prevents Alert Closure

I forked the repo with the changes in this PR and found that updating the runtime-api image did NOT close security alerts. The before and after count remained the same when scanning all the images even though scanning only runtime-api image above with the category parameter closed some alerts:
<img width="1142" height="589" alt="Screenshot 2026-04-06 at 10 47 34 AM" src="https://github.com/user-attachments/assets/3a6d735d-84a2-41bb-9dee-fd51296c0a57" />

Testing revealed that **scanning multiple images in the same workflow prevents alerts from closing**, even when:
- Each image has a unique category
- Vulnerabilities are at different paths (different fingerprints)
- The vulnerability is fixed in one image

### Test Results

| Scenario | Image Updated | Alerts Closed? |
|----------|---------------|----------------|
| Single image scan (runtime-api only) | runtime-api | ✅ **11 alerts closed** |
| Multi-image scan (all 3 images) | runtime-api | ❌ **0 alerts closed** |

### What We Found

When scanning all 3 images:
- runtime-api: 106 vulnerabilities (after update)
- enterprise-server: 412 vulnerabilities  
- runtime: 1327 vulnerabilities
- **Total unique alerts in GitHub UI: 1843** (deduplicated due to shared packages)

Even though the same CVE (e.g., `requests` vulnerability) exists at **different paths** in different images:

| Image | Path |
|-------|------|
| runtime-api | `app/.venv/lib/python3.13/site-packages/requests-...` |
| runtime | `usr/local/venv/lib/python3.12/site-packages/requests-...` |
| runtime | `openhands/poetry/.../requests-...` |

**All alerts get attributed to `trivy-runtime`** (the largest image), and updating smaller images doesn't close their alerts.

This appears to be GitHub's behavior when processing multiple SARIF uploads from the same workflow run - it matches alerts across categories more aggressively than expected.

---

## 🎯 Recommendation: Move Scans to Source Repos

The cleanest solution is to scan each image in its **source repository**:

| Repo | Scans | Benefits |
|------|-------|----------|
| Runtime-API source repo | `runtime-api` image only | ✅ Alerts close when fixed |
| Enterprise-Server source repo | `enterprise-server` image only | ✅ Clear ownership |
| Runtime source repo | `runtime` image only | ✅ No cross-image interference |

This ensures:
- Each repo owns its security alerts
- Alerts close properly when vulnerabilities are fixed
- No cross-image matching/deduplication issues
- OpenHands-Cloud stays focused on deployment (Helm charts)

---

## Summary of Required Fixes

| Fix | Purpose | Status |
|-----|---------|--------|
| Add `category` parameter | Enable alert lifecycle tracking | ✅ In this PR |
| Skip SARIF upload on PRs | Prevent interference with main branch | ✅ In this PR |
| Add `workflow_dispatch` | Allow manual testing | ✅ In this PR |
| Move scans to source repos | Enable proper alert closure | 📋 Recommended |

---

## Post-Merge Cleanup

After merging, you'll need to clean up the ~4600 stale alerts:

**Option 1: Delete old analysis configurations (recommended)**
```bash
gh api "repos/All-Hands-AI/OpenHands-Cloud/code-scanning/analyses?per_page=100" --paginate -q '.[].id' | \
while read id; do
  gh api -X DELETE "repos/All-Hands-AI/OpenHands-Cloud/code-scanning/analyses/$id?confirm_delete_url=true" --silent
  echo "Deleted analysis $id"
done
```

**Option 2: Bulk dismiss via API**
```bash
gh api "repos/All-Hands-AI/OpenHands-Cloud/code-scanning/alerts?state=open&per_page=100" --paginate -q '.[].number' | \
while read num; do
  gh api -X PATCH "repos/All-Hands-AI/OpenHands-Cloud/code-scanning/alerts/$num" \
    -f state=dismissed -f dismissed_reason="won't fix" --silent
  echo "Dismissed alert $num"
done
```

⚠️ **Note:** If you dismiss alerts and then scan again, GitHub will match fingerprints and keep them dismissed. Delete analyses instead for a clean start.

---

## References

- [GitHub Docs: Uploading more than one SARIF file](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-more-than-one-sarif-file-for-a-commit)

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*
