### PR TITLE
fix: make GITHUB_APP_SLUG optional in github-app secret

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.23.1
-version: 0.7.3
+version: 0.7.4
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -165,6 +165,7 @@
     secretKeyRef:
       name: github-app
       key: app-slug
+      optional: true
 {{- end }}
 {{- if .Values.gitlab.enabled }}
 - name: GITLAB_APP_CLIENT_ID


### PR DESCRIPTION
Adds `optional: true` to the `GITHUB_APP_SLUG` secretKeyRef so pods don't fail to start when `app-slug` is not present in the `github-app` Secret.

This is a one-line change, consistent with how `LMNR_PROJECT_API_KEY` and `LMNR_BASE_URL` are handled in the same template.