### PR TITLE
Replace Bitnami PostgreSQL with CloudNative-PG (CNPG)

### DIFF
--- a/.github/workflows/preview-helm-charts.yml
+++ b/.github/workflows/preview-helm-charts.yml
@@ -160,8 +160,6 @@ jobs:
           RUNTIME_API_PREVIEW="${RUNTIME_API_VERSION}-alpha.${{ github.event.pull_request.number }}"
           
           yq -i "(.dependencies[] | select(.name == \"runtime-api\")).version = \"${RUNTIME_API_PREVIEW}\"" charts/openhands/Chart.yaml
-          
-          helm dependency update charts/openhands
 
       - name: Update automation dependency version
         if: steps.check.outputs.should_publish == 'true' && matrix.chart.name == 'openhands' && needs.detect-changes.outputs.automation == 'true'

--- a/charts/automation/Chart.lock
+++ b/charts/automation/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
 - name: minio
   repository: https://charts.min.io/
   version: 5.0.10
-digest: sha256:bb32f5ad11adfc7b0563aeba08a608cfaaa57343152b6439794722dcd02be4ac
-generated: "2026-03-26T15:24:25.529071776Z"
+digest: sha256:58db3f82aecc29448840f9e5349645bc682bb4575ce2d493a9651a7a99f54935
+generated: "2026-04-03T15:12:16.155332-04:00"

--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.0"
 dependencies:
   - name: minio

