### PR TITLE
PLTF-2295: Upgrade litellm for opus 4.7

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -175,6 +175,10 @@ spec:
           OR_APP_NAME: "OpenHands"
           OR_SITE_URL: "https://docs.all-hands.dev"
         model_list:
+          # Temporary LiteLLM 1.83.14 workaround: expose this model through the
+          # proxy for openhands/claude-opus-4-7 because direct Anthropic calls
+          # break thinking translation in this release. Remove after LiteLLM
+          # ships https://github.com/BerriAI/litellm/pull/27074.
           - model_name: "claude-opus-4-7"
             litellm_params:
               model: "anthropic/claude-opus-4-7"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -175,9 +175,9 @@ spec:
           OR_APP_NAME: "OpenHands"
           OR_SITE_URL: "https://docs.all-hands.dev"
         model_list:
-          # Temporary LiteLLM 1.83.14 workaround: expose this model through the
+          # LiteLLM 1.83.14 workaround: expose this model through the
           # proxy for openhands/claude-opus-4-7 because direct Anthropic calls
-          # break thinking translation in this release. Remove after LiteLLM
+          # break thinking translation in this release. Can consider removing after LiteLLM
           # ships https://github.com/BerriAI/litellm/pull/27074.
           - model_name: "claude-opus-4-7"
             litellm_params:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,6 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
+      tag: 'sha-d316113'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -136,7 +136,7 @@ spec:
         enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/berriai/litellm-database'
-        tag: "v1.82.3-stable.patch.3"
+        tag: "v1.83.14-stable"
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       environmentSecrets:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-d316113'
+      tag: 'sha-60f5c1c'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -134,6 +134,10 @@ spec:
       # Migrations run automatically when litellm starts. This disables running them separately as a job.
       migrationJob:
         enabled: false
+      args:
+        - --config
+        - /etc/litellm/config.yaml
+        - --use_v2_migration_resolver
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/berriai/litellm-database'
         tag: "v1.83.14-stable"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -175,6 +175,10 @@ spec:
           OR_APP_NAME: "OpenHands"
           OR_SITE_URL: "https://docs.all-hands.dev"
         model_list:
+          - model_name: "claude-opus-4-7"
+            litellm_params:
+              model: "anthropic/claude-opus-4-7"
+              api_key: os.environ/ANTHROPIC_API_KEY
           - model_name: "claude-sonnet-4-5-20250929"
             litellm_params:
               model: "anthropic/claude-sonnet-4-5-20250929"


### PR DESCRIPTION
## Description

