### PR TITLE
feat(automation): Add KV store secret configuration

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/templates/_env.yaml
+++ b/charts/automation/templates/_env.yaml
@@ -88,6 +88,14 @@
       name: {{ .Values.automationWebhookSecretFromSecret.name }}
       key: {{ .Values.automationWebhookSecretFromSecret.key }}
 {{- end }}
+# KV store secret for JWT signing and value encryption
+{{- if .Values.kvSecretFromSecret }}
+- name: AUTOMATION_KV_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.kvSecretFromSecret.name }}
+      key: {{ .Values.kvSecretFromSecret.key }}
+{{- end }}
 # Datadog configuration
 - name: DD_AGENT_HOST
   value: "datadog-agent.all-hands-system.svc.cluster.local"

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -152,6 +152,13 @@ automationWebhookSecretFromSecret:
   name: automation-webhook-secret
   key: webhook-secret
 
+# KV store secret from K8s secret
+# Used for signing KV store JWT tokens and encrypting stored values
+# Reuses the existing jwt-secret by default (shared with main openhands app)
+kvSecretFromSecret:
+  name: jwt-secret
+  key: jwt-secret
+
 # Datadog configuration
 datadog:
   env: "dev"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.12
+version: 0.4.13
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,5 +42,5 @@ dependencies:
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.4
+    version: 0.1.5
     condition: automation.enabled

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -745,6 +745,11 @@ automation:
   serviceKeyFromSecret:
     name: automation-service-key
     key: automation-service-key
+
+  # KV store secret from K8s secret (reuses jwt-secret)
+  kvSecretFromSecret:
+    name: jwt-secret
+    key: jwt-secret
   
   # Datadog configuration
   datadog:


### PR DESCRIPTION
## Summary

Wire up `AUTOMATION_KV_SECRET` env var for the automation service's KV store feature. This reuses the existing `jwt-secret` by default to avoid requiring a new secret to be configured.

## Changes

- **`charts/automation/templates/_env.yaml`**: Add `AUTOMATION_KV_SECRET` env var from `kvSecretFromSecret`
- **`charts/automation/values.yaml`**: Add `kvSecretFromSecret` config (defaults to `jwt-secret`)
- **`charts/openhands/values.yaml`**: Pass `kvSecretFromSecret` to automation subchart

## Why reuse jwt-secret?

The KV store needs a secret for:
1. Signing JWT tokens that grant automations access to their KV namespace
2. Encrypting stored values at rest (JWE encryption)

The existing `jwt-secret` has the same security properties (per-deployment secret used for cryptographic operations), so reusing it:
- Avoids adding new secrets to `openhands-secrets` chart
- Avoids adding new Replicated config items
- Works out of the box with existing deployments

## Related

- OpenHands/automation#67 - KV store implementation issue
- OpenHands/automation#69 - KV store service PR

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ea99883f-8bf5-4af3-8208-5b43940363c3)