### PR TITLE
Migrate Keycloak from Bitnami chart to Codecentric KeycloakX

### DIFF
--- a/charts/openhands-secrets/templates/keycloak-realm.yaml
+++ b/charts/openhands-secrets/templates/keycloak-realm.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 data:
   realm-name: {{ .Values.config.keycloak_realm_name | b64enc | quote }}
-  server-url: {{ "http://keycloak" | b64enc | quote }}
+  server-url: {{ "http://keycloak-http" | b64enc | quote }}
   client-id: {{ .Values.config.keycloak_client_id | b64enc | quote }}
   client-secret: {{ .Values.config.keycloak_client_secret | b64enc | quote }}
   smtp-password: {{ .Values.config.keycloak_smtp_password | b64enc | quote }}

--- a/charts/openhands-secrets/templates/keycloak-realm.yaml
+++ b/charts/openhands-secrets/templates/keycloak-realm.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 data:
   realm-name: {{ .Values.config.keycloak_realm_name | b64enc | quote }}
-  server-url: {{ "http://keycloak-http" | b64enc | quote }}
+  server-url: {{ "http://openhands-keycloak-http" | b64enc | quote }}
   client-id: {{ .Values.config.keycloak_client_id | b64enc | quote }}
   client-secret: {{ .Values.config.keycloak_client_secret | b64enc | quote }}
   smtp-password: {{ .Values.config.keycloak_smtp_password | b64enc | quote }}

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -2,9 +2,9 @@ dependencies:
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.2.5
-- name: keycloak
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.7.5
+- name: keycloakx
+  repository: https://codecentric.github.io/helm-charts
+  version: 7.1.9
 - name: langfuse
   repository: https://langfuse.github.io/langfuse-k8s
   version: 1.2.13
@@ -25,6 +25,9 @@ dependencies:
   version: 1.9.0
 - name: runtime-api
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.24
-digest: sha256:bca3722cdd4840a4557955ea2b80e38991cc2d0a0211855a791cf98e37410e45
-generated: "2026-03-18T00:28:58.972983917-04:00"
+  version: 0.2.6
+- name: automation
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.0
+digest: sha256:9704eb8e0893624e1ab033871f04966cc9446437d785a89dce7b249de8c05ac0
+generated: "2026-04-03T17:26:28.296356-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -12,9 +12,10 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 9.2.5
     condition: clickhouse.enabled
-  - name: keycloak
-    version: 24.7.5
-    repository: oci://registry-1.docker.io/bitnamicharts
+  - name: keycloakx
+    alias: keycloak
+    version: 7.1.9
+    repository: https://codecentric.github.io/helm-charts
     condition: keycloak.enabled
   - name: langfuse
     repository: https://langfuse.github.io/langfuse-k8s

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -34,10 +34,18 @@ keycloak:
   enabled: true
   ingress:
     enabled: false
-    hostname: "auth.app.example.com"
     annotations: {}
     # Value should match your Issuer/ClusterIssuer and uncomment if you're using cert-manager for certificates
     # cert-manager.io/cluster-issuer: letsencrypt
+    rules: []
+    #  - host: auth.app.example.com
+    #    paths:
+    #      - path: /
+    #        pathType: Prefix
+    tls: []
+    #  - secretName: keycloak-tls
+    #    hosts:
+    #      - auth.app.example.com
 
 postgresql:
   enabled: true

--- a/charts/openhands/templates/_init-containers.yaml
+++ b/charts/openhands/templates/_init-containers.yaml
@@ -30,7 +30,7 @@
       done
   env:
     - name: DATABASES
-      value: "{{ .Values.keycloak.externalDatabase.database }}{{- if (index .Values "litellm-helm").enabled }} {{ (index .Values "litellm-helm").db.database }}{{- end }}{{- if .Values.langfuse.enabled }} {{ .Values.langfuse.postgresql.auth.database }}{{- end }}"
+      value: "{{ .Values.keycloak.database.database }}{{- if (index .Values "litellm-helm").enabled }} {{ (index .Values "litellm-helm").db.database }}{{- end }}{{- if .Values.langfuse.enabled }} {{ .Values.langfuse.postgresql.auth.database }}{{- end }}"
     {{- include "openhands.env" . | nindent 4 }}
 {{- end }}
 {{- if .Values.databaseMigrations.migrate }}

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -243,7 +243,7 @@ spec:
     {{- end }}
     {{- if .Values.keycloak.enabled }}
     - statefulsetStatus:
