### PR TITLE
Switch runtime to agent-server everywhere; add warm-runtime count config

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -33,7 +33,7 @@ jobs:
           IMAGES=$(jq -n -c \
             --arg runtime_api "openhands/runtime-api:${RUNTIME_API_TAG}" \
             --arg enterprise "openhands/enterprise-server:${ENTERPRISE_TAG}" \
-            --arg runtime "openhands/runtime:${RUNTIME_TAG}" \
+            --arg runtime "openhands/agent-server:${RUNTIME_TAG}" \
             '[$runtime_api, $enterprise, $runtime]')
 
           echo "images=${IMAGES}" >> $GITHUB_OUTPUT

--- a/charts/image-loader/Chart.yaml
+++ b/charts/image-loader/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: image-loader
 description: A Helm chart for loading images on nodes using a DaemonSet with configurable runtime class
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0.0"

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.12.0-python
+  tag: 1.17.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.17.0-python
+  tag: 1.16.1-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: ghcr.io/all-hands-ai/runtime
-  tag: 0.9.6-nikolaik
+  repository: ghcr.io/openhands/agent-server
+  tag: 1.12.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.22.1
+appVersion: cloud-1.23.0
 version: 0.4.13
 maintainers:
   - name: rbren

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.23.0
+appVersion: cloud-1.22.1
 version: 0.4.13
 maintainers:
   - name: rbren

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.13
+version: 0.4.14
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.2.12
+    version: 0.2.13
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.22.1
-version: 0.4.14
+version: 0.5.0
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -70,8 +70,10 @@
 {{- end }}
 - name: NO_SETUP
   value: 'true'
-- name: SANDBOX_RUNTIME_CONTAINER_IMAGE
-  value: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag | default (printf "%s-nikolaik" (.Values.image.tag | default .Chart.AppVersion)) }}"
+- name: AGENT_SERVER_IMAGE_REPOSITORY
+  value: "{{ .Values.runtime.image.repository }}"
+- name: AGENT_SERVER_IMAGE_TAG
+  value: "{{ .Values.runtime.image.tag }}"
 - name: SANDBOX_REMOTE_RUNTIME_API_URL
   value: {{ .Values.sandbox.apiHostname }}
 - name: SANDBOX_API_KEY

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -210,9 +210,8 @@ resendSync:
 
 runtime:
   image:
-    repository: ghcr.io/openhands/runtime
-    tag: cloud-1.22.1-nikolaik
-  runAsRoot: true
+    repository: ghcr.io/openhands/agent-server
+    tag: 1.12.0-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -537,31 +536,28 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/runtime:cloud-1.22.1-nikolaik"
-        working_dir: "/openhands/code/"
-        environment: {}
+        image: "ghcr.io/openhands/agent-server:1.12.0-python"
+        working_dir: "/workspace"
+        environment:
+          LOG_JSON: "1"
+          LOG_JSON_LEVEL_KEY: "severity"
+          OH_ALLOW_CORS_ORIGINS_0: ""
+          OH_BASH_EVENTS_DIR: "/workspace/bash_events"
+          OH_CONVERSATIONS_PATH: "/workspace/conversations"
+          OH_ENABLE_VNC: "0"
+          OH_VSCODE_PORT: "60001"
+          OH_WEBHOOKS_0_BASE_URL: ""
+          OPENVSCODE_SERVER_ROOT: "/openhands/.openvscode-server"
+          VSCODE_PORT: "60001"
+          WORKER_1: "12000"
+          WORKER_2: "12001"
         command:
-          - /openhands/micromamba/bin/micromamba
-          - run
-          - -n
-          - openhands
-          - poetry
-          - run
-          - python
-          - -u
-          - -m
-          - openhands.runtime.action_execution_server
+          - /usr/local/bin/openhands-agent-server
+          - "--port"
           - "60000"
-          - --working-dir
-          - /workspace
-          - --plugins
-          - agent_skills
-          - jupyter
-          - vscode
-          - --username
-          - root
-          - --user-id
-          - "0"
+        run_as_user: 10001
+        run_as_group: 10001
+        fs_group: 10001
   databaseMigrations:
     waitForDatabase: true
     createDatabases: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -114,7 +114,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.23.0
+  tag: cloud-1.22.1
 
 ingress:
   enabled: false
