### PR TITLE
PLTF-2502: upgrade laminar helm chart to address noisy postgres error

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.8
+  version: 0.1.9
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -29,5 +29,5 @@ dependencies:
 - name: crd-check
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:35a0b71e637e72ed0ff261f8b36037a2989df0fa815584259b5c44a45f000c7f
-generated: "2026-04-28T14:57:49.113748-05:00"
+digest: sha256:78f868a70fc330264c1ca35ddc3f5df18966a331fe4c1dd7aa7c75012d195124
+generated: "2026-05-11T13:51:23.009396-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.10
+version: 0.7.11
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.8
+    version: 0.1.9
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai


### PR DESCRIPTION
## Description

There is a noisy postgres error coming from the laminar setup: `FATAL: role "root" does not exist`.

Upgrading the laminar helm chart includes the fix https://github.com/lmnr-ai/lmnr-helm/pull/22.

## Verification

Deployed this branch to a Replicated embedded-cluster customer by switching from the stable channel to this branch's release channel.

**Before upgrade** (`laminar-postgres-0` logs, sampled at probe cadence):

```
2026-05-11 18:43:25.223 UTC [5215] FATAL:  role "root" does not exist
2026-05-11 18:43:29.517 UTC [5223] FATAL:  role "root" does not exist
2026-05-11 18:43:35.222 UTC [5231] FATAL:  role "root" does not exist
... (repeating every 5–10s indefinitely)
```

**After upgrade**, `laminar-postgres-0` was rolled and the probe commands now use the correct shell expansion:

```json
{"exec":{"command":["/bin/sh","-c","exec pg_isready -U \"$POSTGRES_USER\" -d \"lmnr\" -h 127.0.0.1 -p 5432"]}, ...}
```

Logs since the new pod came up show **0** occurrences of `FATAL: role "root" does not exist` (versus ~6/min previously).

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Can continue to have conversations automatically send traces to laminar:
<img width="1507" height="811" alt="Screenshot 2026-05-11 at 2 11 43 PM" src="https://github.com/user-attachments/assets/a603b844-2fb4-47b4-be43-30cd5470ae0d" />
