### PR TITLE
PLTF-1597: add environment variable to enable GitHub resolver

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -296,6 +296,8 @@ spec:
     - when: '{{repl ConfigOptionEquals "github_auth_enabled" "1" }}'
       recursiveMerge: true
       values:
+        env:
+          ENABLE_V1_GITHUB_RESOLVER: "true"
         githubApp:
           enabled: true
           appId: '{{repl ConfigOption "github_app_id"}}'


### PR DESCRIPTION
## Description

This setting enables the GitHub resolver when the user has their GitHub app set up to subscribe to events.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<img width="1510" height="808" alt="Screenshot 2026-04-24 at 5 06 12 PM" src="https://github.com/user-attachments/assets/ea0284c9-f5b5-4dcb-91cc-87814417b31b" />
