### PR TITLE
fix: update Keycloak realm config on every deployment

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.0
-version: 0.4.2
+version: 0.4.3
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         checksum/keycloak-config: {{ include (print $.Template.BasePath "/keycloak-config-script.yaml") . | sha256sum }}
         checksum/litellm-config: {{ include (print $.Template.BasePath "/litellm-config-script.yaml") . | sha256sum }}
+        rollme: {{ now | quote }}
         {{- if .Values.allowedUsers }}
         checksum/user-waitlist: {{ include (print $.Template.BasePath "/user-waitlist-configmap.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -88,21 +88,40 @@ data:
     if [ "$GITHUB_PROXY" = "1" ]; then
       export GITHUB_BASE_URL="https://{{ .Values.ingress.host }}/github-proxy/test-auth-feat"
     fi
+    # If Bitbucket Data Center is not enabled, we still need to provide
+    # a host, otherwise the realm creation will fail since it tries to create an OAuth2 provider
+    # with an invalid host. We set it to a placeholder value since the provider won't actually be used.
+    #
+    # This is different from the other providers we configure, where keycloak defaults
+    # the host name to the well known host for the provider (e.g. github.com), even if the provider is disabled.
+    # Self-hosted Bitbucket Data Center instances don't have a well known host.
+    #
+    # Some refactoring of the provider configuration would help, but this is a simple workaround for now.
+    export BITBUCKET_DATA_CENTER_HOST=${BITBUCKET_DATA_CENTER_HOST:-"placeholder.invalid"}
+
+    envsubst '$WEB_HOST,$AUTH_WEB_HOST,$KEYCLOAK_REALM_NAME,$KEYCLOAK_CLIENT_ID,$KEYCLOAK_CLIENT_SECRET,$GITHUB_APP_CLIENT_ID,$GITHUB_APP_CLIENT_SECRET,$GITLAB_APP_CLIENT_ID,$GITLAB_APP_CLIENT_SECRET,$BITBUCKET_APP_CLIENT_ID,$BITBUCKET_APP_CLIENT_SECRET,$GITHUB_BASE_URL,$KEYCLOAK_SMTP_PASSWORD,$BITBUCKET_DATA_CENTER_HOST,$BITBUCKET_DATA_CENTER_CLIENT_ID,$BITBUCKET_DATA_CENTER_CLIENT_SECRET'< /app/allhands-realm-github-provider.json.tmpl > /app/allhands-realm-github-provider.json
+
     if [ "$ERROR_MESSAGE" = "Realm not found." ]; then
       echo "Creating allhands realm..."
-
-      # If Bitbucket Data Center is not enabled, we still need to provide
-      # a host, otherwise the realm creation will fail since it tries to create an OAuth2 provider
-      # with an invalid host. We set it to a placeholder value since the provider won't actually be used.
-      #
-      # This is different from the other providers we configure, where keycloak defaults
-      # the host name to the well known host for the provider (e.g. github.com), even if the provider is disabled.
-      # Self-hosted Bitbucket Data Center instances don't have a well known host.
-      #
-      # Some refactoring of the provider configuration would help, but this is a simple workaround for now.
-      export BITBUCKET_DATA_CENTER_HOST=${BITBUCKET_DATA_CENTER_HOST:-"placeholder.invalid"}
-
-      envsubst '$WEB_HOST,$AUTH_WEB_HOST,$KEYCLOAK_REALM_NAME,$KEYCLOAK_CLIENT_ID,$KEYCLOAK_CLIENT_SECRET,$GITHUB_APP_CLIENT_ID,$GITHUB_APP_CLIENT_SECRET,$GITLAB_APP_CLIENT_ID,$GITLAB_APP_CLIENT_SECRET,$BITBUCKET_APP_CLIENT_ID,$BITBUCKET_APP_CLIENT_SECRET,$GITHUB_BASE_URL,$KEYCLOAK_SMTP_PASSWORD,$BITBUCKET_DATA_CENTER_HOST,$BITBUCKET_DATA_CENTER_CLIENT_ID,$BITBUCKET_DATA_CENTER_CLIENT_SECRET'< /app/allhands-realm-github-provider.json.tmpl > /app/allhands-realm-github-provider.json
       keycloak_api_call "curl -s -X POST \"$KEYCLOAK_SERVER_URL/admin/realms\" -H \"Authorization: Bearer $ACCESS_TOKEN\" -H \"Content-Type: application/json\" --data \"@/app/allhands-realm-github-provider.json\""
       echo "Created allhands realm."
+    else
+      echo "Updating allhands realm configuration..."
+
+      # Update realm-level settings (token lifespans, login config, etc.)
+      keycloak_api_call "curl -s -X PUT \"$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME\" \
+        -H \"Authorization: Bearer $ACCESS_TOKEN\" \
+        -H \"Content-Type: application/json\" \
+        --data \"@/app/allhands-realm-github-provider.json\""
+
+      # Update sub-resources (identity providers, clients, roles, mappers) via partial import.
+      # OVERWRITE policy replaces existing resources with the template version,
+      # making the template the source of truth on every deployment.
+      jq '. + {"ifResourceExists": "OVERWRITE"}' /app/allhands-realm-github-provider.json > /tmp/partial-import.json
+      keycloak_api_call "curl -s -X POST \"$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME/partialImport\" \
+        -H \"Authorization: Bearer $ACCESS_TOKEN\" \
+        -H \"Content-Type: application/json\" \
+        --data \"@/tmp/partial-import.json\""
+
+      echo "Updated allhands realm configuration."
     fi


### PR DESCRIPTION
## Description

Fixes: https://github.com/All-Hands-AI/OpenHands-Cloud/issues/309

The Keycloak init container only creates the realm on first deployment. If the realm already exists, config changes (e.g. a customer updating their GitHub OAuth app credentials) are silently ignored and never propagated to Keycloak. This has been a pain point for customers needing auth configuration updates.

This changes the init container to also update an existing realm on every deployment using two Keycloak Admin API calls: `PUT /admin/realms/{realm}` for realm-level settings and `POST /admin/realms/{realm}/partialImport` with `ifResourceExists: OVERWRITE` for sub-resources (identity providers, clients, roles, mappers). Both are idempotent and don't affect existing user accounts or sessions.

Note: this makes the realm template the authoritative source of truth — manual changes made in the Keycloak admin console will be overwritten on next deploy.

## Helm Chart Checklist

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

The `envsubst` and Bitbucket Data Center placeholder setup were moved before the if/else so both the create and update branches share the rendered template. No new Helm values or secrets are required.