### PR TITLE
Add numeric regex validation to GitHub app id in replicated config

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -366,6 +366,10 @@ spec:
           type: text
           when: 'repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}'
           required: true
+          validation:
+            regex:
+              pattern: ^[0-9]+$
+              message: Must be a numeric value
         - name: github_app_webhook_secret
           title: GitHub App Webhook Secret
           help_text: Webhook secret from your GitHub App


### PR DESCRIPTION
Resolves https://github.com/All-Hands-AI/OpenHands-Cloud/issues/525

Adds validation to ensure `GitHub App Id` is a numeric value. This ensures that only valid ids are accepted in the Replicated configuration.

### Testing

In a Replicated installer, there is now an input validation error when the user enters a non numeric GitHub app id:
<img width="968" height="141" alt="Screenshot 2026-04-06 at 11 29 55 AM" src="https://github.com/user-attachments/assets/a3f6ff44-ba05-4c5d-bd68-add224650846" />

The error goes away when the user corrects the value to a numeric app id:
<img width="950" height="128" alt="Screenshot 2026-04-06 at 11 30 02 AM" src="https://github.com/user-attachments/assets/ef3474e6-5a90-4dde-914c-0df57b752bc5" />