### PR TITLE
PLTF-2036: add script to create Slack app for Replicated OHE

### DIFF
--- a/scripts/create_slack_app/README.md
+++ b/scripts/create_slack_app/README.md
@@ -17,15 +17,17 @@ Create a Slack app configured for the Replicated self-hosted install of OpenHand
 
 ## Usage
 
+Run from the repository root:
+
 ```bash
-./create_slack_app.py --base-domain <your-domain> --slack-token <xoxe.xoxp-...>
+./scripts/create_slack_app/create_slack_app.py --base-domain <your-domain> --slack-token <xoxe.xoxp-...>
 ```
 
 The token can also be provided via the `SLACK_CONFIG_TOKEN` environment variable:
 
 ```bash
 export SLACK_CONFIG_TOKEN=xoxe.xoxp-...
-./create_slack_app.py --base-domain <your-domain>
+./scripts/create_slack_app/create_slack_app.py --base-domain <your-domain>
 ```
 
 ### Options
@@ -40,7 +42,7 @@ export SLACK_CONFIG_TOKEN=xoxe.xoxp-...
 ### Example
 
 ```bash
-./create_slack_app.py --base-domain mycompany.com --slack-token xoxe.xoxp-...
+./scripts/create_slack_app/create_slack_app.py --base-domain mycompany.com --slack-token xoxe.xoxp-...
 ```
 
 ### Output

