### PR TITLE
fix: update automation uvicorn entrypoint to openhands.automation namespace

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
         command: ["ddtrace-run"]
         args:
           - "uvicorn"
-          - "automation.app:app"
+          - "openhands.automation.app:app"
           - "--host"
           - "0.0.0.0"
           - "--port"

--- a/charts/automation/templates/events-deployment.yaml
+++ b/charts/automation/templates/events-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         command: ["ddtrace-run"]
         args:
           - "uvicorn"
-          - "automation.app:app"
+          - "openhands.automation.app:app"
           - "--host"
           - "0.0.0.0"
           - "--port"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.9
+version: 0.7.10
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,7 +42,7 @@ dependencies:
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.6
+    version: 0.1.7
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/all-hands-ai/helm-charts


### PR DESCRIPTION
## Summary

Fixes the Kubernetes pods crashing with `ModuleNotFoundError: No module named 'automation'` after the automation package namespace restructuring.

## Problem

The automation package was restructured in OpenHands/automation#104 to use the `openhands.automation` namespace instead of the root `automation` namespace. However, the Helm chart templates still referenced the old module path `automation.app:app`, causing pods to crash on startup:

```
ModuleNotFoundError: No module named 'automation'
```

## Changes

Updated the uvicorn entrypoint from `automation.app:app` to `openhands.automation.app:app` in:

- `charts/automation/templates/deployment.yaml` (main automation pods)
- `charts/automation/templates/events-deployment.yaml` (webhook event handler pods)

## Related

- OpenHands/automation#101 - Original namespace restructuring issue
- OpenHands/automation#104 - Automation package restructuring PR

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b33b5123-22ea-492c-8d60-d7e3bfd980fd)