### PR TITLE
feat: add path-based sandbox routing to Replicated installer

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.9
+version: 0.4.10
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.2.11
+    version: 0.2.12
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.2.11 # Change this to trigger a new helm chart version being published
+version: 0.2.12 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/sandbox-gateway.yaml
+++ b/charts/runtime-api/templates/sandbox-gateway.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.sandboxGateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.sandboxGateway.name | default "sandbox-gateway" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.sandboxGateway.gatewayClassName | default "traefik" }}
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: {{ .Values.sandboxGateway.listenerPort | default 8443 }}
+      hostname: {{ required "sandboxGateway.hostname is required when sandboxGateway.enabled is true" .Values.sandboxGateway.hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ .Values.sandboxGateway.tlsSecretName | default "openhands-tls" }}
+      allowedRoutes:
+        namespaces:
+          from: All
+{{- end }}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -173,6 +173,22 @@ ingressBase:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       cert-manager.io/cluster-issuer: letsencrypt-prod
 
+# Shared Gateway API Gateway for path-based sandbox routing.
+# When enabled, renders a gateway.networking.k8s.io/v1 Gateway that the
+# runtime-api attaches HTTPRoutes to (one per sandbox). The name must match
+# the GATEWAY_NAME env var passed to the runtime-api container.
+sandboxGateway:
+  enabled: false
+  name: sandbox-gateway
+  gatewayClassName: traefik
+  hostname: ""
+  # Internal port the Gateway listener binds to. Must match the gateway
+  # controller's entrypoint port — NOT the external port clients dial.
+  # Traefik's websecure entrypoint listens on 8443 by default (NodePort/
+  # Service 443 maps to container 8443), so 8443 is the right default here.
+  listenerPort: 8443
+  tlsSecretName: openhands-tls
+
 autoscaling:
   enabled: true
   minReplicas: 3

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -59,6 +59,19 @@ spec:
           type: text
           default: "runtime.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+        - name: runtime_routing_mode
+          title: Sandbox Routing Mode
+          help_text: |
+            How sandbox URLs are constructed.
+            "Subdomain" routes each sandbox at {id}.<runtime base> and requires a wildcard TLS cert for *.<runtime base>.
+            "Path" routes every sandbox at <runtime base>/{id} via the Kubernetes Gateway API — the uploaded TLS cert only needs a SAN for <runtime base> (no wildcard). Requires the Gateway API CRDs to be installed in the cluster.
+          type: select_one
+          default: "subdomain"
+          items:
+            - name: "subdomain"
+              title: "Subdomain routing (wildcard cert required)"
+            - name: "path"
+              title: "Path-based routing (no wildcard cert)"
 
     - name: tls_configuration
       title: Certificate Configuration

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -473,8 +473,8 @@ spec:
           title: Sandbox Routing Mode
           help_text: |
             How sandbox URLs are constructed.
-            Subdomain routes each sandbox at {id}.<runtime base>. The uploaded TLS cert must have a SAN for *.<runtime base>.
-            Path-based routes every sandbox at <runtime base>/{id}. The uploaded TLS cert must have a SAN for <runtime base>.
+            Subdomain routes each sandbox at `{id}.{runtime_base}`. The uploaded TLS cert must have a SAN for `*.{runtime_base}`.
+            Path-based routes every sandbox at `{runtime_base}/{id}`. The uploaded TLS cert must have a SAN for `{runtime_base}`.
           type: select_one
           default: "subdomain"
           items:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -59,19 +59,6 @@ spec:
           type: text
           default: "runtime.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
-        - name: runtime_routing_mode
-          title: Sandbox Routing Mode
-          help_text: |
-            How sandbox URLs are constructed.
-            "Subdomain" routes each sandbox at {id}.<runtime base> and requires a wildcard TLS cert for *.<runtime base>.
-            "Path" routes every sandbox at <runtime base>/{id} via the Kubernetes Gateway API — the uploaded TLS cert only needs a SAN for <runtime base> (no wildcard). Requires the Gateway API CRDs to be installed in the cluster.
-          type: select_one
-          default: "subdomain"
-          items:
-            - name: "subdomain"
-              title: "Subdomain routing (wildcard cert required)"
-            - name: "path"
-              title: "Path-based routing (no wildcard cert)"
 
     - name: tls_configuration
       title: Certificate Configuration
@@ -475,6 +462,19 @@ spec:
       title: Sandbox Configuration
       description: OpenHands conversations run in isolated sandboxes. Configure sandbox resources and lifecycle settings here. Adjust these settings based on your expected workload and the size of your cluster.
       items:
+        - name: runtime_routing_mode
+          title: Sandbox Routing Mode
+          help_text: |
+            How sandbox URLs are constructed.
+            "Subdomain" routes each sandbox at {id}.<runtime base> and requires a wildcard TLS cert for *.<runtime base>.
+            "Path" routes every sandbox at <runtime base>/{id} via the Kubernetes Gateway API — the uploaded TLS cert only needs a SAN for <runtime base> (no wildcard).
+          type: select_one
+          default: "subdomain"
+          items:
+            - name: "subdomain"
+              title: "Subdomain routing (wildcard cert required)"
+            - name: "path"
+              title: "Path-based routing (no wildcard cert)"
         - name: sandbox_idle_seconds
           title: Idle Time (seconds)
           help_text: How long (in seconds) before idle conversations are paused. Pausing a conversation frees up memory and CPU resources.

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -466,15 +466,15 @@ spec:
           title: Sandbox Routing Mode
           help_text: |
             How sandbox URLs are constructed.