Upgrades LiteLLM from `v1.82.3-stable.patch.3` to `v1.83.14-stable` to match the version we use in SaaS (cloud). Adds support for Claude Opus 4.7 by adding the model to the LiteLLM proxy model list as a workaround given the LiteLLM bug when using the Anthropic provider directly. Also includes a temporary enterprise-server image override (`sha-d316113`) that fixes org settings 500 errors on upgrade installs (OpenHands/OpenHands#14326).

### Changes

- **LiteLLM image**: `v1.82.3-stable.patch.3` → `v1.83.14-stable`
- **Proxy model list**: adds `claude-opus-4-7` → `anthropic/claude-opus-4-7`
- **v2 migration resolver**: enables `--use_v2_migration_resolver` on LiteLLM startup to prevent schema thrashing during upgrades
- **Enterprise-server image override**: pins to `sha-d316113` to include the org settings PATCH write-path fix (OpenHands/OpenHands#14326); to be replaced with a release tag once that PR merges

### Why the proxy model entry is required

LiteLLM 1.83.14 has a bug where `thinking: {type: enabled}` is not correctly translated to the adaptive thinking format when calling Anthropic directly with claude-opus-4-7, causing a `BadRequestError` from the Anthropic API. The workaround is to route requests through the LiteLLM proxy using the `openhands` provider (`litellm_proxy/claude-opus-4-7`), which uses the `reasoning_effort` parameter path that works correctly in this version.

Without the proxy model entry, the proxy rejects requests with "Invalid model name passed in model=claude-opus-4-7". The upstream fix is tracked in [LiteLLM PR #27074](https://github.com/BerriAI/litellm/pull/27074).

### Why the v2 migration resolver is required

Without `--use_v2_migration_resolver`, LiteLLM's `_resolve_all_migrations` logic can thrash the database schema during rolling deployments when two versions contend for the same database. This flag limits migration behavior to `prisma migrate deploy` only, preventing the diff-and-force recovery path that caused a production incident (PLTF-2292) on April 29, 2026. Customers upgrading from v1.82.3 to v1.83.14 are exposed to this without the flag.

### Why `--config /etc/litellm/config.yaml` is explicitly added

This is not a new LiteLLM 1.83.14 requirement. The upstream `litellm-helm` chart already starts LiteLLM with `--config /etc/litellm/config.yaml` by default so it loads the mounted proxy config (including `proxy_config.model_list`).

In this PR we also need to add `--use_v2_migration_resolver`. Because the chart's `args` value replaces the entire default argument list rather than appending to it, we must restate `--config /etc/litellm/config.yaml` alongside the new flag. Without it, LiteLLM would start without loading the mounted config file and would ignore the configured proxy models.

### Why the enterprise-server image override is required

Customers upgrading from an older version have `agent_kind='llm'` stored in their org's `agent_settings` DB column (written by the old enterprise server before `LLMAgentSettings` was renamed to `OpenHandsAgentSettings`). The `PATCH /api/organizations/{id}/settings` write path validates the merged settings against `OpenHandsAgentSettings` without normalizing the legacy value, causing a 500 error that prevents saving org settings — including switching to `litellm_proxy/claude-opus-4-7`. The fix is in OpenHands/OpenHands#14326. The `sha-d316113` override will be replaced with the official release tag once that PR merges.

### Usage

In OpenHands org defaults, configure:
- **Model**: `openhands/claude-opus-4-7`
- **Base URL**: `http://openhands-litellm:4000`

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

Changes are only in the Replicated configs not the main charts so no version bump is needed.

## Additional Notes

The LiteLLM thinking translation bug affects the `anthropic` provider path only. The `openhands` provider path (via the LiteLLM proxy) is unaffected and works correctly with this configuration.

Verified in a Replicated install that this configuration upgrades LiteLLM to 1.83.14. Also allows us to use the Claude Opus 4.7 model via the OpenHands provider to use the proxied model:
<img width="1254" height="610" alt="Screenshot 2026-05-06 at 6 49 18 PM" src="https://github.com/user-attachments/assets/7b2de695-ae67-47ab-b258-89ca3050278c" />
<img width="971" height="810" alt="Screenshot 2026-05-06 at 6 49 34 PM" src="https://github.com/user-attachments/assets/94331a9e-1bb7-4bc7-9adb-61e1b6f73478" />

Looking at the exported conversation metadata confirms the model used in the test conversation is the proxied model:
<img width="361" height="24" alt="Screenshot 2026-05-06 at 6 50 57 PM" src="https://github.com/user-attachments/assets/077806ad-a605-4435-9e3e-d57f44907d43" />

Tested the upgrade path from 0.7.3 → 0.7.8 on a Replicated embedded cluster VM. LiteLLM startup logs confirmed the v2 migration resolver was active (`Using v2 migration resolver (--use_v2_migration_resolver)`), 11 pending migrations were applied cleanly via `prisma migrate deploy`, and no schema thrashing occurred. The diff-and-force recovery path was not triggered.

Verified the org settings PATCH fix (OpenHands/OpenHands#14326) on both install paths using enterprise-server `sha-d316113`:

- **Fresh install** (0.7.8): org created with `agent_kind='openhands'`, org settings saved successfully with `litellm_proxy/claude-opus-4-7`, conversation completed and confirmed via `conversation_metadata.llm_model = litellm_proxy/claude-opus-4-7` in the DB ✅
- **Upgrade install** (0.7.3 → 0.7.8): org had legacy `agent_kind='llm'` in DB before upgrade, org settings saved successfully after upgrade with `agent_kind` normalized to `'openhands'` and model updated to `litellm_proxy/claude-opus-4-7` in the DB ✅