### PR TITLE
fix(helm): Bump openhands chart to 0.4.2 to publish automation:0.1.2

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.21.0
-version: 0.4.1
+version: 0.4.2
 maintainers:
   - name: rbren
   - name: xingyao


### PR DESCRIPTION
## Description

This PR fixes the failed `publish-helm-charts` workflow that prevented `automation:0.1.2` from being published to GHCR.

### Root Cause

When [PR #531](https://github.com/All-Hands-AI/OpenHands-Cloud/pull/531) was merged, a race condition occurred:

1. PR #531 bumped `openhands` from `0.4.0` → `0.4.1`
2. However, [commit 4490104](https://github.com/All-Hands-AI/OpenHands-Cloud/commit/4490104) (Laminar support) had already bumped `openhands` to `0.4.1` on `main`
3. Git merged both to `0.4.1` (no version change detected)
4. The `validate-chart-versions` workflow failed because it saw content changes without a version bump
5. Since validation failed **before** the publish step, `automation:0.1.2` was never published

### Fix

This minimal version bump (`0.4.1` → `0.4.2`) triggers the publish workflow to complete successfully, which will publish:
- `openhands:0.4.2`
- `automation:0.1.2` ← This was missing!

### Related

- Fixes the failing check on [PR #543](https://github.com/All-Hands-AI/OpenHands-Cloud/pull/543) (Release 1.22.0)
- After this PR merges and the workflow succeeds, PR #543 can revert the automation version bump back to `0.1.2`

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25a935ab-8858-46d9-87c7-8381ef055ffd)