### PR TITLE
fix: Add http:// scheme to MinIO S3 endpoint URLs

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/templates/_env.yaml
+++ b/charts/automation/templates/_env.yaml
@@ -45,7 +45,7 @@
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ (index .Values.minio.svcaccts 0).secretKey }}
 - name: AWS_S3_ENDPOINT
-  value: {{ printf "%s-minio:9000" .Release.Name }}
+  value: {{ printf "http://%s-minio:9000" .Release.Name }}
 {{- else }}
 # Using external minio (e.g., parent chart's minio instance)
 - name: AWS_ACCESS_KEY_ID

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -113,7 +113,7 @@ minio:
   # External minio configuration (used when enabled=false but filestore.ephemeral=true)
   # Configure this to point to an existing minio instance (e.g., parent chart's minio)
   external:
-    endpoint: "minio:9000"
+    endpoint: "http://minio:9000"
     accessKey: "default"
     secretKey: "notasecret"
 

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.0
-version: 0.4.6
+version: 0.4.7
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,5 +42,5 @@ dependencies:
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.3
+    version: 0.1.4
     condition: automation.enabled

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -44,7 +44,7 @@
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ (index .Values.minio.svcaccts 0).secretKey }}
 - name: AWS_S3_ENDPOINT
-  value: {{ printf "%s-%s" $.Release.Name "minio:9000" }}
+  value: {{ printf "http://%s-%s" $.Release.Name "minio:9000" }}
 - name: AWS_S3_BUCKET
   value: {{ .Values.filestore.bucket }}
 - name: AWS_S3_SECURE

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -44,7 +44,7 @@
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ (index .Values.minio.svcaccts 0).secretKey }}
 - name: AWS_S3_ENDPOINT
-  value: {{ printf "http://%s-%s" $.Release.Name "minio:9000" }}
+  value: {{ printf "http://%s-minio:9000" $.Release.Name }}
 - name: AWS_S3_BUCKET
   value: {{ .Values.filestore.bucket }}
 - name: AWS_S3_SECURE

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -737,7 +737,7 @@ automation:
     enabled: false
     # External minio configuration (points to parent chart's minio)
     external:
-      endpoint: "minio:9000"
+      endpoint: "http://minio:9000"
       accessKey: "default"
       secretKey: "notasecret"
   


### PR DESCRIPTION
## Description

Shared conversation pages return a 500 because botocore raises `ValueError: Invalid endpoint: openhands-minio:9000` — it requires a full URL with a scheme. Some code paths in the application add the scheme automatically based on `AWS_S3_SECURE`, but this isn't done consistently everywhere. It's safer to set the correct `http://` scheme at the source in the chart rather than relying on every consumer to handle a bare host.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Fixed in both the openhands and automation charts (templates and default values).