### PR TITLE
Fix bitbucket-data-center-app secret not created when BBDC enabled

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/bitbucket-data-center-app.yaml
+++ b/charts/openhands-secrets/templates/bitbucket-data-center-app.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.config.github_oauth_client_id .Values.config.github_oauth_client_secret .Values.config.github_app_id .Values.config.github_app_webhook_secret .Values.config.github_app_private_key }}
+{{- if or .Values.config.bitbucket_data_center_domain .Values.config.bitbucket_data_center_client_id .Values.config.bitbucket_data_center_client_secret }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Motivation

The `bitbucket-data-center-app` secret template has had the wrong conditional since it was first added — it was gated on GitHub config values instead of Bitbucket Data Center values (copy-paste error). This was never caught because `github_app_private_key` was wrapped in erroneous single quotes in `replicated/secrets.yaml`, so even when no GitHub App was configured the value resolved to `''` (truthy in Helm). The recent fix to remove those quotes (#533) made the field correctly resolve to empty, which exposed this bug — BBDC-only installs now fail with `CreateContainerConfigError` on every pod that references the missing secret.

## Approach

Replaced the GitHub conditional with the correct Bitbucket Data Center config values so the secret is created when any BBDC config is provided, matching the gating logic already used in `_env.yaml`.