### PR TITLE
chore(litellm): bump image to v1.83.10-stable

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -136,7 +136,7 @@ spec:
         enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/berriai/litellm-database'
-        tag: "v1.82.3-stable.patch.3"
+        tag: "v1.83.10-stable"
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       environmentSecrets:


### PR DESCRIPTION
## Description

Upgrade the bundled LiteLLM proxy image from `v1.82.3-stable.patch.3` to the upstream `v1.83.10-stable` tag

## Helm Chart Checklist

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

(N/A — only the image tag pin in `replicated/openhands.yaml` changes; no chart sources modified.)

## Additional Notes

Promoted to channel `jl/litellm-1.83.10` as release sequence 663 via `make release`.