### PR TITLE
Revert keycloak partialImport realm updates

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: keycloak
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 24.7.5
+- name: laminar
+  repository: https://lmnr-ai.github.io/lmnr-helm
+  version: 0.1.7
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -18,7 +21,13 @@ dependencies:
   repository: oci://charts.shortrib.io/library
   version: 1.9.0
 - name: runtime-api
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.24
-digest: sha256:bca3722cdd4840a4557955ea2b80e38991cc2d0a0211855a791cf98e37410e45
-generated: "2026-03-18T00:28:58.972983917-04:00"
+  repository: file://../runtime-api
+  version: 0.2.9
+- name: automation
+  repository: file://../automation
+  version: 0.1.3
+- name: plugin-directory
+  repository: file://../plugin-directory
+  version: 0.1.0
+digest: sha256:94d4575008b00cdd065884f6863beb08c9add73c7e30ef3916c1f534bfb00ee3
+generated: "2026-04-15T08:25:11.08263-04:00"

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: keycloak
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 24.7.5
-- name: laminar
-  repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.7
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -21,13 +18,7 @@ dependencies:
   repository: oci://charts.shortrib.io/library
   version: 1.9.0
 - name: runtime-api
-  repository: file://../runtime-api
-  version: 0.2.9
-- name: automation
-  repository: file://../automation
-  version: 0.1.3
-- name: plugin-directory
-  repository: file://../plugin-directory
-  version: 0.1.0
-digest: sha256:94d4575008b00cdd065884f6863beb08c9add73c7e30ef3916c1f534bfb00ee3
-generated: "2026-04-15T08:25:11.08263-04:00"
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.24
+digest: sha256:bca3722cdd4840a4557955ea2b80e38991cc2d0a0211855a791cf98e37410e45
+generated: "2026-03-18T00:28:58.972983917-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.0
-version: 0.4.4
+version: 0.4.5
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       annotations:
         checksum/keycloak-config: {{ include (print $.Template.BasePath "/keycloak-config-script.yaml") . | sha256sum }}
         checksum/litellm-config: {{ include (print $.Template.BasePath "/litellm-config-script.yaml") . | sha256sum }}
