### PR TITLE
PLTF-2035: Remove upload trivy results as they get uploaded somewhere else now

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -62,7 +62,3 @@ jobs:
           output: 'trivy-results.sarif'
           timeout: '10m'
           scanners: 'vuln'  # Only scan vulnerabilities, not secrets/config
-      - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Description
Remove upload trivy results as they get uploaded somewhere else now.
https://linear.app/all-hands-ai/issue/PLTF-2035/remove-upload-of-trivy-results-to-github

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
