### PR TITLE
PLTF-2294: Enable automations UI in replicated install

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "1.0"

--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/automation-db-secret.yaml
+++ b/charts/openhands-secrets/templates/automation-db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: automation-db-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  db-password: {{ .Values.config.postgres_password | b64enc | quote }}

--- a/charts/openhands-secrets/templates/automation-db-secret.yaml
+++ b/charts/openhands-secrets/templates/automation-db-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.automation.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 type: Opaque
 data:
   db-password: {{ .Values.config.postgres_password | b64enc | quote }}
+{{- end }}

--- a/charts/openhands-secrets/templates/automation-service-key.yaml
+++ b/charts/openhands-secrets/templates/automation-service-key.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: automation-service-key
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  automation-service-key: {{ .Values.config.automation_service_key | b64enc | quote }}

--- a/charts/openhands-secrets/templates/automation-service-key.yaml
+++ b/charts/openhands-secrets/templates/automation-service-key.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.automation.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 type: Opaque
 data:
   automation-service-key: {{ .Values.config.automation_service_key | b64enc | quote }}
+{{- end }}

--- a/charts/openhands-secrets/templates/automation-webhook-secret.yaml
+++ b/charts/openhands-secrets/templates/automation-webhook-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: automation-webhook-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  webhook-secret: {{ .Values.config.automation_webhook_secret | b64enc | quote }}

--- a/charts/openhands-secrets/templates/automation-webhook-secret.yaml
+++ b/charts/openhands-secrets/templates/automation-webhook-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.automation.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 type: Opaque
 data:
   webhook-secret: {{ .Values.config.automation_webhook_secret | b64enc | quote }}