-        name: keycloak
+        name: {{ .Release.Name }}-keycloak
         namespace: {{ .Release.Namespace }}
         outcomes:
           - fail:

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -75,7 +75,7 @@ spec:
           maxAge: 168h
     {{- end }}
     {{- if .Values.keycloak.enabled }}
-    # Keycloak logs (Bitnami chart)
+    # Keycloak logs (KeycloakX chart)
     - logs:
         name: app/{{ .Release.Name }}-keycloak/logs
         namespace: {{ .Release.Namespace }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -305,10 +305,21 @@ keycloak:
     existingSecretKey: password
 
   dbchecker:
-    enabled: true
-    image:
-      repository: docker.io/library/busybox
-      tag: "1.37"
+    enabled: false
+
+  waitForDbImage: "bitnamilegacy/postgresql:latest"
+  extraInitContainers: |
+    - name: wait-for-db
+      image: "{{ .Values.waitForDbImage }}"
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Waiting for PostgreSQL at {{ .Values.database.hostname }}:{{ .Values.database.port }}..."
+          until pg_isready -h "{{ .Values.database.hostname }}" -p "{{ .Values.database.port }}" > /dev/null 2>&1; do
+            echo "PostgreSQL is unavailable - sleeping 2s"
+            sleep 2
+          done
+          echo "PostgreSQL is ready!"
 
   proxy:
     enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -291,6 +291,11 @@ keycloak:
   fullnameOverride: keycloak
   replicas: 1
 
+  command:
+    - "/opt/keycloak/bin/kc.sh"
+  args:
+    - "start"
+
   image:
     repository: quay.io/keycloak/keycloak
     tag: "26.5.5"
@@ -305,21 +310,10 @@ keycloak:
     existingSecretKey: password
 
   dbchecker:
-    enabled: false
-
-  waitForDbImage: "bitnamilegacy/postgresql:latest"
-  extraInitContainers: |
-    - name: wait-for-db
-      image: "{{ .Values.waitForDbImage }}"
-      command: ['sh', '-c']
-      args:
-        - |
-          echo "Waiting for PostgreSQL at {{ .Values.database.hostname }}:{{ .Values.database.port }}..."
-          until pg_isready -h "{{ .Values.database.hostname }}" -p "{{ .Values.database.port }}" > /dev/null 2>&1; do
-            echo "PostgreSQL is unavailable - sleeping 2s"
-            sleep 2
-          done
-          echo "PostgreSQL is ready!"
+    enabled: true
+    image:
+      repository: docker.io/library/busybox
+      tag: "1.37"
 
   proxy:
     enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -351,10 +351,6 @@ keycloak:
           key: admin-password
     - name: KC_FEATURES
       value: token-exchange,admin-fine-grained-authz
-    - name: KC_HTTP_ENABLED
-      value: "true"
-    - name: KC_PROXY_HEADERS
-      value: "xforwarded"
     - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
       value: "true"
     - name: KC_DB_USERNAME

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -307,7 +307,7 @@ keycloak:
   dbchecker:
     enabled: true
     image:
-      repository: docker.io/busybox
+      repository: docker.io/library/busybox
       tag: "1.37"
 
   proxy:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -287,8 +287,7 @@ clickhouse:
 
 keycloak:
   enabled: false
-  url: "http://keycloak-http"
-  fullnameOverride: keycloak
+  url: "http://openhands-keycloak-http"
   replicas: 1
 
   command:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -356,6 +356,8 @@ keycloak:
           key: admin-password
     - name: KC_FEATURES
       value: token-exchange,admin-fine-grained-authz
+    - name: KC_HOSTNAME_STRICT
+      value: "false"
     - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
       value: "true"
     - name: KC_DB_USERNAME

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -287,38 +287,68 @@ clickhouse:
 
 keycloak:
   enabled: false
-  url: "http://keycloak"
+  url: "http://keycloak-http"
   fullnameOverride: keycloak
-  replicaCount: 1
-  production: true
-  proxyHeaders: forwarded
+  replicas: 1
+
+  image:
+    repository: quay.io/keycloak/keycloak
+    tag: "26.5.5"
+    pullPolicy: IfNotPresent
+
+  database:
+    vendor: postgres
+    hostname: oh-main-postgresql
+    port: 5432
+    database: bitnami_keycloak
+    existingSecret: postgres-password
+    existingSecretKey: password
+
+  dbchecker:
+    enabled: true
+    image:
+      repository: docker.io/busybox
+      tag: "1.37"
+
+  proxy:
+    enabled: true
+    mode: xforwarded
+
+  http:
+    relativePath: "/"
+
+  service:
+    type: ClusterIP
+    httpPort: 80
+
+  serviceAccount:
+    create: true
+    name: "keycloak-sa"
+
   ingress:
     enabled: false
-    # REQUIRED: Update to a hostname in a DNS domain you own
-    # hostname: auth.app.example.com
-    servicePort: 80
-    tls: true
+    ingressClassName: traefik
     annotations: {}
       # UPDATE: if you use cert-manager, enter your clusterIssuer may not match.
       # cert-manager.io/cluster-issuer: letsencrypt-production
-    ingressClassName: traefik
-  auth:
-    adminUser: tmpadmin
-    existingSecret: keycloak-admin
-    passwordSecretKey: admin-password
-  service:
-    type: ClusterIP
-  serviceAccount:
-    name: "keycloak-sa"
-  postgresql:
-    enabled: false
-  externalDatabase:
-    host: oh-main-postgresql
-    database: bitnami_keycloak
-    existingSecret: postgres-password
-    existingSecretUserKey: username
-    existingSecretPasswordKey: password
-  extraEnvVars:
+    rules: []
+    #  - host: auth.app.example.com
+    #    paths:
+    #      - path: /
+    #        pathType: Prefix
+    tls: []
+    #  - secretName: keycloak-tls
+    #    hosts:
+    #      - auth.app.example.com
+
+  extraEnv: |
+    - name: KEYCLOAK_ADMIN
+      value: tmpadmin
+    - name: KEYCLOAK_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: keycloak-admin
+          key: admin-password
     - name: KC_FEATURES
       value: token-exchange,admin-fine-grained-authz
     - name: KC_HTTP_ENABLED
@@ -327,45 +357,11 @@ keycloak:
       value: "xforwarded"
     - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
       value: "true"
-  image:
-    repository: bitnamilegacy/keycloak
-  waitForDb:
-    image: "bitnamilegacy/postgresql:latest"
-  initContainers:
-    - name: wait-for-db
-      # The Bitnami Keycloak subchart renders initContainers through common.tplvalues.render,
-      # so this template expression is evaluated at deploy time rather than being treated as
-      # a literal string. This lets us override just the image (e.g. for Replicated proxy)
-      # without duplicating the entire init container.
-      image: '{{ .Values.waitForDb.image }}'
-      command: ['sh', '-c']
-      args:
-        - |
-          echo "Waiting for database \"$KEYCLOAK_DATABASE_NAME\" at $KEYCLOAK_DATABASE_HOST:$KEYCLOAK_DATABASE_PORT..."
-          until PGPASSWORD=$DB_PASS pg_isready -h "$KEYCLOAK_DATABASE_HOST" -p "$KEYCLOAK_DATABASE_PORT" -U "$DB_USER" -d "$KEYCLOAK_DATABASE_NAME" > /dev/null 2>&1; do
-            echo "PostgreSQL is unavailable - sleeping 5s"
-            sleep 5
-          done
-          echo "PostgreSQL is ready, checking database exists..."
-          until PGPASSWORD=$DB_PASS psql -h "$KEYCLOAK_DATABASE_HOST" -p "$KEYCLOAK_DATABASE_PORT" -U "$DB_USER" -d "$KEYCLOAK_DATABASE_NAME" -c "SELECT 1" > /dev/null 2>&1; do
-            echo "Database \"$KEYCLOAK_DATABASE_NAME\" not ready - sleeping 5s"
-            sleep 5
-          done
-          echo "Database \"$KEYCLOAK_DATABASE_NAME\" is ready!"
-      envFrom:
-        - configMapRef:
-            name: keycloak-env-vars
-      env:
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: postgres-password
-              key: username
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: postgres-password
-              key: password
+    - name: KC_DB_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: postgres-password
+          key: username
 
 langfuse:
   # Enable this if you want to use langfuse for tracing

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -27,7 +27,7 @@ spec:
 
     # keycloak
     - openhands/statefulset/keycloak
-    - openhands/service/keycloak
+    - openhands/service/keycloak-http
 
     # postgres
     - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/statefulset/openhands-postgresql{{repl end}}'

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -26,8 +26,8 @@ spec:
     - openhands/ingress/openhands-mcp-ingress
 
     # keycloak
-    - openhands/statefulset/keycloak
-    - openhands/service/keycloak-http
+    - openhands/statefulset/openhands-keycloak
+    - openhands/service/openhands-keycloak-http
 
     # postgres
     - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/statefulset/openhands-postgresql{{repl end}}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -90,10 +90,8 @@ spec:
         existingSecret: postgres-password
         existingSecretKey: password
       dbchecker:
-        enabled: true
-        image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/os-shell'
-          tag: "12"
+        enabled: false
+      waitForDbImage: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql:latest'
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -405,9 +403,7 @@ spec:
         keycloak:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
-          dbchecker:
-            image:
-              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/os-shell'
+          waitForDbImage: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql:latest'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -94,8 +94,8 @@ spec:
       dbchecker:
         enabled: true
         image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/busybox'
-          tag: "1.37"
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/bitnamilegacy/os-shell'
+          tag: "12"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -409,7 +409,7 @@ spec:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
           dbchecker:
             image:
-              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/os-shell'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -57,7 +57,7 @@ spec:
 
     keycloak:
       enabled: true
-      url: 'http://keycloak-http'
+      url: 'http://openhands-keycloak-http'
       resources:
         requests:
           cpu: 500m
@@ -459,7 +459,7 @@ spec:
         {{repl $llmDomain := $derive | ternary (printf "llm-proxy.%s" $bd) (ConfigOption "llm_proxy_hostname") }}
         {{repl $runtimeApiDomain := $derive | ternary (printf "runtime-api.%s" $bd) (ConfigOption "runtime_api_hostname") }}
         {{repl $runtimeBaseDomain := $derive | ternary (printf "runtime.%s" $bd) (ConfigOption "runtime_base_hostname") }}
-        {{repl $computedNoProxy := "127.0.0.1,cluster.local,keycloak-http,keycloak-headless,kubernetes,localhost,oh-main-clickhouse,oh-main-langfuse,oh-main-lite-llm,oh-main-runtime-api,openhands-integrations-service,openhands-litellm,openhands-mcp-service,openhands-minio,openhands-runtime-api,openhands-service,svc" }}
+        {{repl $computedNoProxy := "127.0.0.1,cluster.local,openhands-keycloak-http,openhands-keycloak-headless,kubernetes,localhost,oh-main-clickhouse,oh-main-langfuse,oh-main-lite-llm,oh-main-runtime-api,openhands-integrations-service,openhands-litellm,openhands-mcp-service,openhands-minio,openhands-runtime-api,openhands-service,svc" }}
         {{repl if ne $bd "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $bd }}{{repl end }}
         {{repl if ne $appDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $appDomain }}{{repl end }}
         {{repl if ne $authDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $authDomain }}{{repl end }}

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -92,8 +92,8 @@ spec:
       dbchecker:
         enabled: true
         image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/busybox'
-          tag: "1.37"
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/os-shell'
+          tag: "12"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -407,7 +407,7 @@ spec:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
           dbchecker:
             image:
-              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/os-shell'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -90,8 +90,10 @@ spec:
         existingSecret: postgres-password
         existingSecretKey: password
       dbchecker:
-        enabled: false
-      waitForDbImage: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql:latest'
+        enabled: true
+        image:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/library/busybox'
+          tag: "1.37"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -403,7 +405,9 @@ spec:
         keycloak:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
-          waitForDbImage: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql:latest'
+          dbchecker:
+            image:
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -90,7 +90,10 @@ spec:
         existingSecret: postgres-password
         existingSecretKey: password
       dbchecker:
-        enabled: false
+        enabled: true
+        image:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/busybox'
+          tag: "1.37"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -403,7 +406,8 @@ spec:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
           dbchecker:
-            enabled: false
+            image:
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -107,10 +107,6 @@ spec:
               key: admin-password
         - name: KC_FEATURES
           value: token-exchange,admin-fine-grained-authz
-        - name: KC_HTTP_ENABLED
-          value: "true"
-        - name: KC_PROXY_HEADERS
-          value: "xforwarded"
         - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
           value: "true"
         - name: KC_DB_USERNAME
@@ -488,10 +484,6 @@ spec:
                   key: admin-password
             - name: KC_FEATURES
               value: token-exchange,admin-fine-grained-authz
-            - name: KC_HTTP_ENABLED
-              value: "true"
-            - name: KC_PROXY_HEADERS
-              value: "xforwarded"
             - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
               value: "true"
             - name: KC_DB_USERNAME

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -94,8 +94,8 @@ spec:
       dbchecker:
         enabled: true
         image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/bitnamilegacy/os-shell'
-          tag: "12"
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/busybox'
+          tag: "1.37"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -409,7 +409,7 @@ spec:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
           dbchecker:
             image:
-              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/os-shell'
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -89,10 +89,12 @@ spec:
         database: bitnami_keycloak
         existingSecret: postgres-password
         existingSecretKey: password
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
       dbchecker:
         enabled: true
         image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/library/busybox'
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io/busybox'
           tag: "1.37"
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -109,6 +109,8 @@ spec:
               key: admin-password
         - name: KC_FEATURES
           value: token-exchange,admin-fine-grained-authz
+        - name: KC_HOSTNAME_STRICT
+          value: "false"
         - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
           value: "true"
         - name: KC_DB_USERNAME
@@ -486,6 +488,8 @@ spec:
                   key: admin-password
             - name: KC_FEATURES
               value: token-exchange,admin-fine-grained-authz
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
             - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
               value: "true"
             - name: KC_DB_USERNAME

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -90,10 +90,7 @@ spec:
         existingSecret: postgres-password
         existingSecretKey: password
       dbchecker:
-        enabled: true
-        image:
-          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/busybox'
-          tag: "1.37"
+        enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
         tag: "26.5.5"
@@ -406,8 +403,7 @@ spec:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
           dbchecker:
-            image:
-              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
+            enabled: false
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -57,8 +57,7 @@ spec:
 
     keycloak:
       enabled: true
-      url: 'http://keycloak'
-      resourcesPreset: none
+      url: 'http://keycloak-http'
       resources:
         requests:
           cpu: 500m
@@ -71,29 +70,54 @@ spec:
       ingress:
         enabled: true
         ingressClassName: traefik
-        hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
-        tls: true
         annotations:
           nginx.ingress.kubernetes.io/upstream-vhost: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
           nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-        secrets:
-          - name: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}-tls'
-            key: |
-              {{repl ConfigOptionData "tls_private_key" | nindent 14}}
-            certificate: |
-              {{repl ConfigOptionData "tls_certificate" | nindent 14}}
-      externalDatabase:
-        host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        rules:
+          - host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - secretName: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}-tls'
+            hosts:
+              - '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+      database:
+        vendor: postgres
+        hostname: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        port: 5432
+        database: bitnami_keycloak
         existingSecret: postgres-password
-        existingSecretUserKey: username
-        existingSecretPasswordKey: password
-      image:
-        repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/keycloak'
-      keycloakConfigCli:
+        existingSecretKey: password
+      dbchecker:
+        enabled: true
         image:
-          repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/keycloak-config-cli'
-      waitForDb:
-        image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql:latest'
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/busybox'
+          tag: "1.37"
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/keycloak/keycloak'
+        tag: "26.5.5"
+      extraEnv: |
+        - name: KEYCLOAK_ADMIN
+          value: tmpadmin
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin
+              key: admin-password
+        - name: KC_FEATURES
+          value: token-exchange,admin-fine-grained-authz
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        - name: KC_PROXY_HEADERS
+          value: "xforwarded"
+        - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
+          value: "true"
+        - name: KC_DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: postgres-password
+              key: username
 
     litellm:
       enabled: true
@@ -292,7 +316,7 @@ spec:
           # existingSecretUserKey: username
           # existingSecretPasswordKey: password
         keycloak:
-          externalDatabase:
+          database:
             database: '{{repl ConfigOption "external_postgres_keycloak_database"}}'
         litellm-helm:
           db:
@@ -320,10 +344,6 @@ spec:
         postgresql:
           image:
             repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
-        keycloak:
-          postgresql:
-            image:
-              repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
     - when: '{{repl ConfigOptionEquals "langfuse_enabled" "1" }}'
       recursiveMerge: true
       values:
@@ -388,12 +408,10 @@ spec:
                 fs_group: 10001
         keycloak:
           image:
-            repository: '{{repl LocalRegistryNamespace }}/keycloak'
-          keycloakConfigCli:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/keycloak'
+          dbchecker:
             image:
-              repository: '{{repl LocalRegistryNamespace }}/keycloak-config-cli'
-          waitForDb:
-            image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql:latest'
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'
@@ -441,7 +459,7 @@ spec:
         {{repl $llmDomain := $derive | ternary (printf "llm-proxy.%s" $bd) (ConfigOption "llm_proxy_hostname") }}
         {{repl $runtimeApiDomain := $derive | ternary (printf "runtime-api.%s" $bd) (ConfigOption "runtime_api_hostname") }}
         {{repl $runtimeBaseDomain := $derive | ternary (printf "runtime.%s" $bd) (ConfigOption "runtime_base_hostname") }}
-        {{repl $computedNoProxy := "127.0.0.1,cluster.local,keycloak,keycloak-headless,kubernetes,localhost,oh-main-clickhouse,oh-main-langfuse,oh-main-lite-llm,oh-main-runtime-api,openhands-integrations-service,openhands-litellm,openhands-mcp-service,openhands-minio,openhands-runtime-api,openhands-service,svc" }}
+        {{repl $computedNoProxy := "127.0.0.1,cluster.local,keycloak-http,keycloak-headless,kubernetes,localhost,oh-main-clickhouse,oh-main-langfuse,oh-main-lite-llm,oh-main-runtime-api,openhands-integrations-service,openhands-litellm,openhands-mcp-service,openhands-minio,openhands-runtime-api,openhands-service,svc" }}
         {{repl if ne $bd "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $bd }}{{repl end }}
         {{repl if ne $appDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $appDomain }}{{repl end }}
         {{repl if ne $authDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $authDomain }}{{repl end }}
@@ -459,8 +477,15 @@ spec:
           SSL_VERIFY: '{{repl if ConfigOptionEquals "ssl_verify" "1"}}True{{repl else}}False{{repl end}}'
           OH_AGENT_SERVER_ENV: '{{repl printf "{\"HTTP_PROXY\": \"%s\", \"HTTPS_PROXY\": \"%s\", \"NO_PROXY\": \"%s\", \"SSL_VERIFY\": \"%s\", \"GIT_SSL_NO_VERIFY\": \"%s\"}" (ConfigOption "http_proxy") (ConfigOption "https_proxy") $computedNoProxy (ConfigOptionEquals "ssl_verify" "1" | ternary "True" "False") (ConfigOptionEquals "ssl_verify" "1" | ternary "False" "True") }}'
         keycloak:
-          extraEnvVars:
-            # Existing KC env vars (must be repeated because recursiveMerge replaces arrays)
+          # All extraEnv vars must be repeated because recursiveMerge replaces entire keys
+          extraEnv: |
+            - name: KEYCLOAK_ADMIN
+              value: tmpadmin
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: admin-password
             - name: KC_FEATURES
               value: token-exchange,admin-fine-grained-authz
             - name: KC_HTTP_ENABLED
@@ -469,7 +494,11 @@ spec:
               value: "xforwarded"
             - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
               value: "true"
-            # Proxy env vars
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-password
+                  key: username
             - name: HTTP_PROXY
               value: '{{repl ConfigOption "http_proxy"}}'
             - name: HTTPS_PROXY


### PR DESCRIPTION
## Description

Migrate the Keycloak Helm chart dependency from Bitnami to the [Codecentric KeycloakX](https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx) chart, using the official `quay.io/keycloak/keycloak:26.5.5` image.

**Why:** Bitnami has changed their licensing model. Their charts and images now require a paid subscription, and only the `latest` tag is available for development purposes. We are currently using legacy versions of their images (`bitnamilegacy/keycloak`). This migration moves us to the official upstream Keycloak image and a community-maintained chart that doesn't have these licensing restrictions.

## Helm Chart Checklist

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Test Results

Fresh install on Replicated embedded cluster (instance-2) with external PostgreSQL — **PASS**.

**Home screen:**
<img width="1200" height="809" alt="home-screen" src="https://github.com/user-attachments/assets/2d47ee20-e404-4657-bef5-af7a82ac683b" />


**Test conversation:**
<img width="1200" height="809" alt="test-conversation" src="https://github.com/user-attachments/assets/433b85d8-4253-4aca-bbd9-636417f5c18e" />


## Additional Notes