@@ -211,7 +211,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.17.0-python
+    tag: 1.16.1-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -536,7 +536,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/agent-server:1.17.0-python"
+        image: "ghcr.io/openhands/agent-server:1.16.1-python"
         working_dir: "/workspace"
         environment:
           LOG_JSON: "1"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -114,7 +114,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.22.1
+  tag: cloud-1.23.0
 
 ingress:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -211,7 +211,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.12.0-python
+    tag: 1.17.0-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -536,7 +536,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/agent-server:1.12.0-python"
+        image: "ghcr.io/openhands/agent-server:1.17.0-python"
         working_dir: "/workspace"
         environment:
           LOG_JSON: "1"

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.2.12 # Change this to trigger a new helm chart version being published
+version: 0.2.13 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -207,7 +207,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/agent-server:1.17.0-python"
+      image: "ghcr.io/openhands/agent-server:1.16.1-python"
       working_dir: "/workspace"
       environment:
         LOG_JSON: "1"

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -207,31 +207,28 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/runtime:cloud-1.22.1-nikolaik"
-      working_dir: "/openhands/code/"
-      environment: {}
+      image: "ghcr.io/openhands/agent-server:1.12.0-python"
+      working_dir: "/workspace"
+      environment:
+        LOG_JSON: "1"
+        LOG_JSON_LEVEL_KEY: "severity"
+        OH_ALLOW_CORS_ORIGINS_0: ""
+        OH_BASH_EVENTS_DIR: "/workspace/bash_events"
+        OH_CONVERSATIONS_PATH: "/workspace/conversations"
+        OH_ENABLE_VNC: "0"
+        OH_VSCODE_PORT: "60001"
+        OH_WEBHOOKS_0_BASE_URL: ""
+        OPENVSCODE_SERVER_ROOT: "/openhands/.openvscode-server"
+        VSCODE_PORT: "60001"
+        WORKER_1: "12000"
+        WORKER_2: "12001"
       command:
-        - /openhands/micromamba/bin/micromamba
-        - run
-        - -n
-        - openhands
-        - poetry
-        - run
-        - python
-        - -u
-        - -m
-        - openhands.runtime.action_execution_server
+        - /usr/local/bin/openhands-agent-server
+        - "--port"
         - "60000"
-        - --working-dir
-        - /workspace
-        - --plugins
-        - agent_skills
-        - jupyter
-        - vscode
-        - --username
-        - root
-        - --user-id
-        - "0"
+      run_as_user: 10001
+      run_as_group: 10001
+      fs_group: 10001
 
 # Database cleanup CronJob configuration
 dbCleanup:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -207,7 +207,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/agent-server:1.12.0-python"
+      image: "ghcr.io/openhands/agent-server:1.17.0-python"
       working_dir: "/workspace"
       environment:
         LOG_JSON: "1"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -545,6 +545,15 @@ spec:
             regex:
               pattern: ^[1-9][0-9]*m$
               message: Must be a CPU value in millicores (e.g., 500m, 1000m)
+        - name: sandbox_warm_runtime_count
+          title: Warm Runtime Count
+          help_text: Number of warm runtime pods to keep ready so new conversations start instantly. Set to 0 to disable and cold-start each sandbox.
+          type: text
+          default: "1"
+          validation:
+            regex:
+              pattern: ^(0|[1-9][0-9]*)$
+              message: Must be a non-negative integer
 
     - name: proxy_configuration
       title: Proxy Configuration

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -547,7 +547,7 @@ spec:
               message: Must be a CPU value in millicores (e.g., 500m, 1000m)
         - name: sandbox_warm_runtime_count
           title: Warm Runtime Count
-          help_text: Number of warm runtime pods to keep ready so new conversations start instantly. Set to 0 to disable and cold-start each sandbox.
+          help_text: Number of warm runtime sandboxes to keep ready so new conversations start instantly. Set to 0 to disable and cold-start each sandbox.
           type: text
           default: "1"
           validation:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -177,7 +177,7 @@ spec:
         LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       warmRuntimes:
         enabled: true
-        count: 1
+        count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
             image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.17.0-python'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -54,7 +54,7 @@ spec:
         # this is what we need to use for real deployments
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
         # repository: 'ghcr.io/openhands/agent-server'
-        tag: '1.17.0-python'
+        tag: '1.16.1-python'
 
     keycloak:
       enabled: true