--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -5,10 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
-  - name: postgresql
-    version: 15.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
   - name: minio
     version: 5.0.10
     repository: https://charts.min.io/

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -24,54 +24,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      {{- if .Values.database.createDatabaseUser }}
-      # Create automation database and user in an existing PostgreSQL instance
-      - name: create-db-user
-        image: postgres:14
-        env:
-          - name: PGPASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.database.superuserSecretName }}
-                key: {{ .Values.database.superuserSecretKey }}
-          - name: DB_HOST
-            value: {{ .Values.database.host | quote }}
-          - name: DB_PORT
-            value: {{ .Values.database.port | quote }}
-          - name: DB_NAME
-            value: {{ .Values.database.name | quote }}
-          - name: DB_USER
-            value: {{ .Values.database.user | quote }}
-          - name: DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.database.secretName }}
-                key: {{ .Values.database.secretKey }}
-        command:
-          - sh
-          - -c
-          - |
-            echo "Waiting for PostgreSQL at $DB_HOST to be available..."
-            for i in $(seq 1 60); do
-              if psql -h $DB_HOST -p $DB_PORT -U postgres -d postgres -c "SELECT 1;" > /dev/null 2>&1; then
-                echo "PostgreSQL is up!"
-
-                echo "Creating the database $DB_NAME if it doesn't exist..."
-                psql -h $DB_HOST -p $DB_PORT -U postgres -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1 || \
-                psql -h $DB_HOST -p $DB_PORT -U postgres -d postgres -c "CREATE DATABASE $DB_NAME;"
-
-                echo "Creating the user $DB_USER if it doesn't exist..."
-                psql -h $DB_HOST -p $DB_PORT -U postgres -d $DB_NAME -tc "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'" | grep -q 1 || \
-                (psql -h $DB_HOST -p $DB_PORT -U postgres -d $DB_NAME -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER; GRANT USAGE ON SCHEMA public TO $DB_USER; GRANT CREATE ON SCHEMA public TO $DB_USER; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $DB_USER;")
-
-                exit 0
-              fi
-              echo "Waiting for PostgreSQL... ($i/60)"
-              sleep 5
-            done
-            echo "PostgreSQL did not become available in time."
-            exit 1
-      {{- end }}
       - name: wait-for-db
         image: postgres:16
         command: ['sh', '-c']

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
             echo "PostgreSQL is up and running!"
         env:
         {{- include "automation.env" . | nindent 8 }}
+      {{- if .Values.database.createDatabases }}
       - name: create-db
         image: postgres:16
         command: ['sh', '-c']
@@ -49,11 +50,14 @@ spec:
             $PSQL -d postgres -c "CREATE DATABASE $AUTOMATION_DB_NAME;"
         env:
         {{- include "automation.env" . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.database.migrate }}
       - name: migrate
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
         command: ["alembic", "upgrade", "head"]
         env:
         {{- include "automation.env" . | nindent 8 }}
+      {{- end }}
       containers:
       - name: automation
         imagePullPolicy: Always

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -71,23 +71,32 @@ spec:
             done
             echo "PostgreSQL did not become available in time."
             exit 1
-      {{- else if .Values.postgresql.enabled }}
-      # Wait for the automation's own PostgreSQL subchart to be ready
-      - name: wait-for-postgres
-        image: bitnamilegacy/postgresql:latest
+      {{- end }}
+      - name: wait-for-db
+        image: postgres:16
         command: ['sh', '-c']
         args:
           - |
-            DB_HOST="{{ .Values.database.host }}"
-            echo "Waiting for PostgreSQL at $DB_HOST to be ready..."
-            until PGPASSWORD=$AUTOMATION_DB_PASS psql -h $DB_HOST -p {{ .Values.database.port }} -U {{ .Values.database.user }} -c '\q' > /dev/null 2>&1; do
+            echo "Waiting for PostgreSQL at $AUTOMATION_DB_HOST to be ready..."
+            until PGPASSWORD=$AUTOMATION_DB_PASS pg_isready -h $AUTOMATION_DB_HOST -p $AUTOMATION_DB_PORT -U $AUTOMATION_DB_USER > /dev/null 2>&1; do
               echo "PostgreSQL is unavailable - sleeping for 2 seconds"
               sleep 2
             done
             echo "PostgreSQL is up and running!"
         env:
         {{- include "automation.env" . | nindent 8 }}
-      {{- end }}
+      - name: create-db
+        image: postgres:16
+        command: ['sh', '-c']
+        args:
+          - |
+            export PGPASSWORD=$AUTOMATION_DB_PASS
+            PSQL="psql -h $AUTOMATION_DB_HOST -p $AUTOMATION_DB_PORT -U $AUTOMATION_DB_USER"
+            echo "Ensuring database \"$AUTOMATION_DB_NAME\" exists..."
+            $PSQL -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='$AUTOMATION_DB_NAME'" | grep -q 1 || \
+            $PSQL -d postgres -c "CREATE DATABASE $AUTOMATION_DB_NAME;"
+        env:
+        {{- include "automation.env" . | nindent 8 }}
       - name: migrate
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
         command: ["alembic", "upgrade", "head"]

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -137,25 +137,6 @@ datadog:
 # Env vars passed directly to the container
 env: {}
 
-# PostgreSQL subchart configuration (for ephemeral/feature environments)
-# When enabled, deploys an in-cluster PostgreSQL instance
-# Service name will be "{release-name}-postgresql", secret name also "{release-name}-postgresql"
-postgresql:
-  enabled: false
-  auth:
-    username: postgres
-    database: automations
-  primary:
-    persistence:
-      enabled: false
-    initdb:
-      scriptsConfigMap: ""
-  service:
-    ports:
-      postgresql: 5432
-  image:
-    repository: bitnamilegacy/postgresql
-
 global:
   security:
     # This allows using the bitnamilegacy image repo

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -45,18 +45,22 @@ automationBaseUrl: ""
 
 # PostgreSQL database configuration
 database:
-  # Full hostname of the PostgreSQL server
-  # Examples:
-  #   - Cloud SQL: "my-project:us-central1:my-instance"
-  #   - In-cluster: "openhands-main-postgresql"
-  #   - Feature env: "openhands-feature-branch-postgresql"
+  # Hostname of the PostgreSQL server
   host: ""
+  # Port of the PostgreSQL server
   port: "5432"
+  # Database user
   user: "automation_user"
+  # Database name
   name: "automations"
-  # Secret containing the automation database password
+  # Name of the Kubernetes secret containing the database password
   secretName: "automation-db-secret"
+  # Key within the secret that holds the password
   secretKey: "db-password"
+  # Create the database if it does not exist
+  createDatabases: false
+  # Run database migrations on startup
+  migrate: true
 
 # GCP Cloud SQL (leave empty for non-GCP)
 gcp:

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -57,14 +57,6 @@ database:
   # Secret containing the automation database password
   secretName: "automation-db-secret"
   secretKey: "db-password"
-  # Create database and user in an existing PostgreSQL instance
-  # When true, runs an init container to create the database and user
-  # Useful when sharing a PostgreSQL instance with other services
-  createDatabaseUser: false
-  # Secret containing the postgres superuser password (for creating the automation user)
-  # Only used when createDatabaseUser=true
-  superuserSecretName: "postgres-password"
-  superuserSecretKey: "password"
 
 # GCP Cloud SQL (leave empty for non-GCP)
 gcp:

--- a/charts/infra/Chart.lock
+++ b/charts/infra/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.23.2
+digest: sha256:db9f0efc07f208bcd280bc9c19e7c1c5983a36b45ac9b2976e16503a8dea45ab
+generated: "2026-04-03T15:12:06.037216-04:00"

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: infra
+description: Infrastructure components for OpenHands (CNPG operator)
+type: application
+version: 0.1.0
+appVersion: "1.0"
+dependencies:
+  - name: cloudnative-pg
+    repository: https://cloudnative-pg.github.io/charts
+    version: 0.23.x
+    condition: cloudnative-pg.enabled

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -1,0 +1,2 @@
+cloudnative-pg:
+  enabled: true

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -14,9 +14,6 @@ dependencies:
 - name: minio
   repository: https://charts.min.io/
   version: 5.0.10
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.3.0
@@ -25,6 +22,9 @@ dependencies:
   version: 1.9.0
 - name: runtime-api
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.24
-digest: sha256:bca3722cdd4840a4557955ea2b80e38991cc2d0a0211855a791cf98e37410e45
-generated: "2026-03-18T00:28:58.972983917-04:00"
+  version: 0.2.6
+- name: automation
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.0
+digest: sha256:bf943198f5990e2b0e752f9d35cd984dc3863f8b4321f40c08a0c8d440d951df
+generated: "2026-04-03T15:12:20.635728-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.19.0
-version: 0.3.11
+version: 0.4.0
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,9 +38,9 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.2.6
+    version: 0.3.0
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.0
+    version: 0.2.0
     condition: automation.enabled

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -28,10 +28,6 @@ dependencies:
     version: 5.0.10
     condition: filestore.ephemeral
     repository: https://charts.min.io/
-  - name: postgresql
-    version: 15.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
   - name: redis
     version: 20.3.0
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -305,13 +305,13 @@
   value: "1"
 {{- end }}
 
-{{- if .Values.postgresql.enabled }}
+{{- if .Values.cnpg.enabled }}
 - name: DB_HOST
-  value: "{{ .Release.Name }}-postgresql"
+  value: "oh-main-postgresql-rw"
 - name: DB_USER
-  value: "{{ .Values.postgresql.auth.username }}"
+  value: "{{ .Values.cnpg.username | default "postgres" }}"
 - name: DB_NAME
-  value: "{{ .Values.postgresql.auth.database }}"
+  value: "{{ .Values.externalDatabase.database | default "openhands" }}"
 {{- else }}
 - name: DB_HOST
   value: "{{ .Values.externalDatabase.host }}"
@@ -342,7 +342,7 @@
 - name: DB_PASS
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
       key: password
 {{- if .Values.jira.enabled }}
 - name: ENABLE_JIRA

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -305,21 +305,14 @@
   value: "1"
 {{- end }}
 
-{{- if .Values.cnpg.enabled }}
 - name: DB_HOST
-  value: "oh-main-postgresql-rw"
+  value: {{ .Values.database.host | quote }}
+- name: DB_PORT
+  value: {{ .Values.database.port | quote }}
 - name: DB_USER
-  value: "{{ .Values.cnpg.username | default "postgres" }}"
+  value: {{ .Values.database.user | quote }}
 - name: DB_NAME
-  value: "{{ .Values.externalDatabase.database | default "openhands" }}"
-{{- else }}
-- name: DB_HOST
-  value: "{{ .Values.externalDatabase.host }}"
-- name: DB_USER
-  value: "{{ .Values.externalDatabase.username }}"
-- name: DB_NAME
-  value: "{{ .Values.externalDatabase.database }}"
-{{- end }}
+  value: {{ .Values.database.name | quote }}
 {{- if .Values.datadog.enabled }}
 # Datadog configuration
 - name: DD_AGENT_HOST
@@ -342,8 +335,8 @@
 - name: DB_PASS
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
-      key: password
+      name: {{ .Values.database.secretName }}
+      key: {{ .Values.database.secretKey }}
 {{- if .Values.jira.enabled }}
 - name: ENABLE_JIRA
   value: "true"

--- a/charts/openhands/templates/_init-containers.yaml
+++ b/charts/openhands/templates/_init-containers.yaml
@@ -14,7 +14,7 @@
       echo "PostgreSQL is up and running!"
   env:
     {{- include "openhands.env" . | nindent 4 }}
-{{- if .Values.databaseMigrations.createDatabases }}
+{{- if .Values.database.createDatabases }}
 - name: create-db
   image: "postgres:16"
   command: ['sh', '-c']
@@ -33,7 +33,7 @@
       value: "{{ .Values.keycloak.externalDatabase.database }}{{- if (index .Values "litellm-helm").enabled }} {{ (index .Values "litellm-helm").db.database }}{{- end }}{{- if .Values.langfuse.enabled }} {{ .Values.langfuse.postgresql.auth.database }}{{- end }}"
     {{- include "openhands.env" . | nindent 4 }}
 {{- end }}
-{{- if .Values.databaseMigrations.migrate }}
+{{- if .Values.database.migrate }}
 - name: migrate-db
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
   command: ["/bin/sh", "-c"]

--- a/charts/openhands/templates/_init-containers.yaml
+++ b/charts/openhands/templates/_init-containers.yaml
@@ -1,6 +1,6 @@
 {{- define "openhands.dbInitContainers" }}
 - name: wait-for-db
-  image: "bitnamilegacy/postgresql:latest"
+  image: "postgres:16"
   command: ['sh', '-c']
   args:
     - |
@@ -16,7 +16,7 @@
     {{- include "openhands.env" . | nindent 4 }}
 {{- if .Values.databaseMigrations.createDatabases }}
 - name: create-db
-  image: "bitnamilegacy/postgresql:latest"
+  image: "postgres:16"
   command: ['sh', '-c']
   args:
     - |

--- a/charts/openhands/templates/cnpg-cluster.yaml
+++ b/charts/openhands/templates/cnpg-cluster.yaml
@@ -25,4 +25,9 @@ spec:
   {{- if .Values.cnpg.imageName }}
   imageName: {{ .Values.cnpg.imageName }}
   {{- end }}
+
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/openhands/templates/cnpg-cluster.yaml
+++ b/charts/openhands/templates/cnpg-cluster.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: oh-main-postgresql
+  namespace: {{ .Release.Namespace }}
+spec:
+  instances: {{ .Values.cnpg.instances | default 1 }}
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
+
+  bootstrap:
+    initdb:
+      database: postgres
+      owner: {{ .Values.cnpg.username | default "postgres" }}
+
+  storage:
+    size: {{ .Values.cnpg.storage.size | default "10Gi" }}
+    {{- if .Values.cnpg.storage.storageClass }}
+    storageClass: {{ .Values.cnpg.storage.storageClass }}
+    {{- end }}
+
+  {{- if .Values.cnpg.imageName }}
+  imageName: {{ .Values.cnpg.imageName }}
+  {{- end }}
+{{- end }}

--- a/charts/openhands/templates/cnpg-cluster.yaml
+++ b/charts/openhands/templates/cnpg-cluster.yaml
@@ -9,12 +9,12 @@ spec:
 
   enableSuperuserAccess: true
   superuserSecret:
-    name: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
+    name: {{ .Values.database.secretName }}
 
   bootstrap:
     initdb:
       database: postgres
-      owner: {{ .Values.cnpg.username | default "postgres" }}
+      owner: {{ .Values.database.user }}
 
   storage:
     size: {{ .Values.cnpg.storage.size | default "10Gi" }}

--- a/charts/openhands/templates/service.yaml
+++ b/charts/openhands/templates/service.yaml
@@ -30,25 +30,6 @@ spec:
     app.kubernetes.io/name: runtime-api
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-{{- if .Values.postgresql.enabled }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: oh-main-postgresql
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: tcp-postgresql
-      port: 5432
-      targetPort: tcp-postgresql
-      nodePort: null
-  selector:
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/component: primary
-{{- end }}
 {{- if and .Values.redis.enabled .Values.langfuse.enabled }}
 ---
 apiVersion: v1

--- a/charts/openhands/templates/troubleshoot/_shared.tpl
+++ b/charts/openhands/templates/troubleshoot/_shared.tpl
@@ -1,18 +1,16 @@
 {{- define "troubleshoot.collectors.shared" -}}
 - clusterInfo: {}
 - clusterResources: {}
-{{- if .Values.externalDatabase.enabled }}
-{{- with .Values.externalDatabase }}
-{{- if .host }}
+{{- if not .Values.cnpg.enabled }}
+{{- with .Values.database }}
 - postgresql:
     collectorName: external-postgresql
-    uri: postgresql://{{ .username | default "postgres" }}:@{{ .host }}:{{ .port | default 5432 }}/{{ .database | default "openhands" }}?sslmode=disable
+    uri: postgresql://{{ .user }}:@{{ .host }}:{{ .port }}/{{ .name }}?sslmode=disable
     tls:
       disabled: true
     password:
-      secretName: {{ .existingSecret | default "postgres-password" }}
-      secretKey: {{ .existingSecretPasswordKey | default "password" }}
-{{- end }}
+      secretName: {{ .secretName }}
+      secretKey: {{ .secretKey }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -54,7 +52,7 @@
           message: "No default storage class found - required for PostgreSQL, Redis, and file storage"
       - pass:
           message: "Default storage class is available"
-{{- if .Values.externalDatabase.enabled }}
+{{- if not .Values.cnpg.enabled }}
 - postgresql:
     checkName: "External PostgreSQL Database Health"
     collectorName: external-postgresql

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -128,12 +128,12 @@ spec:
     {{- if .Values.cnpg.enabled }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://postgres:@oh-main-postgresql-rw:5432/openhands?sslmode=disable
+        uri: postgresql://{{ .Values.database.user }}:@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}?sslmode=disable
         tls:
           disabled: true
         password:
-          secretName: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
-          secretKey: password
+          secretName: {{ .Values.database.secretName }}
+          secretKey: {{ .Values.database.secretKey }}
     {{- end }}
     {{- if .Values.redis.enabled }}
     - redis:

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -52,14 +52,13 @@ spec:
           - app=openhands-mcp
         limits:
           maxAge: 720h
-    {{- if .Values.postgresql.enabled }}
-    # PostgreSQL logs (Bitnami chart)
+    {{- if .Values.cnpg.enabled }}
+    # PostgreSQL logs (CNPG)
     - logs:
-        name: app/{{ .Release.Name }}-postgresql/logs
+        name: app/oh-main-postgresql/logs
         namespace: {{ .Release.Namespace }}
         selector:
-          - app.kubernetes.io/name=postgresql
-          - app.kubernetes.io/instance={{ .Release.Name }}
+          - cnpg.io/cluster=oh-main-postgresql
         limits:
           maxAge: 168h
     {{- end }}
@@ -126,15 +125,15 @@ spec:
         namespace: ingress-nginx
         limits:
           maxAge: 168h
-    {{- if .Values.postgresql.enabled }}
+    {{- if .Values.cnpg.enabled }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://postgres:@{{ .Release.Name }}-postgresql:5432/openhands?sslmode=disable
+        uri: postgresql://postgres:@oh-main-postgresql-rw:5432/openhands?sslmode=disable
         tls:
           disabled: true
         password:
-          secretName: {{ .Release.Name }}-postgresql
-          secretKey: postgres-password
+          secretName: {{ .Values.cnpg.superuserSecret | default "postgres-password" }}
+          secretKey: password
     {{- end }}
     {{- if .Values.redis.enabled }}
     - redis:
@@ -217,17 +216,17 @@ spec:
               when: ">= 1"
               message: "OpenHands Runtime API deployment is ready"
     {{- end }}
-    {{- if .Values.postgresql.enabled }}
+    {{- if .Values.cnpg.enabled }}
     - statefulsetStatus:
-        name: {{ .Release.Name }}-postgresql
+        name: oh-main-postgresql-1
         namespace: {{ .Release.Namespace }}
         outcomes:
           - fail:
               when: "< 1"
-              message: "OpenHands PostgreSQL statefulset is not ready"
+              message: "OpenHands PostgreSQL (CNPG) is not ready"
           - pass:
               when: ">= 1"
-              message: "OpenHands PostgreSQL statefulset is ready"
+              message: "OpenHands PostgreSQL (CNPG) is ready"
     {{- end }}
     {{- if .Values.redis.enabled }}
     - statefulsetStatus:
@@ -263,7 +262,7 @@ spec:
           - pass:
               when: ">= 1"
               message: "Ingress NGINX controller deployment is ready"
-    {{- if .Values.postgresql.enabled }}
+    {{- if .Values.cnpg.enabled }}
     - postgresql:
         checkName: "PostgreSQL Database Health"
         collectorName: postgresql
@@ -274,9 +273,6 @@ spec:
           - fail:
               when: "version == \"\""
               message: "PostgreSQL version could not be determined"
-          - warn:
-              when: "version < 12.0.0"
-              message: "PostgreSQL version is older than recommended (12.0.0+)"
           - pass:
               when: "connected == true"
               message: "PostgreSQL database is healthy"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -313,7 +313,7 @@ keycloak:
   postgresql:
     enabled: false
   externalDatabase:
-    host: oh-main-postgresql
+    host: oh-main-postgresql-rw
     database: bitnami_keycloak
     existingSecret: postgres-password
     existingSecretUserKey: username
@@ -330,7 +330,7 @@ keycloak:
   image:
     repository: bitnamilegacy/keycloak
   waitForDb:
-    image: "bitnamilegacy/postgresql:latest"
+    image: "postgres:16"
   initContainers:
     - name: wait-for-db
       # The Bitnami Keycloak subchart renders initContainers through common.tplvalues.render,
@@ -392,7 +392,7 @@ langfuse:
       existingSecretKey: password
   postgresql:
     deploy: false
-    host: oh-main-postgresql
+    host: oh-main-postgresql-rw
     auth:
       username: postgres
       database: postgres_langfuse
@@ -424,7 +424,7 @@ litellm-helm:
     deployStandalone: false
     useExisting: true
     database: litellm
-    endpoint: "oh-main-postgresql"
+    endpoint: "oh-main-postgresql-rw"
     secret:
       name: postgres-password
       usernameKey: username
@@ -493,24 +493,14 @@ minio:
       memory: 512Mi
       cpu: 100m
 
-postgresql:
+cnpg:
   enabled: true
-  auth:
-    username: postgres
-    existingSecret: postgres-password
-  primary:
-    initdb:
-      scriptsConfigMap: ""
-    persistence:
-      enabled: false
-    # Add the following if using Karpenter with persistence
-    # podAnnotations:
-    #   karpenter.sh/do-not-evict: "true"
-  service:
-    ports:
-      postgresql: 5432
-  image:
-    repository: bitnamilegacy/postgresql
+  instances: 1
+  username: postgres
+  superuserSecret: postgres-password
+  storage:
+    size: 10Gi
+    storageClass: ""
 
 externalDatabase:
   enabled: false
@@ -603,13 +593,6 @@ runtime-api:
   databaseMigrations:
     createDatabases: false
     migrate: true
-  postgresql:
-    auth:
-      username: postgres
-      existingSecret: postgres-password
-  externalDatabase:
-    enabled: false
-    existingSecret: postgres-password
   ingress:
     enabled: false
     # REQUIRED: Update to a hostname in a DNS domain you own
@@ -619,7 +602,7 @@ runtime-api:
       cert-manager.io/cluster-issuer: letsencrypt-production
     tls: true
   env:
-    DB_HOST: oh-main-postgresql
+    DB_HOST: oh-main-postgresql-rw
     DB_USER: postgres
     DB_NAME: runtime_api_db
     K8S_NAMESPACE: "openhands"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -27,10 +27,6 @@ datadog:
 debuggingRoutes:
   enabled: false
 
-databaseMigrations:
-  createDatabases: false
-  migrate: true
-
 deployment:
   replicas: 1
   resources:
@@ -493,18 +489,32 @@ minio:
       memory: 512Mi
       cpu: 100m
 
+# PostgreSQL database configuration
+database:
+  # Full hostname of the PostgreSQL server
+  # Examples:
+  #   - In-cluster CNPG: "oh-main-postgresql-rw"
+  #   - Cloud SQL: "my-project:us-central1:my-instance"
+  #   - External: "postgres.example.com"
+  host: "oh-main-postgresql-rw"
+  port: "5432"
+  user: "postgres"
+  name: "openhands"
+  # Secret containing the database password
+  secretName: "postgres-password"
+  secretKey: "password"
+  # Create databases for openhands and its dependencies (keycloak, litellm, langfuse)
+  createDatabases: false
+  # Run alembic migrations on startup
+  migrate: true
+
+# CloudNative-PG embedded PostgreSQL cluster
 cnpg:
   enabled: true
   instances: 1
-  username: postgres
-  superuserSecret: postgres-password
   storage:
     size: 10Gi
     storageClass: ""
-
-externalDatabase:
-  enabled: false
-  existingSecret: postgres-password
 
 redis:
   enabled: true
@@ -590,7 +600,7 @@ runtime-api:
           - root
           - --user-id
           - "0"
-  databaseMigrations:
+  database:
     createDatabases: false
     migrate: true
   ingress:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -491,21 +491,21 @@ minio:
 
 # PostgreSQL database configuration
 database:
-  # Full hostname of the PostgreSQL server
-  # Examples:
-  #   - In-cluster CNPG: "oh-main-postgresql-rw"
-  #   - Cloud SQL: "my-project:us-central1:my-instance"
-  #   - External: "postgres.example.com"
+  # Hostname of the PostgreSQL server
   host: "oh-main-postgresql-rw"
+  # Port of the PostgreSQL server
   port: "5432"
+  # Database user
   user: "postgres"
+  # Database name
   name: "openhands"
-  # Secret containing the database password
+  # Name of the Kubernetes secret containing the database password
   secretName: "postgres-password"
+  # Key within the secret that holds the password
   secretKey: "password"
-  # Create databases for openhands and its dependencies (keycloak, litellm, langfuse)
+  # Create the database if it does not exist
   createDatabases: false
-  # Run alembic migrations on startup
+  # Run database migrations on startup
   migrate: true
 
 # CloudNative-PG embedded PostgreSQL cluster

--- a/charts/runtime-api/Chart.lock
+++ b/charts/runtime-api/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 15.5.38
 - name: helm-release-pruner
   repository: https://charts.fairwinds.com/stable
   version: 3.3.0
-digest: sha256:9f911cd2f97b7cbaa03b13b538f1ee44e0fb589f40c797c71ccc032e3a669ba5
-generated: "2026-03-05T14:27:07.142687-05:00"
+digest: sha256:17ba46bc56d903ec8100cfc6ba09b16db5ee1e1e28cdf2a7b953c17a3a5610aa
+generated: "2026-04-03T15:12:10.702816-04:00"

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -4,10 +4,6 @@ description: A Helm chart for the FastAPI application
 version: 0.2.6 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
-  - name: postgresql
-    version: 15.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
   - name: helm-release-pruner
     version: 3.3.0
     repository: https://charts.fairwinds.com/stable

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.2.6 # Change this to trigger a new helm chart version being published
+version: 0.3.0 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: helm-release-pruner

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -3,6 +3,14 @@
 - name: {{ $key }}
   value: {{ $value | quote }}
 {{- end }}
+- name: DB_HOST
+  value: {{ .Values.database.host | quote }}
+- name: DB_PORT
+  value: {{ .Values.database.port | quote }}
+- name: DB_USER
+  value: {{ .Values.database.user | quote }}
+- name: DB_NAME
+  value: {{ .Values.database.name | quote }}
 - name: RUNTIME_DEAD_SECONDS
   value: {{ printf "%.0f" .Values.cleanup.dead_seconds | quote }}
 {{- if .Values.runtimeInSameCluster }}
@@ -39,6 +47,6 @@
 - name: DB_PASS
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.database.existingSecret | default "postgres-password" }}
-      key: password
+      name: {{ .Values.database.secretName }}
+      key: {{ .Values.database.secretKey }}
 {{- end }}

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -36,26 +36,9 @@
 - name: DD_TRACE_SAMPLING_RULES
   value: '[{"resource": "GET /health", "sample_rate": 0.0}, {"resource": "GET /internal/metrics", "sample_rate": 0.0}]'
 {{- end }}
-{{- if .Values.postgresql.enabled }}
-- name: DB_HOST
-  value: "{{ .Release.Name }}-postgresql"
-- name: DB_USER
-  value: "{{ .Values.postgresql.auth.username }}"
-- name: DB_NAME
-  value: "{{ .Values.postgresql.auth.database }}"
-{{- else if .Values.database.create }} # should only be true for AWS deploys
-- name: DB_HOST
-  value: "{{.Values.database.host}}"
-- name: DB_PORT
-  value: "{{.Values.database.port}}"
-- name: DB_USER
-  value: "{{.Values.database.new_user}}"
-- name: DB_NAME
-  value: "{{.Values.database.name}}"
-{{- end }}
 - name: DB_PASS
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ .Values.database.existingSecret | default "postgres-password" }}
       key: password
 {{- end }}

--- a/charts/runtime-api/templates/_helpers.tpl
+++ b/charts/runtime-api/templates/_helpers.tpl
@@ -54,33 +54,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 PostgreSQL host
 */}}
 {{- define "runtime-api.postgresql.host" -}}
