### PR TITLE
Port runtime-api rollout hardening into cloud chart

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.8
+version: 0.4.9
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.2.10
+    version: 0.2.11
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.2.10 # Change this to trigger a new helm chart version being published
+version: 0.2.11 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/deployment.yaml
+++ b/charts/runtime-api/templates/deployment.yaml
@@ -8,6 +8,12 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.deployment.strategy.maxUnavailable }}
+      maxSurge: {{ .Values.deployment.strategy.maxSurge }}
   selector:
     matchLabels:
       {{- include "runtime-api.selectorLabels" . | nindent 6 }}
@@ -69,18 +75,34 @@ spec:
                   key: admin-password
             
 
-          livenessProbe:
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.probes.startup.path }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.probes.readiness.path }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.warmRuntimes.enabled .Values.ingressBase.enabled }}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -49,6 +49,33 @@ resources:
     cpu: 100m
     memory: 100Mi
 
+deployment:
+  minReadySeconds: 10
+  strategy:
+    maxUnavailable: 0
+    maxSurge: 1
+
+probes:
+  liveness:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /health
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3
+  startup:
+    enabled: true
+    path: /health
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 12
+
 # Unified job settings for both jobs and cronjobs
 jobSettings:
   # Resource configuration


### PR DESCRIPTION
## Summary
- port the runtime-api chart hardening from OpenHands/runtime-api#512 into `charts/runtime-api`
- add `minReadySeconds` and a conservative rolling update strategy to the runtime-api Deployment
- make runtime-api probes configurable in values and add a startup probe alongside the existing readiness/liveness behavior

## Source
- OpenHands/runtime-api#512

## Incident context
A recent production Datadog investigation for `Runtime API HTTP 5xx errors` pointed to a short burst of runtime-api failures during scale-up/rollout:
- monitor: `Runtime API HTTP 5xx errors > {{threshold}} in 15 minutes` (Datadog monitor `2248011`)
- incident window: `2026-04-18 18:49:41Z` to `2026-04-18 18:49:46Z`
- symptom: Traefik `502` responses on `GET /sessions/<id>` across multiple session IDs
- validated separately: Service, EndpointSlice, and Ingress wiring were correct; the `:80` backends seen in Traefik logs were the error-page middleware, not the original runtime-api upstream
- most likely cause: a newly added runtime-api pod began receiving traffic before it was fully ready

This PR reduces that rollout-time risk by ensuring new runtime-api pods must pass startup/readiness checks before becoming routable, while also keeping pods ready for a minimum dwell period and avoiding unavailable capacity during rolling updates.

## Validation
- `helm lint ./charts/runtime-api`
- `helm dependency build ./charts/runtime-api`
- `helm template runtime-api ./charts/runtime-api`

## Notes
This keeps the OpenHands Cloud runtime-api chart aligned with the rollout/readiness safeguards proposed in the upstream runtime-api chart PR.

_This draft PR was created and updated by an AI assistant (OpenHands) on behalf of the user._