--- a/scripts/create_slack_app/README.md
+++ b/scripts/create_slack_app/README.md
@@ -1,0 +1,78 @@
+# Description
+
+Create a Slack app configured for the Replicated self-hosted install of OpenHands Enterprise (OHE).
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) installed
+- A Slack workspace where you have permission to create apps
+- A Slack App Configuration Token (see [Getting a Token](#getting-a-token))
+
+## Getting a Token
+
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
+2. In the **Your App Configuration Tokens** section, click **Generate Token**
+3. Select your workspace and click **Generate**
+4. Copy the **access token** (starts with `xoxe.xoxp-`)
+
+## Usage
+
+```bash
+./create_slack_app.py --base-domain <your-domain> --slack-token <xoxe.xoxp-...>
+```
+
+The token can also be provided via the `SLACK_CONFIG_TOKEN` environment variable:
+
+```bash
+export SLACK_CONFIG_TOKEN=xoxe.xoxp-...
+./create_slack_app.py --base-domain <your-domain>
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--base-domain` | **(Required)** Base domain for your OHE installation (e.g., `mycompany.com`) |
+| `--slack-token` | Slack App Configuration Token (`xoxe.xoxp-...`). Falls back to `SLACK_CONFIG_TOKEN` env var |
+| `--app-name` | Display name for the Slack app (default: `OpenHands`) |
+| `--dry-run` | Show what would be created without calling the Slack API |
+
+### Example
+
+```bash
+./create_slack_app.py --base-domain mycompany.com --slack-token xoxe.xoxp-...
+```
+
+### Output
+
+After successful creation, you'll receive:
+
+- **Slack Client ID** - Used to configure the Slack integration in OHE
+- **Slack Client Secret** - Keep this secret!
+- **Slack Signing Secret** - Used to verify incoming Slack requests
+
+## Permissions
+
+### Bot Token Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `app_mentions:read` | View messages that directly mention the bot |
+| `chat:write` | Send messages as the bot |
+| `users:read` | View people in the workspace |
+| `channels:history` | View messages in public channels |
+| `groups:history` | View messages in private channels |
+| `mpim:history` | View messages in group direct messages |
+| `im:history` | View messages in direct messages |
+
+## Configuration
+
+The app is configured with:
+
+- **Redirect URL**: `https://app.<base-domain>/slack/install-callback`
+- **Event Subscription URL**: `https://app.<base-domain>/slack/on-event`
+- **Interactivity Request URL**: `https://app.<base-domain>/slack/on-form-interaction`
+- **Options Load URL**: `https://app.<base-domain>/slack/on-options-load`
+- **Bot Events**: `app_mention`
+- **Socket Mode**: Disabled
+- **Org Deploy**: Disabled

--- a/scripts/create_slack_app/create_slack_app.py
+++ b/scripts/create_slack_app/create_slack_app.py
@@ -7,17 +7,11 @@
 
 import argparse
 import os
-import secrets
 from typing import Any
 
 import requests
 
-APP_NAME_PREFIX = "openhands"
 SLACK_MANIFEST_API = "https://slack.com/api/apps.manifest.create"
-
-
-def generate_unique_app_name() -> str:
-    return f"{APP_NAME_PREFIX}-{secrets.token_hex(4)}"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/create_slack_app/create_slack_app.py
+++ b/scripts/create_slack_app/create_slack_app.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests"]
+# ///
+"""CLI to create a Slack app for an OpenHands Enterprise (OHE) instance."""
+
+import argparse
+import os
+import secrets
+from typing import Any
+
+import requests
+
+APP_NAME_PREFIX = "openhands"
+SLACK_MANIFEST_API = "https://slack.com/api/apps.manifest.create"
+
+
+def generate_unique_app_name() -> str:
+    return f"{APP_NAME_PREFIX}-{secrets.token_hex(4)}"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a Slack app for an OpenHands Enterprise (OHE) instance."
+    )
+    parser.add_argument(
+        "--base-domain",
+        required=True,
+        help="Base domain for the OpenHands instance (e.g., mycompany.com). "
+        "The app URLs will be constructed as https://app.<base-domain>/slack/...",
+    )
+    parser.add_argument(
+        "--slack-token",
+        default=os.environ.get("SLACK_CONFIG_TOKEN"),
+        help="Slack app configuration token (xoxe-...). "
+        "Falls back to SLACK_CONFIG_TOKEN env var. "
+        "Obtain one from api.slack.com/apps → your workspace → App-Level Tokens "
+        "with apps:write and apps:read scopes.",
+    )
+    parser.add_argument(
+        "--app-name",
+        default=None,
+        help="Display name for the Slack app (default: OpenHands).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be created without calling the Slack API.",
+    )
+    return parser.parse_args(argv)
+
+
+def build_app_manifest(
+    base_domain: str,
+    app_name: str | None = None,
+) -> dict[str, Any]:
+    display_name = app_name if app_name is not None else "OpenHands"
+    app_base_url = f"https://app.{base_domain}"
+    return {
+        "display_information": {
+            "name": display_name,
+        },
+        "features": {
+            "bot_user": {
+                "display_name": display_name,
+                "always_online": False,
+            },
+        },
+        "oauth_config": {
+            "redirect_urls": [
+                f"{app_base_url}/slack/install-callback",
+            ],
+            "scopes": {
+                "bot": [
+                    "app_mentions:read",
+                    "chat:write",
+                    "users:read",
+                    "channels:history",
+                    "groups:history",
+                    "mpim:history",
+                    "im:history",
+                ],
+            },
+        },
+        "settings": {
+            "event_subscriptions": {
+                "request_url": f"{app_base_url}/slack/on-event",
+                "bot_events": ["app_mention"],
+            },
+            "interactivity": {
+                "is_enabled": True,
+                "request_url": f"{app_base_url}/slack/on-form-interaction",
+                "message_menu_options_url": f"{app_base_url}/slack/on-options-load",
+            },
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": False,
+            "token_rotation_enabled": False,
+        },
+    }
+
+
+def create_slack_app(manifest: dict[str, Any], token: str) -> dict:
+    response = requests.post(
+        SLACK_MANIFEST_API,
+        headers={"Authorization": f"Bearer {token}"},
+        json={"manifest": manifest},
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not data.get("ok"):
+        detail = data.get("errors") or data.get("error", "unknown error")
+        raise RuntimeError(f"Slack API error: {detail}\nFull response: {data}")
+    return data
+
+
+def main(
+    base_domain: str,
+    slack_token: str,
+    dry_run: bool = False,
+    app_name: str | None = None,
+) -> None:
+    if dry_run:
+        print(f"Would create Slack app for domain '{base_domain}'")
+        return
+
+    manifest = build_app_manifest(base_domain, app_name)
+    result = create_slack_app(manifest, token=slack_token)
+    credentials = result.get("credentials", {})
+
+    print(f"Slack Client ID: {credentials.get('client_id')}")
+    print(f"Slack Client Secret: {credentials.get('client_secret')}")
+    print(f"Slack Signing Secret: {credentials.get('signing_secret')}")
+
+
+def missing_token_message() -> str:
+    return (
+        "Error: Slack configuration token required. "
+        "Pass --slack-token or set SLACK_CONFIG_TOKEN env var.\n\n"
+        "To get a token:\n"
+        "  1. Go to https://api.slack.com/apps\n"
+        "  2. Click Generate Token in the Your App Configuration Tokens section\n"
+        "  3. Use the access token (starts with xoxe.xoxp-)"
+    )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if not args.slack_token:
+        raise SystemExit(missing_token_message())
+    main(
+        base_domain=args.base_domain,
+        slack_token=args.slack_token,
+        dry_run=args.dry_run,
+        app_name=args.app_name,
+    )

--- a/scripts/create_slack_app/setup.cfg
+++ b/scripts/create_slack_app/setup.cfg
@@ -1,0 +1,3 @@
+[mutmut]
+paths_to_mutate=create_slack_app.py
+runner=python -m pytest test_create_slack_app.py -x -q

--- a/scripts/create_slack_app/test_create_slack_app.py
+++ b/scripts/create_slack_app/test_create_slack_app.py
@@ -1,0 +1,465 @@
+"""Tests for create_slack_app.py — written before implementation (TDD RED phase)."""
+
+import os
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def make_mock_response(response_data: dict, ok: bool = True) -> MagicMock:
+    mock = MagicMock()
+    mock.json.return_value = response_data
+    if ok:
+        mock.raise_for_status.return_value = None
+    else:
+        mock.raise_for_status.side_effect = Exception("HTTP error")
+    return mock
+
+
+def make_successful_create_response(
+    app_id: str = "A0B12DUAWTX",
+    client_id: str = "1234567890.9876543210",
+    client_secret: str = "client_secret_value",
+    signing_secret: str = "signing_secret_value",
+    verification_token: str = "verification_token_value",
+) -> dict:
+    return {
+        "ok": True,
+        "app_id": app_id,
+        "credentials": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "verification_token": verification_token,
+            "signing_secret": signing_secret,
+        },
+        "oauth_authorize_url": "https://slack.com/oauth/v2/authorize?client_id=1234",
+    }
+
+
+@contextmanager
+def mock_main_dependencies(response_data: dict | None = None):
+    if response_data is None:
+        response_data = make_successful_create_response()
+    mocks = {}
+    with patch("create_slack_app.requests.post") as mock_post:
+        mock_post.return_value = make_mock_response(response_data)
+        mocks["requests_post"] = mock_post
+        yield mocks
+
+
+# ---------------------------------------------------------------------------
+# TestBuildAppManifest
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAppManifest:
+    def test_redirect_url_uses_base_domain(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        redirect_urls = manifest["oauth_config"]["redirect_urls"]
+        assert "https://app.example.com/slack/install-callback" in redirect_urls
+
+    def test_event_subscription_request_url_uses_base_domain(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert (
+            manifest["settings"]["event_subscriptions"]["request_url"]
+            == "https://app.example.com/slack/on-event"
+        )
+
+    def test_interactivity_request_url_uses_base_domain(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert (
+            manifest["settings"]["interactivity"]["request_url"]
+            == "https://app.example.com/slack/on-form-interaction"
+        )
+
+    def test_options_load_url_uses_base_domain(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert (
+            manifest["settings"]["interactivity"]["message_menu_options_url"]
+            == "https://app.example.com/slack/on-options-load"
+        )
+
+    def test_bot_event_is_app_mention(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert "app_mention" in manifest["settings"]["event_subscriptions"]["bot_events"]
+
+    def test_bot_scopes_include_all_required(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+        for scope in [
+            "app_mentions:read",
+            "chat:write",
+            "users:read",
+            "channels:history",
+            "groups:history",
+            "mpim:history",
+            "im:history",
+        ]:
+            assert scope in bot_scopes, f"Missing bot scope: {scope}"
+
+    def test_no_user_scopes_configured(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert "user" not in manifest["oauth_config"]["scopes"]
+
+    def test_display_name_defaults_to_openhands(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["features"]["bot_user"]["display_name"] == "OpenHands"
+        assert manifest["display_information"]["name"] == "OpenHands"
+
+    def test_bot_user_does_not_include_username_field(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert "username" not in manifest["features"]["bot_user"]
+
+    def test_custom_app_name_sets_display_name(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com", app_name="my-bot")
+        assert manifest["features"]["bot_user"]["display_name"] == "my-bot"
+        assert manifest["display_information"]["name"] == "my-bot"
+
+    def test_interactivity_is_enabled(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["settings"]["interactivity"]["is_enabled"] is True
+
+    def test_socket_mode_is_disabled(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["settings"]["socket_mode_enabled"] is False
+
+    def test_urls_use_https(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["oauth_config"]["redirect_urls"][0].startswith("https://")
+        assert manifest["settings"]["event_subscriptions"]["request_url"].startswith("https://")
+        assert manifest["settings"]["interactivity"]["request_url"].startswith("https://")
+
+    def test_always_online_is_false(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["features"]["bot_user"]["always_online"] is False
+
+    def test_org_deploy_enabled_is_false(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["settings"]["org_deploy_enabled"] is False
+
+    def test_token_rotation_enabled_is_false(self):
+        from create_slack_app import build_app_manifest
+
+        manifest = build_app_manifest("example.com")
+        assert manifest["settings"]["token_rotation_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestCreateSlackApp
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSlackApp:
+    def test_calls_correct_api_endpoint(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response(make_successful_create_response())
+            create_slack_app(manifest, token="xoxe-test-token")
+        assert mock_post.call_args[0][0] == "https://slack.com/api/apps.manifest.create"
+
+    def test_includes_token_in_authorization_header(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response(make_successful_create_response())
+            create_slack_app(manifest, token="xoxe-my-token")
+        headers = mock_post.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer xoxe-my-token"
+
+    def test_sends_manifest_in_request_body(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response(make_successful_create_response())
+            create_slack_app(manifest, token="xoxe-test-token")
+        assert mock_post.call_args[1]["json"]["manifest"] == manifest
+
+    def test_returns_full_response_data(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        expected = make_successful_create_response()
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response(expected)
+            result = create_slack_app(manifest, token="xoxe-test-token")
+        assert result == expected
+
+    def test_raises_on_slack_api_error(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response({"ok": False, "error": "invalid_manifest"})
+            with pytest.raises(RuntimeError, match="invalid_manifest"):
+                create_slack_app(manifest, token="xoxe-test-token")
+
+    def test_raises_on_http_error(self):
+        from create_slack_app import build_app_manifest, create_slack_app
+
+        manifest = build_app_manifest("example.com")
+        with patch("create_slack_app.requests.post") as mock_post:
+            mock_post.return_value = make_mock_response({}, ok=False)
+            with pytest.raises(Exception):
+                create_slack_app(manifest, token="xoxe-test-token")
+
+
+# ---------------------------------------------------------------------------
+# TestParseArgs
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_base_domain_is_required(self):
+        from create_slack_app import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(argv=[])
+
+    def test_base_domain_is_parsed(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(argv=["--base-domain", "example.com", "--slack-token", "tok"])
+        assert args.base_domain == "example.com"
+
+    def test_slack_token_is_parsed(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(argv=["--base-domain", "example.com", "--slack-token", "xoxe-abc"])
+        assert args.slack_token == "xoxe-abc"
+
+    def test_app_name_defaults_to_none(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(argv=["--base-domain", "example.com", "--slack-token", "tok"])
+        assert args.app_name is None
+
+    def test_app_name_is_parsed(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(
+            argv=["--base-domain", "example.com", "--slack-token", "tok", "--app-name", "my-app"]
+        )
+        assert args.app_name == "my-app"
+
+    def test_dry_run_defaults_to_false(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(argv=["--base-domain", "example.com", "--slack-token", "tok"])
+        assert args.dry_run is False
+
+    def test_dry_run_flag_sets_true(self):
+        from create_slack_app import parse_args
+
+        args = parse_args(
+            argv=["--base-domain", "example.com", "--slack-token", "tok", "--dry-run"]
+        )
+        assert args.dry_run is True
+
+    def test_slack_token_read_from_env_when_not_passed(self):
+        from create_slack_app import parse_args
+
+        with patch.dict(os.environ, {"SLACK_CONFIG_TOKEN": "xoxe-from-env"}):
+            args = parse_args(argv=["--base-domain", "example.com"])
+        assert args.slack_token == "xoxe-from-env"
+
+    def test_cli_token_takes_precedence_over_env(self):
+        from create_slack_app import parse_args
+
+        with patch.dict(os.environ, {"SLACK_CONFIG_TOKEN": "xoxe-from-env"}):
+            args = parse_args(argv=["--base-domain", "example.com", "--slack-token", "xoxe-cli"])
+        assert args.slack_token == "xoxe-cli"
+
+
+# ---------------------------------------------------------------------------
+# TestDryRun
+# ---------------------------------------------------------------------------
+
+
+class TestMissingTokenMessage:
+    def test_includes_api_slack_com_apps_url(self):
+        from create_slack_app import missing_token_message
+
+        assert "https://api.slack.com/apps" in missing_token_message()
+
+    def test_instructs_to_click_generate_token(self):
+        from create_slack_app import missing_token_message
+
+        assert "Generate Token" in missing_token_message()
+
+    def test_references_app_configuration_tokens_section(self):
+        from create_slack_app import missing_token_message
+
+        assert "Your App Configuration Tokens" in missing_token_message()
+
+    def test_instructs_to_use_access_token(self):
+        from create_slack_app import missing_token_message
+
+        assert "access token" in missing_token_message()
+
+
+class TestDryRun:
+    def test_dry_run_prints_domain(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies():
+            main(base_domain="example.com", slack_token="tok", dry_run=True)
+        assert "example.com" in capsys.readouterr().out
+
+    def test_dry_run_does_not_call_slack_api(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="example.com", slack_token="tok", dry_run=True)
+        mocks["requests_post"].assert_not_called()
+
+    def test_dry_run_shows_domain(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies():
+            main(base_domain="example.com", slack_token="tok", dry_run=True)
+        assert "example.com" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# TestMain — output order and content
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_outputs_client_id(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies(make_successful_create_response(client_id="cid-123")):
+            main(base_domain="example.com", slack_token="tok")
+        assert "cid-123" in capsys.readouterr().out
+
+    def test_outputs_client_secret(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies(make_successful_create_response(client_secret="csec-456")):
+            main(base_domain="example.com", slack_token="tok")
+        assert "csec-456" in capsys.readouterr().out
+
+    def test_outputs_signing_secret(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies(make_successful_create_response(signing_secret="ssec-789")):
+            main(base_domain="example.com", slack_token="tok")
+        assert "ssec-789" in capsys.readouterr().out
+
+    def test_output_order_is_client_id_then_client_secret_then_signing_secret(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies(
+            make_successful_create_response(
+                client_id="CID", client_secret="CSEC", signing_secret="SSEC"
+            )
+        ):
+            main(base_domain="example.com", slack_token="tok")
+        out = capsys.readouterr().out
+        cid_pos = out.index("CID")
+        csec_pos = out.index("CSEC")
+        ssec_pos = out.index("SSEC")
+        assert cid_pos < csec_pos < ssec_pos
+
+    def test_output_labels_client_id(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies():
+            main(base_domain="example.com", slack_token="tok")
+        assert "Slack Client ID" in capsys.readouterr().out
+
+    def test_output_labels_client_secret(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies():
+            main(base_domain="example.com", slack_token="tok")
+        assert "Slack Client Secret" in capsys.readouterr().out
+
+    def test_output_labels_signing_secret(self, capsys):
+        from create_slack_app import main
+
+        with mock_main_dependencies():
+            main(base_domain="example.com", slack_token="tok")
+        assert "Slack Signing Secret" in capsys.readouterr().out
+
+    def test_passes_token_to_api(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="example.com", slack_token="xoxe-my-token")
+        headers = mocks["requests_post"].call_args[1]["headers"]
+        assert "xoxe-my-token" in headers["Authorization"]
+
+    def test_passes_base_domain_to_manifest(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="mycompany.com", slack_token="tok")
+        redirect_urls = mocks["requests_post"].call_args[1]["json"]["manifest"]["oauth_config"][
+            "redirect_urls"
+        ]
+        assert any("mycompany.com" in url for url in redirect_urls)
+
+    def test_uses_custom_app_name(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="example.com", slack_token="tok", app_name="custom-bot")
+        manifest = mocks["requests_post"].call_args[1]["json"]["manifest"]
+        assert manifest["display_information"]["name"] == "custom-bot"
+
+    def test_display_name_is_OpenHands_when_no_app_name_provided(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="example.com", slack_token="tok")
+        manifest = mocks["requests_post"].call_args[1]["json"]["manifest"]
+        assert manifest["display_information"]["name"] == "OpenHands"
+
+    def test_bot_display_name_is_OpenHands_when_no_app_name_provided(self):
+        from create_slack_app import main
+
+        with mock_main_dependencies() as mocks:
+            main(base_domain="example.com", slack_token="tok")
+        manifest = mocks["requests_post"].call_args[1]["json"]["manifest"]
+        assert manifest["features"]["bot_user"]["display_name"] == "OpenHands"


### PR DESCRIPTION
## Summary

- Adds `scripts/create_slack_app/create_slack_app.py` — a CLI script that creates a Slack app via the Slack manifest API, configured for a Replicated self-hosted OHE instance
- Pass `--base-domain` to set all webhook/redirect URLs; outputs Slack Client ID, Client Secret, and Signing Secret
- Includes README with usage, required bot token scopes, and all configured URLs

When Slack token is not provided:
```
% ./scripts/create_slack_app/create_slack_app.py --base-domain <BASE_DOMAIN>
Error: Slack configuration token required. Pass --slack-token or set SLACK_CONFIG_TOKEN env var.

To get a token:
  1. Go to https://api.slack.com/apps
  2. Click Generate Token in the Your App Configuration Tokens section
  3. Use the access token (starts with xoxe.xoxp-)
```

When Slack token is provided and valid, you will get the 3 secret values needed for the Replicated self hosted install Slack configuration to enable the Slack resolver:
```
% ./scripts/create_slack_app/create_slack_app.py --base-domain <BASE_DOMAIN> --slack-token <SLACK_TOKEN>
Slack Client ID: <SLACK_CLIENT_ID>
Slack Client Secret: <SLACK_CLIENT_SECRET>
Slack Signing Secret: <SLACK_SIGNING_SECRET>
```

## Bot Token Scopes

`app_mentions:read`, `chat:write`, `users:read`, `channels:history`, `groups:history`, `mpim:history`, `im:history`

## Test plan

- [x] Run `./scripts/create_slack_app/create_slack_app.py --base-domain <your-domain> --slack-token <xoxe.xoxp-...>` and confirm a Slack app is created with the correct settings
- [x] Verify the three credentials are printed in order: Slack Client ID, Slack Client Secret, Slack Signing Secret
- [x] 50/50 tests passing (`uv run --with pytest --with requests --python 3.12 python -m pytest scripts/create_slack_app/test_create_slack_app.py`)
- [x] Verify in a Replicated install with the Slack configuration set up with Slack secrets of the script generated Slack app that a successful resolver invocation was processed i.e. `@OpenHands flip a coin`