-{{- .Values.env.DB_HOST | default "oh-main-postgresql-rw" -}}
+{{- .Values.database.host -}}
 {{- end -}}
 
 {{/*
 PostgreSQL username
 */}}
 {{- define "runtime-api.postgresql.username" -}}
-{{- .Values.env.DB_USER | default "postgres" -}}
+{{- .Values.database.user -}}
 {{- end -}}
 
 {{/*
 PostgreSQL database
 */}}
 {{- define "runtime-api.postgresql.database" -}}
-{{- .Values.env.DB_NAME | default "runtime_api_db" -}}
+{{- .Values.database.name -}}
 {{- end -}}
 
 {{/*
 PostgreSQL secret name
 */}}
 {{- define "runtime-api.postgresql.secretName" -}}
-{{- .Values.database.existingSecret | default "postgres-password" -}}
+{{- .Values.database.secretName -}}
 {{- end -}}
 
 {{/*
 PostgreSQL secret key
 */}}
 {{- define "runtime-api.postgresql.secretKey" -}}
-{{- printf "password" -}}
+{{- .Values.database.secretKey -}}
 {{- end -}}

--- a/charts/runtime-api/templates/_helpers.tpl
+++ b/charts/runtime-api/templates/_helpers.tpl
@@ -54,53 +54,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 PostgreSQL host
 */}}
 {{- define "runtime-api.postgresql.host" -}}