-        rollme: {{ now | quote }}
         {{- if .Values.allowedUsers }}
         checksum/user-waitlist: {{ include (print $.Template.BasePath "/user-waitlist-configmap.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -88,64 +88,21 @@ data:
     if [ "$GITHUB_PROXY" = "1" ]; then
       export GITHUB_BASE_URL="https://{{ .Values.ingress.host }}/github-proxy/test-auth-feat"
     fi
-    # If Bitbucket Data Center is not enabled, we still need to provide
-    # a host, otherwise the realm creation will fail since it tries to create an OAuth2 provider
-    # with an invalid host. We set it to a placeholder value since the provider won't actually be used.
-    #
-    # This is different from the other providers we configure, where keycloak defaults
-    # the host name to the well known host for the provider (e.g. github.com), even if the provider is disabled.
-    # Self-hosted Bitbucket Data Center instances don't have a well known host.
-    #
-    # Some refactoring of the provider configuration would help, but this is a simple workaround for now.
-    export BITBUCKET_DATA_CENTER_HOST=${BITBUCKET_DATA_CENTER_HOST:-"placeholder.invalid"}
-
-    envsubst '$WEB_HOST,$AUTH_WEB_HOST,$KEYCLOAK_REALM_NAME,$KEYCLOAK_CLIENT_ID,$KEYCLOAK_CLIENT_SECRET,$GITHUB_APP_CLIENT_ID,$GITHUB_APP_CLIENT_SECRET,$GITLAB_APP_CLIENT_ID,$GITLAB_APP_CLIENT_SECRET,$BITBUCKET_APP_CLIENT_ID,$BITBUCKET_APP_CLIENT_SECRET,$GITHUB_BASE_URL,$KEYCLOAK_SMTP_PASSWORD,$BITBUCKET_DATA_CENTER_HOST,$BITBUCKET_DATA_CENTER_CLIENT_ID,$BITBUCKET_DATA_CENTER_CLIENT_SECRET'< /app/allhands-realm-github-provider.json.tmpl > /app/allhands-realm-github-provider.json
-
     if [ "$ERROR_MESSAGE" = "Realm not found." ]; then
       echo "Creating allhands realm..."
+
+      # If Bitbucket Data Center is not enabled, we still need to provide
+      # a host, otherwise the realm creation will fail since it tries to create an OAuth2 provider
+      # with an invalid host. We set it to a placeholder value since the provider won't actually be used.
+      #
+      # This is different from the other providers we configure, where keycloak defaults
+      # the host name to the well known host for the provider (e.g. github.com), even if the provider is disabled.
+      # Self-hosted Bitbucket Data Center instances don't have a well known host.
+      #
+      # Some refactoring of the provider configuration would help, but this is a simple workaround for now.
+      export BITBUCKET_DATA_CENTER_HOST=${BITBUCKET_DATA_CENTER_HOST:-"placeholder.invalid"}
+
+      envsubst '$WEB_HOST,$AUTH_WEB_HOST,$KEYCLOAK_REALM_NAME,$KEYCLOAK_CLIENT_ID,$KEYCLOAK_CLIENT_SECRET,$GITHUB_APP_CLIENT_ID,$GITHUB_APP_CLIENT_SECRET,$GITLAB_APP_CLIENT_ID,$GITLAB_APP_CLIENT_SECRET,$BITBUCKET_APP_CLIENT_ID,$BITBUCKET_APP_CLIENT_SECRET,$GITHUB_BASE_URL,$KEYCLOAK_SMTP_PASSWORD,$BITBUCKET_DATA_CENTER_HOST,$BITBUCKET_DATA_CENTER_CLIENT_ID,$BITBUCKET_DATA_CENTER_CLIENT_SECRET'< /app/allhands-realm-github-provider.json.tmpl > /app/allhands-realm-github-provider.json
       keycloak_api_call "curl -s -X POST \"$KEYCLOAK_SERVER_URL/admin/realms\" -H \"Authorization: Bearer $ACCESS_TOKEN\" -H \"Content-Type: application/json\" --data \"@/app/allhands-realm-github-provider.json\""
       echo "Created allhands realm."
-    else
-      echo "Updating allhands realm configuration..."
-
-      # Update realm-level settings (token lifespans, login config, etc.)
-      keycloak_api_call "curl -s -X PUT \"$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME\" \
-        -H \"Authorization: Bearer $ACCESS_TOKEN\" \
-        -H \"Content-Type: application/json\" \
-        --data \"@/app/allhands-realm-github-provider.json\""
-
-      # Update the allhands client in-place (preserves UUID, sessions, and role assignments).
-      # partialImport with OVERWRITE would delete and recreate the client with a new UUID,
-      # orphaning user sessions and any in-flight OAuth flows.
-      # Safe for concurrent execution — PUT is idempotent.
-      ALLHANDS_UUID=$(curl -s "$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME/clients?clientId=$KEYCLOAK_CLIENT_ID" \
-        -H "Authorization: Bearer $ACCESS_TOKEN" | jq -r '.[0].id')
-      if [ -z "$ALLHANDS_UUID" ] || [ "$ALLHANDS_UUID" = "null" ]; then
-        echo "Error: Could not find client $KEYCLOAK_CLIENT_ID"
-        exit 1
-      fi
-      jq --arg cid "$KEYCLOAK_CLIENT_ID" '.clients[] | select(.clientId == $cid)' \
-        /app/allhands-realm-github-provider.json > /tmp/allhands-client.json
-      keycloak_api_call "curl -s -X PUT \"$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME/clients/$ALLHANDS_UUID\" \
-        -H \"Authorization: Bearer $ACCESS_TOKEN\" \
-        -H \"Content-Type: application/json\" \
-        --data \"@/tmp/allhands-client.json\""
-      echo "Updated allhands client."
-
-      # Update identity providers and mappers via partialImport.
-      # Only IDPs and mappers are included — built-in clients (broker, account, realm-management, etc.)
-      # are excluded because OVERWRITE would recreate them with new role UUIDs, orphaning every
-      # user's role assignments (read-token, offline_access, default-roles) and destroying
-      # scope mappings.
-      jq '{
-        ifResourceExists: "OVERWRITE",
-        identityProviders: .identityProviders,
-        identityProviderMappers: .identityProviderMappers
-      }' /app/allhands-realm-github-provider.json > /tmp/partial-import.json
-      keycloak_api_call "curl -s -X POST \"$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME/partialImport\" \
-        -H \"Authorization: Bearer $ACCESS_TOKEN\" \
-        -H \"Content-Type: application/json\" \
-        --data \"@/tmp/partial-import.json\""
-
-      echo "Updated allhands realm configuration."
     fi


### PR DESCRIPTION
## Description

Reverts 50f0e96 and 5bddde9 which introduced `partialImport` with `OVERWRITE` to update the Keycloak realm config on every deployment and pod restart.

The `partialImport OVERWRITE` strategy was silently dropping user scope assignments (`offline_access`, broker `read-token`, `default-roles`) by recreating built-in clients with new UUIDs on every pod restart. This broke sign-in for users who logged out and back in, producing 403 errors on `broker/gitlab/token` and "Offline tokens not allowed" failures.

Bumps openhands chart version to `0.4.5`.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

This is a pure revert so there are no new values or breaking changes. The keycloak-config-script returns to its pre-5bddde9 behavior where it only creates the realm on first deploy and does not attempt to update it on subsequent restarts.