### PR TITLE
PLTF-1597: subscribe to issue_comment, pull_request, and pull_request_review_comment events

### DIFF
--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -92,6 +92,11 @@ def build_app_manifest(
             "statuses": "write",
             "workflows": "write",
         },
+        "default_events": [
+            "issue_comment",
+            "pull_request",
+            "pull_request_review_comment",
+        ],
         "hook_attributes": {
             "url": f"https://app.{base_domain}/integration/github/events",
         },

--- a/scripts/create_github_app/test_create_github_app.py
+++ b/scripts/create_github_app/test_create_github_app.py
@@ -239,6 +239,22 @@ class TestBuildAppManifest:
         manifest = build_app_manifest(base_domain="example.com")
         assert manifest["request_oauth_on_install"] is True
 
+    @pytest.mark.parametrize("event", [
+        "issue_comment",
+        "pull_request",
+        "pull_request_review_comment",
+    ])
+    def test_manifest_subscribes_to_event(self, event):
+        """Test that manifest subscribes to required GitHub events."""
+        manifest = build_app_manifest(base_domain="example.com")
+        assert event in manifest["default_events"]
+
+    def test_manifest_has_only_expected_events(self):
+        """Test that manifest subscribes to exactly the expected events, no more."""
+        manifest = build_app_manifest(base_domain="example.com")
+        expected = {"issue_comment", "pull_request", "pull_request_review_comment"}
+        assert set(manifest["default_events"]) == expected
+
 
 class TestGenerateManifestHtml:
     """Tests for generate_manifest_html function."""


### PR DESCRIPTION
## Summary

- Adds `default_events` to the GitHub App manifest so created apps automatically subscribe to `issue_comment`, `pull_request`, and `pull_request_review_comment` events
- These events are required for the resolver to react to PR/issue activity

## Test plan

- [x] RED: 4 failing tests written before implementation (`test_manifest_subscribes_to_event` parametrized × 3, `test_manifest_has_only_expected_events`)
- [x] GREEN: Added `default_events` list to `build_app_manifest` — all 59 tests pass
- [x] Tests verify each event is present individually and that no unexpected events are added

## TDD Evidence

RED phase: failing tests added for `default_events` key with all 3 event strings
GREEN phase: minimum implementation — added `default_events` list to manifest dict
All 59 tests passing after change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing
<img width="469" height="133" alt="Screenshot 2026-04-24 at 5 48 26 PM" src="https://github.com/user-attachments/assets/c7941fcd-7588-4a26-9e1a-5829d0f4c3ba" />
<img width="1114" height="286" alt="Screenshot 2026-04-24 at 5 48 11 PM" src="https://github.com/user-attachments/assets/e91db2ed-fa20-44f7-b175-60707be2c832" />

GitHub App created with the updated script was subscribed to the 3 event types:
<img width="1243" height="819" alt="Screenshot 2026-04-24 at 5 48 54 PM" src="https://github.com/user-attachments/assets/c236dd38-c70f-4d07-9d17-83ed682a5078" />