-{{- if .Values.postgresql.enabled }}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- else }}
-{{- .Values.database.host -}}
-{{- end }}
+{{- .Values.env.DB_HOST | default "oh-main-postgresql-rw" -}}
 {{- end -}}
 
 {{/*
 PostgreSQL username
 */}}
 {{- define "runtime-api.postgresql.username" -}}
-{{- if .Values.postgresql.enabled }}
-{{- .Values.postgresql.auth.username -}}
-{{- else }}
-{{- .Values.database.user -}}
-{{- end }}
+{{- .Values.env.DB_USER | default "postgres" -}}
 {{- end -}}
 
 {{/*
 PostgreSQL database
 */}}
 {{- define "runtime-api.postgresql.database" -}}
-{{- if .Values.postgresql.enabled }}
-{{- .Values.postgresql.auth.database -}}
-{{- else }}
-{{- .Values.database.name -}}
-{{- end }}
+{{- .Values.env.DB_NAME | default "runtime_api_db" -}}
 {{- end -}}
 
 {{/*
 PostgreSQL secret name
 */}}
 {{- define "runtime-api.postgresql.secretName" -}}
-{{- if .Values.postgresql.enabled }}
-{{- printf "%s-%s" .Release.Name "postgresql" -}}
-{{- else }}
-{{- include "runtime-api.fullname" . -}}
-{{- end }}
+{{- .Values.database.existingSecret | default "postgres-password" -}}
 {{- end -}}
 
 {{/*
 PostgreSQL secret key
 */}}
 {{- define "runtime-api.postgresql.secretKey" -}}