@@ -180,7 +180,7 @@ spec:
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
-            image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.17.0-python'
+            image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.16.1-python'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -328,11 +328,11 @@ spec:
         runtime:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.17.0-python'
+            tag: '1.16.1-python'
           warmRuntimes:
             configs:
               - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.17.0-python'
+                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.16.1-python'
                 working_dir: "/workspace"
                 environment:
                   LOG_JSON: "1"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -52,8 +52,9 @@ spec:
     runtime:
       image:
         # this is what we need to use for real deployments
-        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/runtime'
-        # repository: 'ghcr.io/openhands/runtime'
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
+        # repository: 'ghcr.io/openhands/agent-server'
+        tag: '1.12.0-python'
 
     keycloak:
       enabled: true
@@ -326,7 +327,8 @@ spec:
           repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/deploy'
         runtime:
           image:
-            repository: '{{repl LocalRegistryNamespace }}/runtime'
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
+            tag: '1.12.0-python'
           warmRuntimes:
             configs:
               - name: default

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -54,7 +54,7 @@ spec:
         # this is what we need to use for real deployments
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
         # repository: 'ghcr.io/openhands/agent-server'
-        tag: '1.12.0-python'
+        tag: '1.17.0-python'
 
     keycloak:
       enabled: true
@@ -180,7 +180,7 @@ spec:
         count: 1
         configs:
           - name: default
-            image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.12.0-python'
+            image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.17.0-python'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -328,11 +328,11 @@ spec:
         runtime:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.12.0-python'
+            tag: '1.17.0-python'
           warmRuntimes:
             configs:
               - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.12.0-python'
+                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.17.0-python'
                 working_dir: "/workspace"
                 environment:
                   LOG_JSON: "1"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -24,7 +24,6 @@ spec:
       LITELLM_DEFAULT_MODEL: 'litellm_proxy/claude-sonnet-4-5-20250929'
       REQUIRE_PAYMENT: 0
       ENABLE_BILLING: false
-      ENABLE_ONBOARDING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_BILLING_PAGE: true
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -22,7 +22,6 @@ spec:
 
     env:
       LITELLM_DEFAULT_MODEL: 'litellm_proxy/claude-sonnet-4-5-20250929'
-      LLM_BASE_URL: "http://openhands-litellm:4000"
       REQUIRE_PAYMENT: 0
       ENABLE_BILLING: false
       ENABLE_ONBOARDING: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -25,6 +25,7 @@ spec:
       LLM_BASE_URL: "http://openhands-litellm:4000"
       REQUIRE_PAYMENT: 0
       ENABLE_BILLING: false
+      ENABLE_ONBOARDING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_BILLING_PAGE: true
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'


### PR DESCRIPTION
## Description

Prep for the next release, where the v0 runtime image (`ghcr.io/openhands/runtime:*-nikolaik`) is no longer published. The chart and the Replicated overlay now use `ghcr.io/openhands/agent-server` everywhere — the cold-start runtime, the warm-runtime ConfigMap, the image-loader, and the env vars the enterprise-server reads to launch sandboxes. Two related fixes ride along since the warm-runtime spec is being rewritten anyway: a Replicated config item to set the warm-runtime count, and the removal of `LLM_BASE_URL` from the Replicated env block (more on that below).

The chart's runtime env vars were translated from V0 (`SANDBOX_RUNTIME_CONTAINER_IMAGE`, `SANDBOX_USER_ID`, `RUN_AS_OPENHANDS`) to V1 (`AGENT_SERVER_IMAGE_REPOSITORY`, `AGENT_SERVER_IMAGE_TAG`). The `runtime.runAsRoot` toggle and the `-nikolaik` fallback in `_env.yaml` are gone. `runAsRoot` was a V0 setting, sandbox users are set by agent server configurations now.

`LLM_BASE_URL` was removed from the Replicated env block. Enterprise-server auto-forwards `LLM_*`-prefixed vars onto outgoing sandbox specs, and runtime-api matches incoming sandbox requests against warm pods by exact env-set equality. Any `LLM_*` var on the request that wasn't on the warm pod's ConfigMap caused a match miss and a cold start every time. `LITE_LLM_API_URL` (which the chart already templates from the litellm subchart or `.Values.litellm.url`) is what's actually wanted.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

- Tested end-to-end on a Replicated test instance with the warm runtime now correctly consumed by incoming sandbox requests.