### PR TITLE
fix: gate keycloak config init container on keycloak.enabled

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.9
+version: 0.4.10
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -14,7 +14,9 @@ spec:
       labels:
         app: openhands
       annotations:
+        {{- if .Values.keycloak.enabled }}
         checksum/keycloak-config: {{ include (print $.Template.BasePath "/keycloak-config-script.yaml") . | sha256sum }}
+        {{- end }}
         checksum/litellm-config: {{ include (print $.Template.BasePath "/litellm-config-script.yaml") . | sha256sum }}
         {{- if .Values.allowedUsers }}
         checksum/user-waitlist: {{ include (print $.Template.BasePath "/user-waitlist-configmap.yaml") . | sha256sum }}
@@ -36,16 +38,19 @@ spec:
           configMap:
             name: user-waitlist
         {{- end }}
+        {{- if .Values.keycloak.enabled }}
         - name: keycloak-config-script
           configMap:
             name: keycloak-config-script
             defaultMode: 0755
+        {{- end }}
         - name: litellm-config-script
           configMap:
             name: litellm-config-script
             defaultMode: 0755
       initContainers:
       {{- include "openhands.dbInitContainers" . | nindent 6 }}
+      {{- if .Values.keycloak.enabled }}
       - name: keycloak-config
         imagePullPolicy: Always
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
@@ -57,6 +62,7 @@ spec:
         command:
           - sh
           - /scripts/keycloak-config.sh
+      {{- end }}
       - name: litellm-config
         imagePullPolicy: Always
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.keycloak.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -181,3 +182,4 @@ data:
       # from the beginning without side effects.
       echo "Updated allhands realm configuration."
     fi
+{{- end }}


### PR DESCRIPTION
## Description

When chart consumers bring their own Keycloak (setting `keycloak.enabled=false` on the bundled subchart), the openhands pod still ran a `keycloak-config` init container that bootstraps the admin user and realm against the internal Keycloak service.

We only want to manage Keycloak when the chart is the one controlling it. This gates the init container — along with its script ConfigMap, volume, and pod checksum annotation — on `.Values.keycloak.enabled`, matching the condition already on the Keycloak subchart dependency itself.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Verified via `helm template`:
- `keycloak.enabled=false`: no `keycloak-config` references render (init container, volume, annotation, and ConfigMap all gone).
- `keycloak.enabled=true` (the default for the bundled setup): output is unchanged.