-{{- if .Values.postgresql.enabled }}
-{{- printf "postgres-password" -}}
-{{- else }}
-{{- printf "db-password" -}}
-{{- end }}
+{{- printf "password" -}}
 {{- end -}}

--- a/charts/runtime-api/templates/_init-containers.yaml
+++ b/charts/runtime-api/templates/_init-containers.yaml
@@ -14,7 +14,7 @@
       echo "PostgreSQL is up and running!"
   env:
     {{- include "runtime-api.env" . | nindent 4 }}
-{{- if .Values.databaseMigrations.createDatabases }}
+{{- if .Values.database.createDatabases }}
 - name: create-db
   image: "postgres:16"
   command: ['sh', '-c']
@@ -29,7 +29,7 @@
   env:
     {{- include "runtime-api.env" . | nindent 4 }}
 {{- end }}
-{{- if .Values.databaseMigrations.migrate }}
+{{- if .Values.database.migrate }}
 - name: migrate-db
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
   command: ["alembic", "upgrade", "head"]

--- a/charts/runtime-api/templates/_init-containers.yaml
+++ b/charts/runtime-api/templates/_init-containers.yaml
@@ -1,6 +1,6 @@
 {{- define "runtime-api.dbInitContainers" }}
 - name: wait-for-db
-  image: "bitnamilegacy/postgresql:latest"
+  image: "postgres:16"
   command: ['sh', '-c']
   args:
     - |
@@ -16,7 +16,7 @@
     {{- include "runtime-api.env" . | nindent 4 }}
 {{- if .Values.databaseMigrations.createDatabases }}
 - name: create-db
-  image: "bitnamilegacy/postgresql:latest"
+  image: "postgres:16"
   command: ['sh', '-c']
   args:
     - |

