### PR TITLE
Validate plugin marketplace source URL scheme

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -675,10 +675,14 @@ spec:
           default: "0"
         - name: plugin_directory_marketplace_source
           title: Marketplace Source
-          help_text: "URI of the plugin catalog to load. Supports github://owner/repo[@ref], https:// URLs to a catalog JSON file, or file:// paths."
+          help_text: "URI of the plugin catalog to load. Supports github://owner/repo[@ref], or http(s):// URLs to a catalog JSON file."
           type: text
           when: 'repl{{ ConfigOptionEquals "plugin_directory_enabled" "1" }}'
           required: true
+          validation:
+            regex:
+              pattern: ^(github|https?)://
+              message: Must start with github://, https://, or http://
 
     - name: advanced_options
       title: Advanced Options


### PR DESCRIPTION
## Description

The `plugin_directory_marketplace_source` field on the Replicated config is free-form text. This adds a regex on the field so the Replicated console rejects invalid input at configuration time.

The accepted schemes (`github://`, `https://`, `http://`) match what the catalog loader supports. `file://` is removed because it's only supported for local dev for now. 

## Helm Chart Checklist

<!-- N/A: no Helm charts modified -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values