-            "Subdomain" routes each sandbox at {id}.<runtime base> and requires a wildcard TLS cert for *.<runtime base>.
-            "Path" routes every sandbox at <runtime base>/{id} via the Kubernetes Gateway API — the uploaded TLS cert only needs a SAN for <runtime base> (no wildcard).
+            Subdomain routes each sandbox at {id}.<runtime base>. The uploaded TLS cert must have a SAN for *.<runtime base>.
+            Path-based routes every sandbox at <runtime base>/{id}. The uploaded TLS cert must have a SAN for <runtime base>.
           type: select_one
           default: "subdomain"
           items:
             - name: "subdomain"
-              title: "Subdomain routing (wildcard cert required)"
+              title: "Subdomain"
             - name: "path"
-              title: "Path-based routing (no wildcard cert)"
+              title: "Path-based"
         - name: sandbox_idle_seconds
           title: Idle Time (seconds)
           help_text: How long (in seconds) before idle conversations are paused. Pausing a conversation frees up memory and CPU resources.

--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -27,3 +27,6 @@ spec:
               websecure:
                 exposedPort: 443
                 nodePort: 443
+            providers:
+              kubernetesGateway:
+                enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -462,6 +462,29 @@ spec:
             enabled: true
             project: '{{repl ConfigOption "google_vertex_project_id"}}'
             location: '{{repl ConfigOption "google_vertex_location"}}'
+    # Path-based sandbox routing: route every runtime at <base>/{id} through a
+    # shared Gateway instead of per-sandbox Ingresses at {id}.<base>. Requires
+    # Gateway API CRDs in the cluster; Traefik's kubernetesGateway provider is
+    # enabled in embedded-cluster.yaml.
+    - when: '{{repl ConfigOptionEquals "runtime_routing_mode" "path" }}'
+      recursiveMerge: true
+      values:
+        env:
+          RUNTIME_ROUTING_MODE: "path"
+          RUNTIME_URL_PATTERN: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}/{runtime_id}'
+        runtime-api:
+          env:
+            RUNTIME_ROUTING_MODE: "path"
+            RUNTIME_URL_SEPARATOR: "/"
+            USE_GATEWAY_API: "true"
+            GATEWAY_NAME: "sandbox-gateway"
+            RUNTIME_CERT_SECRET: "openhands-tls"
+          ingressBase:
+            enabled: false
+          sandboxGateway:
+            enabled: true
+            hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
+            tlsSecretName: openhands-tls
 
   builder:
     keycloak:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -485,6 +485,51 @@ spec:
             enabled: true
             hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
             tlsSecretName: openhands-tls
+    - when: '{{repl ConfigOptionEquals "analytics_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        laminar:
+          enabled: true
+          appServer:
+            loadBalancer:
+              enabled: false
+          global:
+            cloudProvider: "aws"
+          clickhouse:
+            persistence:
+              storageClass: "openebs-hostpath" # default storage class for the k0s embededed cluster
+            s3:
+              enabled: false
+          frontend:
+            extraEnv:
+              - name: AUTH_KEYCLOAK_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: keycloak-realm
+                    key: client-id
+              - name: AUTH_KEYCLOAK_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: keycloak-realm
+                    key: client-secret
+              - name: AUTH_KEYCLOAK_ISSUER
+                value: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://auth.app.{{repl ConfigOption "base_domain"}}/realms/allhands{{repl else}}https://{{repl ConfigOption "auth_hostname"}}/realms/allhands{{repl end}}'
+            ingress:
+              hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+              className: "traefik"
+            tls:
+              enabled: true
+              secretName: "openhands-tls"
+              clusterIssuer: ""  # leave empty — cert-manager not needed
+            env:
+              nextauthUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+              nextPublicUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+          postgres:
+            persistence:
+              storageClass: "openebs-hostpath"
+          rabbitmq:
+            persistence:
+              storageClass: "openebs-hostpath"
 
   builder:
     keycloak:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -463,9 +463,9 @@ spec:
             project: '{{repl ConfigOption "google_vertex_project_id"}}'
             location: '{{repl ConfigOption "google_vertex_location"}}'
     # Path-based sandbox routing: route every runtime at <base>/{id} through a
-    # shared Gateway instead of per-sandbox Ingresses at {id}.<base>. Requires
-    # Gateway API CRDs in the cluster; Traefik's kubernetesGateway provider is
-    # enabled in embedded-cluster.yaml.
+    # shared Gateway instead of per-sandbox Ingresses at {id}.<base>. Traefik's
+    # kubernetesGateway provider (enabled in embedded-cluster.yaml) installs
+    # the Gateway API CRDs and serves the Gateway.
     - when: '{{repl ConfigOptionEquals "runtime_routing_mode" "path" }}'
       recursiveMerge: true
       values:


### PR DESCRIPTION
## Description

This adds a `runtime_routing_mode` config option to replicated with a new `path` value that routes every sandbox at `<base>/{id}` through a single shared hostname. A non-wildcard cert with a SAN for the bare `runtime.<base>` is sufficient. Default stays on `subdomain` so existing installs are unchanged.

Some customers can't obtain a wildcard TLS cert for `*.runtime.<base>` — internal CAs often refuse wildcards, and some compliance regimes forbid them outright. Our subdomain routing mode made that wildcard mandatory, effectively blocking those deployments.

The charts do not currently wire up all the environment variables necessary for path-based routing, but the `runtime-api` chart can now optionally create the Gateway.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Verified end-to-end on embedded-cluster `instance-3` in path mode: Gateway `Accepted` + `Programmed`, HTTPRoute `ResolvedRefs`, sandbox reachable from a real browser at `https://runtime.<base>/{id}/`.