--- a/charts/runtime-api/templates/db-cleanup-cronjob.yaml
+++ b/charts/runtime-api/templates/db-cleanup-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dbCleanup.enabled .Values.database.existingSecret }}
+{{- if .Values.dbCleanup.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/runtime-api/templates/db-cleanup-cronjob.yaml
+++ b/charts/runtime-api/templates/db-cleanup-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dbCleanup.enabled (or .Values.postgresql.enabled .Values.database.secretName) }}
+{{- if and .Values.dbCleanup.enabled .Values.database.existingSecret }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
+++ b/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
@@ -14,25 +14,6 @@ spec:
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
           maxAge: 720h
-    {{- if .Values.postgresql.enabled }}
-    # PostgreSQL logs (Bitnami chart)
-    - logs:
-        name: app/{{ .Release.Name }}-postgresql/logs
-        namespace: {{ .Release.Namespace }}
-        selector:
-          - app.kubernetes.io/name=postgresql
-          - app.kubernetes.io/instance={{ .Release.Name }}
-        limits:
-          maxAge: 168h
-    - postgresql:
-        collectorName: postgresql
-        uri: postgresql://postgres:@{{ include "runtime-api.postgresql.host" . }}:5432/{{ .Values.postgresql.auth.database | default "runtime_api" }}?sslmode=disable
-        tls:
-          disabled: true
-        password:
-          secretName: {{ .Release.Name }}-postgresql
-          secretKey: postgres-password
-    {{- end }}
   analyzers: {{- include "runtime.troubleshoot.analyzers.shared" .  | nindent 4 }}
     - deploymentStatus:
         name: {{ include "runtime-api.fullname" . }}
@@ -44,32 +25,4 @@ spec:
           - pass:
               when: ">= 1"
               message: "Runtime API deployment is ready"
-    {{- if .Values.postgresql.enabled }}
-    - statefulsetStatus:
-        name: {{ .Release.Name }}-postgresql
-        namespace: {{ .Release.Namespace }}
-        outcomes:
-          - fail:
-              when: "< 1"
-              message: "Runtime API PostgreSQL statefulset is not ready"
-          - pass:
-              when: ">= 1"
-              message: "Runtime API PostgreSQL statefulset is ready"
-    - postgresql:
-        checkName: "Runtime API PostgreSQL Database Health"
-        collectorName: postgresql
-        outcomes:
-          - fail:
-              when: "connected == false"
-              message: "Cannot connect to Runtime API PostgreSQL database"
-          - fail:
-              when: "version == \"\""
-              message: "Runtime API PostgreSQL version could not be determined"
-          - warn:
-              when: "version < 12.0.0"
-              message: "Runtime API PostgreSQL version is older than recommended (12.0.0+)"
-          - pass:
-              when: "connected == true"
-              message: "Runtime API PostgreSQL database is healthy"
-    {{- end }}
 {{- end -}}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -69,22 +69,27 @@ tolerations: []
 affinity: {}
 
 # PostgreSQL database configuration
+# PostgreSQL database configuration
 database:
-  # Full hostname of the PostgreSQL server
+  # Hostname of the PostgreSQL server
   host: "oh-main-postgresql-rw"
+  # Port of the PostgreSQL server
   port: "5432"
+  # Database user
   user: "postgres"
+  # Database name
   name: "runtime_api_db"
-  # Secret containing the database password
+  # Name of the Kubernetes secret containing the database password
   secretName: "postgres-password"
+  # Key within the secret that holds the password
   secretKey: "password"
-  # Create database on startup via init container
+  # Create the database if it does not exist
   createDatabases: false
-  # Run alembic migrations on startup
+  # Run database migrations on startup
   migrate: true
-  # Create database and user via a Job (used for AWS where terraform doesn't create it)
+  # Create database user if it does not exist
   create: false
-  # Secret containing external database credentials (for create-db-user-job)
+  # Name of the secret containing credentials for user creation
   createJobSecretName: "runtime-api-db-credentials"
   poolSize:
     api: 5

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -72,29 +72,8 @@ tolerations: []
 
 affinity: {}
 
-postgresql:
-  enabled: false
-  isFeatureDeploy: false
-  primary:
-    persistence:
-      enabled: false
-  auth:
-    username: postgres
-    password: "" # This should be set externally for security reasons
-    existingSecret: postgres-password
-    database: runtime_api_db
-  service:
-    ports:
-      postgresql: 5432
-  image:
-    repository: bitnamilegacy/postgresql
-
-externalDatabase:
-  enabled: false
-  existingSecret: postgres-password
-
-# External database configuration (used when postgresql.enabled=false)
 database:
+  existingSecret: postgres-password
   create: false # Will only be true for AWS as it can't create the DB in terraform
   secretName: runtime-api-db-credentials # Secret containing external database credentials
   poolSize:
@@ -216,8 +195,3 @@ datadog:
 replicated:
   enabled: false
 
-global:
-  security:
-    # This allows using the bitnamilegacy image repo.
-    # See: https://github.com/bitnami/containers/issues/83267
-    allowInsecureImages: true

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -3,10 +3,6 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-databaseMigrations:
-  createDatabases: false
-  migrate: true
-
 image:
   repository: ghcr.io/openhands/runtime-api
   tag: sha-7857be8
@@ -72,16 +68,30 @@ tolerations: []
 
 affinity: {}
 
+# PostgreSQL database configuration
 database:
-  existingSecret: postgres-password
-  create: false # Will only be true for AWS as it can't create the DB in terraform
-  secretName: runtime-api-db-credentials # Secret containing external database credentials
+  # Full hostname of the PostgreSQL server
+  host: "oh-main-postgresql-rw"
+  port: "5432"
+  user: "postgres"
+  name: "runtime_api_db"
+  # Secret containing the database password
+  secretName: "postgres-password"
+  secretKey: "password"
+  # Create database on startup via init container
+  createDatabases: false
+  # Run alembic migrations on startup
+  migrate: true
+  # Create database and user via a Job (used for AWS where terraform doesn't create it)
+  create: false
+  # Secret containing external database credentials (for create-db-user-job)
+  createJobSecretName: "runtime-api-db-credentials"
   poolSize:
-    api: 5 # Pool size for API deployment (default)
-    cronjobs: 2 # Pool size for cronjobs (default)
+    api: 5
+    cronjobs: 2
   maxOverflow:
-    api: 10 # Max overflow for API deployment (default)
-    cronjobs: 5 # Max overflow for cronjobs (default)
+    api: 10
+    cronjobs: 5
 
 helm-release-pruner:
   enabled: false

--- a/docs/cnpg-migration-guide.md
+++ b/docs/cnpg-migration-guide.md
@@ -191,11 +191,6 @@ keycloak:
 litellm-helm:
   db:
     endpoint: oh-main-postgresql-rw
-
-# If Langfuse is enabled:
-langfuse:
-  postgresql:
-    host: oh-main-postgresql-rw
 ```
 
 ### 4b. Run the helm upgrade with replicas held at zero
@@ -211,7 +206,7 @@ helm upgrade openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands --versio
   --timeout 600s
 ```
 
-Scale down anything the `--set` overrides didn't cover (e.g. LiteLLM, Langfuse):
+Scale down anything the `--set` overrides didn't cover (e.g. LiteLLM):
 
 ```bash
 kubectl scale deployment -n $NAMESPACE --all --replicas=0

--- a/docs/cnpg-migration-guide.md
+++ b/docs/cnpg-migration-guide.md
@@ -1,0 +1,328 @@
+# Migration Guide: Bitnami PostgreSQL to CloudNative-PG (CNPG)
+
+This guide covers migrating the embedded PostgreSQL from the Bitnami subchart to CloudNative-PG (CNPG) with zero data loss. This applies to deployments using the embedded PostgreSQL (`postgresql.enabled: true` in the old chart).
+
+> **Downtime**: The dump (Step 1) runs while the application is live. Downtime begins when you scale down workloads (Step 3) and ends when the final helm upgrade brings everything back up (Step 6).
+
+## Prerequisites
+
+- `kubectl` access to the cluster
+- `helm` v3
+- Current chart version: openhands `0.3.x` (Bitnami PostgreSQL)
+- Target chart version: openhands `0.4.0` (CNPG)
+
+## Step 1: Dump All Databases
+
+The dump runs as a Kubernetes Job that writes directly to a PVC inside the cluster. This avoids streaming data through `kubectl` (which can timeout via API server or load balancer idle limits).
+
+### 1a. Set variables
+
+```bash
+NAMESPACE=openhands  # adjust if different
+```
+
+### 1b. Create a PVC for the dump
+
+Size this larger than your database. Check current usage with:
+
+```bash
+kubectl exec -n $NAMESPACE \
+  $(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/name=postgresql -o jsonpath='{.items[0].metadata.name}') \
+  -- psql -U postgres -c "SELECT pg_size_pretty(sum(pg_database_size(datname))) FROM pg_database;"
+```
+
+```bash
+kubectl apply -n $NAMESPACE -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pg-migration-dump
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 50Gi   # adjust based on database size
+EOF
+```
+
+### 1c. Run the dump
+
+```bash
+kubectl apply -n $NAMESPACE -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pg-migration-dump
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: dump
+          persistentVolumeClaim:
+            claimName: pg-migration-dump
+      containers:
+        - name: dump
+          image: postgres:17
+          volumeMounts:
+            - name: dump
+              mountPath: /dump
+          env:
+            - name: PGHOST
+              value: oh-main-postgresql
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-password
+                  key: password
+          command: ["sh", "-c"]
+          args:
+            - pg_dumpall --clean --if-exists > /dump/all.sql && ls -lh /dump/all.sql
+EOF
+```
+
+### 1d. Verify
+
+```bash
+kubectl wait --for=condition=Complete job/pg-migration-dump -n $NAMESPACE --timeout=3600s
+kubectl logs job/pg-migration-dump -n $NAMESPACE
+```
+
+The logs should show the dump file size. Once confirmed, clean up the job:
+
+```bash
+kubectl delete job pg-migration-dump -n $NAMESPACE
+```
+
+## Step 2: Install the CNPG Operator
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+
+helm install cnpg-operator cnpg/cloudnative-pg \
+  -n cnpg-system --create-namespace
+
+kubectl wait --for=condition=Available deployment/cnpg-operator-cloudnative-pg \
+  -n cnpg-system --timeout=120s
+```
+
+## Step 3: Scale Down All Workloads
+
+Scale everything to zero and suspend all CronJobs so nothing writes to the database during the migration.
+
+```bash
+kubectl scale deployment -n $NAMESPACE --all --replicas=0
+kubectl scale statefulset -n $NAMESPACE --all --replicas=0
+kubectl patch cronjob -n $NAMESPACE --type=merge -p '{"spec":{"suspend":true}}' --all
+```
+
+Wait until no pods remain:
+
+```bash
+kubectl get pods -n $NAMESPACE
+```
+
+## Step 4: Upgrade the OpenHands Chart (replicas=0)
+
+### 4a. Update your values file
+
+**Remove** these sections:
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    username: postgres
+    existingSecret: postgres-password
+  # ...
+
+externalDatabase:
+  enabled: false
+  existingSecret: postgres-password
+
+databaseMigrations:
+  waitForDatabase: true
+  createDatabases: false
+  migrate: true
+```
+
+**Add** these sections:
+
+```yaml
+database:
+  host: "oh-main-postgresql-rw"
+  port: "5432"
+  user: "postgres"
+  name: "openhands"
+  secretName: "postgres-password"
+  secretKey: "password"
+  waitForDatabase: true
+  createDatabases: true
+  migrate: true
+
+cnpg:
+  enabled: true
+  imageName: "ghcr.io/cloudnative-pg/postgresql:17"
+  instances: 1
+  storage:
+    size: 10Gi
+    # storageClass: ""  # set if you need a specific storage class
+```
+
+**Update `runtime-api`**: Remove the old `databaseMigrations`, `postgresql`, and `externalDatabase` keys. Also remove `DB_HOST` from `runtime-api.env` if present — the chart now derives it from `database.host` automatically. Add:
+
+```yaml
+runtime-api:
+  database:
+    waitForDatabase: true
+    createDatabases: false
+    migrate: true
+```
+
+**Update hostname references** from `oh-main-postgresql` to `oh-main-postgresql-rw`:
+
+```yaml
+keycloak:
+  externalDatabase:
+    host: oh-main-postgresql-rw
+
+litellm-helm:
+  db:
+    endpoint: oh-main-postgresql-rw
+
+# If Langfuse is enabled:
+langfuse:
+  postgresql:
+    host: oh-main-postgresql-rw
+```
+
+### 4b. Run the helm upgrade with replicas held at zero
+
+This creates the CNPG cluster without starting any application pods:
+
+```bash
+helm upgrade openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands --version <VERSION> \
+  -n $NAMESPACE \
+  -f your-values.yaml \
+  --set deployment.replicas=0 \
+  --set runtime-api.replicaCount=0 \
+  --set automation.deployment.replicas=0 \
+  --set keycloak.replicaCount=0 \
+  --timeout 600s
+```
+
+Scale down anything the `--set` overrides didn't cover (e.g. LiteLLM, Langfuse):
+
+```bash
+kubectl scale deployment -n $NAMESPACE --all --replicas=0
+kubectl scale statefulset -n $NAMESPACE --all --replicas=0
+```
+
+### 4c. Wait for the CNPG cluster
+
+```bash
+kubectl wait --for=condition=Ready cluster/oh-main-postgresql \
+  -n $NAMESPACE --timeout=300s
+```
+
+At this point only `oh-main-postgresql-1` should be running.
+
+## Step 5: Restore the Database Dump
+
+```bash
+kubectl apply -n $NAMESPACE -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pg-migration-restore
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: dump
+          persistentVolumeClaim:
+            claimName: pg-migration-dump
+      containers:
+        - name: restore
+          image: postgres:17
+          volumeMounts:
+            - name: dump
+              mountPath: /dump
+          env:
+            - name: PGHOST
+              value: oh-main-postgresql-rw
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-password
+                  key: password
+          command: ["sh", "-c"]
+          args:
+            - psql -f /dump/all.sql
+EOF
+```
+
+```bash
+kubectl wait --for=condition=Complete job/pg-migration-restore -n $NAMESPACE --timeout=7200s
+kubectl logs job/pg-migration-restore -n $NAMESPACE
+```
+
+You will see some harmless errors like `role "postgres" already exists`. Review the output to confirm there are no unexpected errors.
+
+Clean up the migration resources:
+
+```bash
+kubectl delete job pg-migration-restore -n $NAMESPACE
+kubectl delete pvc pg-migration-dump -n $NAMESPACE
+```
+
+## Step 6: Bring the Application Back Up
+
+Run the upgrade again **without** the `--set *.replicas=0` overrides:
+
+```bash
+helm upgrade openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands --version <VERSION> \
+  -n $NAMESPACE \
+  -f your-values.yaml \
+  --wait --timeout 600s
+```
+
+Application pods start up with init containers that run `alembic upgrade head` against the restored data, applying any new migrations before the application starts.
+
+## Verification
+
+1. **CNPG cluster health**:
+   ```bash
+   kubectl get cluster oh-main-postgresql -n $NAMESPACE
+   ```
+   Status should show `Cluster in healthy state`.
+
+2. **Databases present**:
+   ```bash
+   kubectl exec -n $NAMESPACE oh-main-postgresql-1 -- psql -U postgres -c '\l'
+   ```
+
+3. **Application access**: Log in to the OpenHands UI and verify authentication works and existing conversations are visible.
+
+## Rollback
+
+The old Bitnami PostgreSQL PVC is preserved during migration. If you need to roll back:
+
+1. `helm rollback openhands` to the previous revision — the Bitnami StatefulSet reattaches the original PVC with all data intact
+2. Uninstall the CNPG operator
+
+## Cleanup
+
+Once you've verified the migration is successful and no longer need the rollback option:
+
+```bash
+kubectl delete pvc data-oh-main-postgresql-0 -n $NAMESPACE
+```

--- a/docs/cnpg-migration-guide.md
+++ b/docs/cnpg-migration-guide.md
@@ -13,8 +13,6 @@ This guide covers migrating the embedded PostgreSQL from the Bitnami subchart to
 
 ## Step 1: Dump All Databases
 
-The dump runs as a Kubernetes Job that writes directly to a PVC inside the cluster. This avoids streaming data through `kubectl` (which can timeout via API server or load balancer idle limits).
-
 ### 1a. Set variables
 
 ```bash
@@ -112,7 +110,7 @@ kubectl wait --for=condition=Available deployment/cnpg-operator-cloudnative-pg \
 
 ## Step 3: Scale Down All Workloads
 
-Scale everything to zero and suspend all CronJobs so nothing writes to the database during the migration.
+Scale everything to zero so nothing writes to the database during the migration.
 
 ```bash
 kubectl scale deployment -n $NAMESPACE --all --replicas=0
@@ -173,7 +171,7 @@ cnpg:
     # storageClass: ""  # set if you need a specific storage class
 ```
 
-**Update `runtime-api`**: Remove the old `databaseMigrations`, `postgresql`, and `externalDatabase` keys. Also remove `DB_HOST` from `runtime-api.env` if present — the chart now derives it from `database.host` automatically. Add:
+**Update `runtime-api`**: Remove the old `databaseMigrations`, `postgresql`, and `externalDatabase` keys. Also remove `DB_HOST` from `runtime-api.env` if present. Add:
 
 ```yaml
 runtime-api:
@@ -202,8 +200,6 @@ langfuse:
 
 ### 4b. Run the helm upgrade with replicas held at zero
 
-This creates the CNPG cluster without starting any application pods:
-
 ```bash
 helm upgrade openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands --version <VERSION> \
   -n $NAMESPACE \
@@ -228,8 +224,6 @@ kubectl scale statefulset -n $NAMESPACE --all --replicas=0
 kubectl wait --for=condition=Ready cluster/oh-main-postgresql \
   -n $NAMESPACE --timeout=300s
 ```
-
-At this point only `oh-main-postgresql-1` should be running.
 
 ## Step 5: Restore the Database Dump
 
@@ -275,9 +269,9 @@ kubectl wait --for=condition=Complete job/pg-migration-restore -n $NAMESPACE --t
 kubectl logs job/pg-migration-restore -n $NAMESPACE
 ```
 
-You will see some harmless errors like `role "postgres" already exists`. Review the output to confirm there are no unexpected errors.
+You will see some harmless errors like `role "postgres" already exists`. This is expected.
 
-Clean up the migration resources:
+Clean up:
 
 ```bash
 kubectl delete job pg-migration-restore -n $NAMESPACE
@@ -295,7 +289,7 @@ helm upgrade openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands --versio
   --wait --timeout 600s
 ```
 
-Application pods start up with init containers that run `alembic upgrade head` against the restored data, applying any new migrations before the application starts.
+Database migrations run automatically on startup.
 
 ## Verification
 
@@ -314,9 +308,9 @@ Application pods start up with init containers that run `alembic upgrade head` a
 
 ## Rollback
 
-The old Bitnami PostgreSQL PVC is preserved during migration. If you need to roll back:
+The old Bitnami PostgreSQL PVC is preserved during migration.
 
-1. `helm rollback openhands` to the previous revision — the Bitnami StatefulSet reattaches the original PVC with all data intact
+1. `helm rollback openhands` to the previous revision
 2. Uninstall the CNPG operator
 
 ## Cleanup

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -29,9 +29,8 @@ spec:
     - openhands/statefulset/keycloak
     - openhands/service/keycloak
 
-    # postgres
-    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/statefulset/openhands-postgresql{{repl end}}'
-    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/service/openhands-postgresql{{repl end}}'
+    # postgres (CNPG)
+    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/pod/oh-main-postgresql-1{{repl end}}'
 
     # redis
     - openhands/statefulset/openhands-redis-master

--- a/replicated/infra.yaml
+++ b/replicated/infra.yaml
@@ -14,6 +14,8 @@ spec:
       enabled: true
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/cloudnative-pg/cloudnative-pg'
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
 
   optionalValues:
     - when: '{{repl HasLocalRegistry }}'

--- a/replicated/infra.yaml
+++ b/replicated/infra.yaml
@@ -1,0 +1,28 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: infra
+spec:
+  chart:
+    name: infra
+  releaseName: infra
+  namespace: openhands
+  weight: 5
+  helmUpgradeFlags: ["--wait", "--timeout", "300s"]
+  values:
+    cloudnative-pg:
+      enabled: true
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/cloudnative-pg/cloudnative-pg'
+
+  optionalValues:
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        cloudnative-pg:
+          image:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/cloudnative-pg'
+
+  builder:
+    cloudnative-pg:
+      enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -83,7 +83,7 @@ spec:
             certificate: |
               {{repl ConfigOptionData "tls_certificate" | nindent 14}}
       externalDatabase:
-        host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql-rw{{repl end}}'
         existingSecret: postgres-password
         existingSecretUserKey: username
         existingSecretPasswordKey: password
@@ -93,7 +93,7 @@ spec:
         image:
           repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/keycloak-config-cli'
       waitForDb:
-        image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql:latest'
+        image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/postgres:16'
 
     litellm:
       enabled: true
@@ -103,7 +103,7 @@ spec:
       enabled: true
       db:
         # TODO: should the fallback be openhands-postgresql here?
-        endpoint: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        endpoint: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql-rw{{repl end}}'
         secret:
           name: postgres-password
           usernameKey: username
@@ -165,7 +165,7 @@ spec:
         idle_seconds: repl{{ ConfigOption "sandbox_idle_seconds" }}
         dead_seconds: repl{{ ConfigOption "sandbox_dead_seconds" }}
       env:
-        DB_HOST: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        DB_HOST: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql-rw{{repl end}}'
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
@@ -219,7 +219,7 @@ spec:
             kubernetes.io/ingress.class: traefik
     sandbox:
       apiHostname: 'http://openhands-runtime-api:5000'
-    postgresql:
+    cnpg:
       enabled: repl{{ ConfigOptionEquals "postgres_type" "embedded_postgres" }}
     redis:
       enabled: true
@@ -266,21 +266,18 @@ spec:
         runtime-api:
           databaseMigrations:
             createDatabases: true
-        postgresql:
+        cnpg:
           enabled: true
-          auth:
-            username: '{{repl ConfigOption "postgres_username"}}'
-            password: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
-            postgresPassword: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
-            database: '{{repl ConfigOption "postgres_database"}}'
-          persistence:
-            enabled: true
+          username: '{{repl ConfigOption "postgres_username"}}'
+          storage:
+            size: 10Gi
+            storageClass: "openebs-hostpath"
     - when: '{{repl ConfigOptionEquals "postgres_type" "external_postgres" }}'
       recursiveMerge: true
       values:
         databaseMigrations:
           createDatabases: repl{{ ConfigOptionEquals "external_postgres_create_databases" "1" }}
-        postgresql:
+        cnpg:
           enabled: false
         externalDatabase:
           host: '{{repl ConfigOption "external_postgres_host"}}'
@@ -317,13 +314,8 @@ spec:
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
       recursiveMerge: true
       values:
-        postgresql:
-          image:
-            repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
-        keycloak:
-          postgresql:
-            image:
-              repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/postgresql'
+        cnpg:
+          imageName: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/cloudnative-pg/postgresql:16'
     - when: '{{repl ConfigOptionEquals "langfuse_enabled" "1" }}'
       recursiveMerge: true
       values:
@@ -393,10 +385,9 @@ spec:
             image:
               repository: '{{repl LocalRegistryNamespace }}/keycloak-config-cli'
           waitForDb:
-            image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql:latest'
-        postgresql:
-          image:
-            repository: '{{repl LocalRegistryNamespace }}/postgresql'
+            image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgres:16'
+        cnpg:
+          imageName: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql:16'
         redis:
           image:
             repository: '{{repl LocalRegistryNamespace }}/redis'
@@ -527,8 +518,6 @@ spec:
     litellm-helm:
       enabled: true
     minio:
-      enabled: true
-    postgresql:
       enabled: true
     redis:
       enabled: true

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -26,7 +26,7 @@ spec:
 
       # Database configuration
       # TODO: is this the correct hostname fallback for embedded postgres?
-      postgres_host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+      postgres_host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql-rw{{repl end}}'
       postgres_username: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}{{repl ConfigOption "postgres_username"}}{{repl end}}'
       postgres_database: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_database"}}{{repl else}}{{repl ConfigOption "postgres_database"}}{{repl end}}'
       postgres_password: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_password"}}{{repl else}}{{repl ConfigOption "postgres_password"}}{{repl end}}'


