### PR TITLE
chore(litellm): Update litellm image to v1.82.3-stable.patch.2

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -112,7 +112,7 @@ spec:
         enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/berriai/litellm-database'
-        tag: "v1.82.3-stable.patch.2"
+        tag: "v1.82.3-stable.patch.3"
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       environmentSecrets:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -112,9 +112,7 @@ spec:
         enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/berriai/litellm-database'
-        # need to use a version of liteLLM prior to 1.80+ due to a breaking change where the /user/info endpoint returns a 404 for new users
-        # see PR https://github.com/OpenHands/OpenHands/pull/12250 for more info
-        tag: "main-v1.79.1-stable"
+        tag: "v1.82.3-stable.patch.2"
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       environmentSecrets:


### PR DESCRIPTION
## Description

Title.

The deleted comment about pinning to an earlier version is irrelevant now. We've been running 1.80+ for quite some time in staging and prod. 

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Performed a clean install on a replicated instance, and I was able to start a conversation.