+{{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -67,6 +67,10 @@ config:
   plugin_directory_identity_shared_secret: ""
   plugin_directory_session_secret: ""
 
+  # Automation secrets
+  automation_service_key: ""
+  automation_webhook_secret: ""
+
   # TLS certificates
   tls_certificate: ""
   tls_private_key: ""

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -2,6 +2,9 @@
 # This chart creates all the required secrets for OpenHands
 
 # Configuration values will be passed from the parent chart
+automation:
+  enabled: false
+
 config:
   # Security secrets
   admin_password: ""

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -25,6 +25,9 @@ spec:
     - openhands/deployment/openhands-mcp
     - openhands/service/openhands-mcp-service
     - openhands/ingress/openhands-mcp-ingress
+    - openhands/deployment/automation
+    - openhands/service/automation
+    - openhands/ingress/openhands-automation-ingress
 
     # keycloak
     - openhands/statefulset/keycloak

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -25,9 +25,9 @@ spec:
     - openhands/deployment/openhands-mcp
     - openhands/service/openhands-mcp-service
     - openhands/ingress/openhands-mcp-ingress
-    - openhands/deployment/automation
-    - openhands/service/automation
-    - openhands/ingress/openhands-automation-ingress
+    - '{{repl if ConfigOptionEquals "automations_enabled" "1" }}openhands/deployment/automation{{repl end}}'
+    - '{{repl if ConfigOptionEquals "automations_enabled" "1" }}openhands/service/automation{{repl end}}'
+    - '{{repl if ConfigOptionEquals "automations_enabled" "1" }}openhands/ingress/openhands-automation-ingress{{repl end}}'
 
     # keycloak
     - openhands/statefulset/keycloak

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -726,6 +726,11 @@ spec:
       title: Advanced Options
       description: Optional components and advanced configuration settings
       items:
+        - name: automations_enabled
+          title: Enable Automations
+          help_text: Deploy the Automations UI and backend. If you use an external PostgreSQL instance, make sure the automations database requirements are satisfied before enabling this option.
+          type: bool
+          default: "0"
         - name: analytics_enabled
           title: Enable Analytics
           help_text: Enable analytics for LLM observability and tracing

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -352,6 +352,18 @@ spec:
           type: password
           hidden: true
           value: '{{repl RandomString 32}}'
+        - name: automation_service_key
+          title: Automation Service Key
+          help_text: Secret key for the automation service
+          type: password
+          hidden: true
+          value: '{{repl RandomString 32}}'
+        - name: automation_webhook_secret
+          title: Automation Webhook Secret
+          help_text: Secret for validating automation webhooks
+          type: password
+          hidden: true
+          value: '{{repl RandomString 32}}'
 
     - name: bitbucket_data_center_authentication
       title: Bitbucket Data Center Authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -29,6 +29,16 @@ spec:
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       OH_AGENT_SERVER_ENV: '{"SSL_CERT_FILE": "/etc/openhands/ca-bundle/ca-bundle.crt", "REQUESTS_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "GIT_SSL_CAINFO": "/etc/openhands/ca-bundle/ca-bundle.crt", "CURL_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "NODE_EXTRA_CA_CERTS": "/etc/openhands/ca-bundle/ca-bundle.crt"}'
 
+    automationServiceKey:
+      enabled: true
+      existingSecret: automation-service-key
+      secretKey: automation-service-key
+
+    automationWebhookSecret:
+      enabled: true
+      existingSecret: automation-webhook-secret
+      secretKey: webhook-secret
+
     ingress:
       enabled: true
       host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
@@ -300,6 +310,23 @@ spec:
       host: 'repl{{ ConfigOption "gitlab_host" }}'
     slack:
       enabled: repl{{ ConfigOptionEquals "slack_enabled" "1" }}
+
+    automation:
+      enabled: true
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/automation'
+        tag: sha-e52cca3
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
+      openhandsApiUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+      automationBaseUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+      filestore:
+        type: local
+      env:
+        LOCAL_STORAGE_PATH: /tmp/automation
+      database:
+        createDatabaseUser: true
+        host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'
 
     replicated:
       enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -29,16 +29,6 @@ spec:
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       OH_AGENT_SERVER_ENV: '{"SSL_CERT_FILE": "/etc/openhands/ca-bundle/ca-bundle.crt", "REQUESTS_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "GIT_SSL_CAINFO": "/etc/openhands/ca-bundle/ca-bundle.crt", "CURL_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "NODE_EXTRA_CA_CERTS": "/etc/openhands/ca-bundle/ca-bundle.crt"}'
 
-    automationServiceKey:
-      enabled: true
-      existingSecret: automation-service-key
-      secretKey: automation-service-key
-
-    automationWebhookSecret:
-      enabled: true
-      existingSecret: automation-webhook-secret
-      secretKey: webhook-secret
-
     ingress:
       enabled: true
       host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
@@ -311,23 +301,6 @@ spec:
     slack:
       enabled: repl{{ ConfigOptionEquals "slack_enabled" "1" }}
 
-    automation:
-      enabled: true
-      image:
-        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/automation'
-        tag: sha-e52cca3
-      imagePullSecrets:
-        - name: '{{repl ImagePullSecretName }}'
-      openhandsApiUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
-      automationBaseUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
-      filestore:
-        type: local
-      env:
-        LOCAL_STORAGE_PATH: /tmp/automation
-      database:
-        createDatabaseUser: true
-        host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'
-
     replicated:
       enabled: true
       image:
@@ -439,6 +412,34 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+    - when: '{{repl ConfigOptionEquals "automations_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        automationServiceKey:
+          enabled: true
+          existingSecret: automation-service-key
+          secretKey: automation-service-key
+        automationWebhookSecret:
+          enabled: true
+          existingSecret: automation-webhook-secret
+          secretKey: webhook-secret
+        automation:
+          enabled: true
+          image:
+            repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/automation'
+            tag: sha-e52cca3
+          imagePullSecrets:
+            - name: '{{repl ImagePullSecretName }}'
+          openhandsApiUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+          automationBaseUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+          filestore:
+            type: local
+          env:
+            LOCAL_STORAGE_PATH: /tmp/automation
+          database:
+            createDatabaseUser: true
+            host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'
+
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
       recursiveMerge: true
       values:

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -93,5 +93,5 @@ spec:
       auth_hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
 
       # Automation
-      automation_service_key: '{{repl RandomString 32}}'
-      automation_webhook_secret: '{{repl RandomString 32}}'
+      automation_service_key: '{{repl ConfigOption "automation_service_key"}}'
+      automation_webhook_secret: '{{repl ConfigOption "automation_webhook_secret"}}'

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -91,3 +91,7 @@ spec:
         {{repl ConfigOptionData "tls_certificate" | nindent 8}}
       tls_env: '{{repl Namespace }}'
       auth_hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+
+      # Automation
+      automation_service_key: '{{repl RandomString 32}}'
+      automation_webhook_secret: '{{repl RandomString 32}}'

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -92,6 +92,12 @@ spec:
       tls_env: '{{repl Namespace }}'
       auth_hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
 
-      # Automation
-      automation_service_key: '{{repl ConfigOption "automation_service_key"}}'
-      automation_webhook_secret: '{{repl ConfigOption "automation_webhook_secret"}}'
+  optionalValues:
+    - when: '{{repl ConfigOptionEquals "automations_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        automation:
+          enabled: true
+        config:
+          automation_service_key: '{{repl ConfigOption "automation_service_key"}}'
+          automation_webhook_secret: '{{repl ConfigOption "automation_webhook_secret"}}'


### PR DESCRIPTION
## Description

Enables the Automations UI in the Replicated install.

Automations UI will live at https://app.<BASE_DOMAIN>/automations
Swagger docs will live at https://app.<BASE_DOMAIN>/api/automation/docs. The Swagger doc endpoint is a good indicator that the Automations backend is serving successfully.

Changes:
- Add config option for enabling automations
- Add automation deployment/service/ingress to Replicated status informers
- Wire `automationServiceKey` and `automationWebhookSecret` secrets into the openhands helm values
- Add full `automation:` chart config (image, proxied repo, URLs, filestore, database)
- Add `automation_service_key` and `automation_webhook_secret` as persistent hidden config items in `config.yaml` (generated once via `RandomString 32`, persisted across deploys — same pattern as `postgres_password`)
- Reference those config items in `secrets.yaml` via `ConfigOption` rather than inline `RandomString`
- Add `automation-service-key`, `automation-webhook-secret`, and `automation-db-secret` Kubernetes Secret templates to the `openhands-secrets` chart

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Testing
Fresh install

Replicated status informers can show statuses of automation k8s resources:
<img width="394" height="457" alt="Screenshot 2026-05-07 at 12 38 01 AM" src="https://github.com/user-attachments/assets/8999177a-ad1e-4d4f-adfe-5b9af9995821" />

Automations Swagger docs appear at expected endpoint:
<img width="1296" height="704" alt="Screenshot 2026-05-07 at 12 31 09 AM" src="https://github.com/user-attachments/assets/2a92a6db-4c98-4eea-8a59-3634406549d6" />

Automations UI appears at expected endpoint:
<img width="1262" height="671" alt="Screenshot 2026-05-07 at 12 31 12 AM" src="https://github.com/user-attachments/assets/097642eb-183d-4e37-9636-229869b950d8" />

Created an automation with test prompt:
<img width="1256" height="816" alt="Screenshot 2026-05-07 at 12 38 12 AM" src="https://github.com/user-attachments/assets/2eee46ee-8a17-4781-bb0f-aaf78e22f786" />
<img width="1244" height="814" alt="Screenshot 2026-05-07 at 12 38 20 AM" src="https://github.com/user-attachments/assets/8cbf1d03-66f9-4aef-9e56-a064c42e5eb1" />
<img width="1512" height="519" alt="Screenshot 2026-05-07 at 12 38 27 AM" src="https://github.com/user-attachments/assets/e4b1508f-40b3-49d0-b0d0-f153cc137221" />

Upgrade install:
Automations UI loaded.
Swagger docs loaded.
Can create an automation within a conversation.
With GitHub auth still configured as before from the previous install persisting into the upgraded install, I can create a PR in a conversation:
<img width="1248" height="816" alt="Screenshot 2026-05-07 at 1 01 11 AM" src="https://github.com/user-attachments/assets/dca9d155-3c7d-4afe-ad39-0633adf619cd" />
<img width="1263" height="812" alt="Screenshot 2026-05-07 at 1 01 15 AM" src="https://github.com/user-attachments/assets/d18b851a-3e50-47f4-8c44-9e014878a33b" />
<img width="1042" height="800" alt="Screenshot 2026-05-07 at 1 01 19 AM" src="https://github.com/user-attachments/assets/e8275050-eea5-4009-927b-d80286b3e7f0" />