### PR DESCRIPTION
## Description

Resolves https://github.com/All-Hands-AI/OpenHands-Cloud/issues/250

Replace the Bitnami PostgreSQL Helm subchart with [CloudNative-PG](https://cloudnative-pg.io/) (CNPG) for managing PostgreSQL instances.

Bitnami has changed their licensing model. Their charts and images now require a paid subscription, and only the `latest` tag is available for development purposes. We are currently using legacy versions of their images (`bitnamilegacy/postgresql`). CNPG is an open-source, Kubernetes-native PostgreSQL operator that is actively maintained and CNCF-certified.

**This is a breaking change.** Existing embedded PostgreSQL data will not be migrated. Consumers using embedded PostgreSQL will need a fresh install.

Additionally, I've removed the embedded postgres option from all the charts except for `openhands`. Internally, we only ever use the parent chart's postgres instance and pass connection details down into the subcharts. It's a nice simplification of the subcharts to remove embedded postgres, but it does mean that the subcharts can no longer be deployed in a standalone way. Because we only ever exercise the parent chart's embedded postgres, I'm not confident that the subcharts are well tested on their embedded postgres, and I'd like to remove the burden of having to validate and maintain that path.

The new standard database configuration options for all the charts looks like this:
```yaml
  # PostgreSQL database configuration
  database:
    # Hostname of the PostgreSQL server
    host: "..."
    # Port of the PostgreSQL server
    port: "5432"
    # Database user
    user: "..."
    # Database name
    name: "..."
    # Name of the Kubernetes secret containing the database password
    secretName: "..."
    # Key within the secret that holds the password
    secretKey: "..."
    # Create the database if it does not exist
    createDatabases: false
    # Run database migrations on startup
    migrate: true
```



## Helm Chart Checklist

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] ~~I have verified backwards compatibility with existing values.yaml configurations~~ — **N/A: this is an intentional breaking change**
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Test Results

Fresh install on Replicated embedded cluster (instance-1) — **PASS**

### Admin Console Dashboard
<img width="1280" height="806" alt="dashboard-ready" src="https://github.com/user-attachments/assets/51880fc9-6cf5-4330-9c73-195425ccf4f3" />

### App Home
<img width="1280" height="806" alt="app-home" src="https://github.com/user-attachments/assets/b8f212fa-c530-4a67-929f-277a86562754" />

### Test Conversation
<img width="1280" height="806" alt="test-conversation" src="https://github.com/user-attachments/assets/935c91c0-e268-488c-ab6e-da8759d1f629" />

## Additional Notes

- Customers using **external PostgreSQL** are unaffected — the `external_postgres` config path still works as before, just with the CNPG cluster disabled
- Database creation is handled by init containers (not CNPG bootstrap), consistent with the existing pattern