### PR TITLE
PLTF-2504: upgrade laminar helm chart to 0.1.11 (rabbitmq+quickwit hardening + configmap-checksum auto-rollout)

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.10
+  version: 0.1.11
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -29,5 +29,5 @@ dependencies:
 - name: crd-check
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:1729d0818e6f467100417bc2e4e759f69afeafffee8635076cca1f857e27eabc
-generated: "2026-05-12T12:47:48.318063-05:00"
+digest: sha256:d78078e8a928bd23523b17c2541023691f94853c851c394fcd2ef69210e7f6e0
+generated: "2026-05-12T17:49:51.563833-05:00"

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.9
+  version: 0.1.10
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -29,5 +29,5 @@ dependencies:
 - name: crd-check
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:78f868a70fc330264c1ca35ddc3f5df18966a331fe4c1dd7aa7c75012d195124
-generated: "2026-05-11T13:51:23.009396-05:00"
+digest: sha256:1729d0818e6f467100417bc2e4e759f69afeafffee8635076cca1f857e27eabc
+generated: "2026-05-12T12:47:48.318063-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.11
+version: 0.7.12
 maintainers:
   - name: rbren
   - name: xingyao
@@ -14,7 +14,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.9
+    version: 0.1.10
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.10
+    version: 0.1.11
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -416,6 +416,20 @@ laminar:
         clusterIssuer: ""
       annotations: {}
 
+  # Pin to laminar 0.1.9's default. K8s forbids changing StatefulSet
+  # volumeClaimTemplates in place; the 0.1.10 default of 100Gi breaks
+  # `helm upgrade` with "spec: Forbidden". With replicaCount: 1 this
+  # value only describes the template, never new replicas.
+  #
+  # To grow rabbitmq disk where size is actually enforced (e.g. GKE
+  # hyperdisk-balanced), patch the live PVC out of band with
+  # `kubectl patch pvc`. On Replicated's openebs-hostpath this is a
+  # no-op — the LocalPV-hostpath provisioner has no resize handler
+  # and hostpath capacity is metadata only.
+  rabbitmq:
+    persistence:
+      size: "50Gi"
+
 litellm-helm:
   # Set this to false if you are using your own litellm instance
   # NOTE: We recommend using the provided LiteLLM instance (enabled: true) for simplicity


### PR DESCRIPTION
## Description

Bumps the laminar dependency from `0.1.9` to **`0.1.11`**, which combines two upstream releases:

- **[lmnr-ai/lmnr-helm#24](https://github.com/lmnr-ai/lmnr-helm/pull/24) → laminar 0.1.10** — RabbitMQ self-protection (`disk_free_limit.absolute`, `vm_memory_high_watermark.absolute`, console logging), default rabbitmq PVC raised from 50Gi → 100Gi, StorageClass `allowVolumeExpansion: true`, Quickwit hardening (configurable `grpc.max_message_size`, tunable indexer/searcher startup probe budgets, optional `volumeClaimTemplates` with `emptyDir.sizeLimit` fallback, higher indexer resource requests).
- **[lmnr-ai/lmnr-helm#25](https://github.com/lmnr-ai/lmnr-helm/pull/25) → laminar 0.1.11** — adds `checksum/config` pod-template annotations to the rabbitmq StatefulSet and all five quickwit workloads (control-plane, indexer, searcher, metastore, janitor). With this, helm upgrade automatically rolls those pods whenever their configmaps change — no operator action required outside the admin console.

These address out-of-space and memory-limit errors hit during a SaaS prod deployment. SaaS staging and Replicated deployments did not exhibit the issue.

### Pinning rabbitmq PVC size to 50Gi

The laminar 0.1.10 chart bumps the rabbitmq `volumeClaimTemplates` storage from `50Gi` → `100Gi`, and 0.1.11 does not revert that. Kubernetes forbids modifying `volumeClaimTemplates` on an existing StatefulSet, so a first attempt at `helm upgrade openhands 0.7.11 → 0.7.12` on a Replicated install failed:

```
Error: UPGRADE FAILED: StatefulSet.apps "laminar-rabbitmq" is invalid: spec:
Forbidden: updates to statefulset spec for fields other than 'replicas',
'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit',
'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

`charts/openhands/values.yaml` now pins `laminar.rabbitmq.persistence.size: "50Gi"` so the rendered template stays identical to the existing live StatefulSet. Every other 0.1.10/0.1.11 fix still ships (self-protection, console logging, quickwit hardening, allowVolumeExpansion on the chart's StorageClass, configmap-checksum auto-rollout). To grow the rabbitmq disk where size is actually enforced (e.g. GKE `hyperdisk-balanced`), patch the live PVC out of band with `kubectl patch pvc` — already verified on SaaS prod.

## Verification

Verified on a Replicated embedded-cluster install. Each step pushed to the Replicated release channel via `make release`.

### 0.1.10 step (intermediate, captured here for the audit trail)

- [x] `helm lint charts/openhands` passes.
- [x] `helm template` diff against `main` reviewed — only the expected laminar 0.1.10 subchart deltas (rabbitmq/quickwit values + new probe/PVC fields) appear.
- [x] First upgrade attempt failed with the "spec: Forbidden" error above (Replicated `helm history openhands` rev 6) — confirming the PVC immutability issue.
- [x] After pinning `rabbitmq.persistence.size`, the Replicated upgrade `0.7.11 → 0.7.12` (laminar 0.1.10) succeeded (rev 7). All laminar pods Running 1/1.
- [x] Verified live state on the Replicated install matches the chart deltas (see "0.1.10 live-cluster verification" table below).
- [x] Verified RabbitMQ self-protection is actually active in the runtime **after** a manual `kubectl rollout restart sts laminar-rabbitmq` (necessary because 0.1.10 lacks the `checksum/config` annotation):
  - `rabbitmqctl status`: `Memory high watermark setting: 2.0 gb, computed to: 2.0 gb` (was `0.6 of available memory, computed to: 19.85 gb`)
  - `rabbitmqctl status`: `Low free disk space watermark: 2.0 gb`
  - `rabbitmqctl environment`: `{disk_free_limit,"2GB"}`, `{vm_memory_high_watermark,{absolute,"2GB"}}`
  - `/etc/rabbitmq/rabbitmq.conf` in the live pod contains all four self-protection lines.
- [x] No regressions in the postgres path fixed by the prior 0.1.9 bump (#623): `pg_isready` shell-expansion probes still in place, postgres pod still on its rev-4 lifetime (0 restarts), zero `FATAL: role "root" does not exist` log entries across the full pod history (~3h, vs ~6/min pre-fix).

### 0.1.11 step (end-to-end auto-rollout verification)

Done on a freshly-reset Replicated VM so no leftover state (in particular no manually-restarted rabbitmq pod) could mask the new auto-rollout behavior.

- [x] Upstream laminar fix landed: [lmnr-ai/lmnr-helm#25](https://github.com/lmnr-ai/lmnr-helm/pull/25) (released as 0.1.11) adds `checksum/config` on the rabbitmq STS pod template and the 5 quickwit workloads.
- [x] `helm template` diff between laminar 0.1.10 and 0.1.11 (both rendered with the 50Gi pin) is scoped — only chart-label bump + `checksum/config` annotation additions on 6 workloads, no other deltas.
- [x] Reset the Replicated VM, installed the stable channel (rev 1 @ 22:35:31, `openhands-0.7.9` / `laminar-0.1.8`), then upgraded to this branch's release (rev 3 @ 22:57:15, `openhands-0.7.12` / `laminar-0.1.11`). `helm history openhands` shows `Upgrade complete`. Verified the laminar UI works end-to-end: configured the Laminar Project API Key and confirmed traces from openhands conversations show up.
- [x] rabbitmq STS pod template carries `checksum/config: b7fca5ff79bc8d1fb65659a804c98614715bd0c9f7d69d0db3ad6f780185bdde` — matches the rendered hash of `rabbitmq-configmap.yaml`. (Quickwit workloads share `checksum/config: 43075e5f668fd063bfe9b4535fd34fcc57106a9c0e73ae849d0493f9dc528d7a` from the `laminar-quickwit` configmap.)
- [x] Helm upgrade auto-rolled `laminar-rabbitmq-0` — pod `startTime: 2026-05-12T22:57:22Z` is 7 seconds after rev 3 (22:57:15Z), `restartCount: 0` since (no `kubectl rollout restart` involved). A subsequent identity re-upgrade (rev 4) did NOT roll the pod, confirming the checksum mechanism is precise — it rolls only on configmap-content changes, not on every upgrade.
- [x] RabbitMQ runtime has the new self-protection live without manual intervention:
  - `rabbitmqctl status`: `Memory high watermark setting: 2.0 gb, computed to: 2.0 gb` (vs the default `0.6 of available memory, computed to: 19.85 gb` seen on the pre-0.1.11 test cluster).
  - `rabbitmqctl status`: `Low free disk space watermark: 2.0 gb`.
  - `rabbitmqctl environment`: `{disk_free_limit,"2GB"}`, `{vm_memory_high_watermark,{absolute,"2GB"}}`.
- [x] Quickwit components (`control-plane`, `indexer`, `searcher`, `metastore`, `janitor`) all carry the shared `checksum/config` and all rolled at rev 3 (AGE 13m matches rabbitmq's roll time, `restarts: 0` on each). Control-plane, metastore, and janitor are Deployments; indexer and searcher are StatefulSets — annotation works on both kinds.

**Observed side-effect (expected, not a regression):** when rabbitmq auto-rolls during a configmap-content upgrade, `laminar-app-server` and `laminar-app-server-consumer` briefly enter `CrashLoopBackOff` (8 and 5 restarts respectively on this run) and self-recover via their `wait-for-rabbitmq` init containers once the new rabbitmq pod is ready. This is intrinsic to single-replica rabbitmq upgrades and is not specific to this PR.

### 0.1.10 live-cluster verification of chart deltas (Replicated install, rev 7)

| Check | Expected (per PR #24) | Live state |
|---|---|---|
| chart label | `laminar-0.1.10` | ✅ on configmaps + STS |
| rabbitmq STS `volumeClaimTemplates.storage` | `50Gi` (pinned) | ✅ `50Gi`, sc `openebs-hostpath` |
| rabbitmq PVC capacity / requests | `50Gi / 50Gi` | ✅ `50Gi / 50Gi` |
| rabbitmq configmap | `disk_free_limit.absolute = 2GB`, `vm_memory_high_watermark.absolute = 2GB`, `log.console = true`, `log.console.level = info` | ✅ all four lines present |
| rabbitmq runtime self-protection (post-restart) | absolute 2GB watermarks | ✅ both 2.0 gb |
| quickwit configmap | `grpc.max_message_size: "50 MiB"` | ✅ |
| quickwit-indexer startup probe | `failureThreshold=30`, `initialDelaySeconds=15` | ✅ |
| quickwit-indexer resources | `cpu=500m`, `memory=1Gi` | ✅ |
| quickwit-indexer `data` volume | `emptyDir.sizeLimit=20Gi` | ✅ |
| quickwit-searcher startup probe | same as indexer | ✅ |
| quickwit-searcher `data` volume | `emptyDir.sizeLimit=10Gi` | ✅ |
| StorageClass `laminar-sc` | `allowVolumeExpansion: true` | ✅ |

### `helm template` diff summary (laminar-0.1.9 → laminar-0.1.11, default values + 50Gi pin)

Rendered each subchart tarball with `helm template laminar <chart>.tgz --set rabbitmq.persistence.size=50Gi` and diffed.

**Deltas from 0.1.9 → 0.1.10** (all map to [lmnr-ai/lmnr-helm#24](https://github.com/lmnr-ai/lmnr-helm/pull/24)):

| Manifest | Change | PR #24 item |
|---|---|---|
| `helm.sh/chart` labels | `laminar-0.1.9` → `laminar-0.1.10` | version bump (cosmetic) |
| quickwit configmap | `+ grpc.max_message_size: "50 MiB"` | configurable grpc max message size |
| rabbitmq configmap | `+ disk_free_limit.absolute = 2GB`, `+ vm_memory_high_watermark.absolute = 2GB`, `+ log.console = true`, `+ log.console.level = info` | self-protection + console logging |
| storage-class | `+ allowVolumeExpansion: true` | volume expansion support |
| quickwit-indexer startup probe | `+ initialDelaySeconds: 15`, `failureThreshold: 12 → 30` | tunable startup probe budgets |
| quickwit-indexer resources | `cpu: 0.1 → 0.5`, `memory: 100Mi → 1Gi` | higher default indexer requests |
| quickwit-indexer data volume | `emptyDir: {} → emptyDir.sizeLimit: 20Gi` | emptyDir.sizeLimit cap |
| quickwit-searcher startup probe | same as indexer | tunable startup probe budgets |
| quickwit-searcher data volume | `emptyDir: {} → emptyDir.sizeLimit: 10Gi` | emptyDir.sizeLimit cap |
| rabbitmq statefulset PVC | `storage: 50Gi → 100Gi` | larger default PVC (**overridden back to 50Gi in this PR** — see "Pinning rabbitmq PVC size to 50Gi" above) |

**Deltas from 0.1.10 → 0.1.11** (all map to [lmnr-ai/lmnr-helm#25](https://github.com/lmnr-ai/lmnr-helm/pull/25)):

| Manifest | Change | PR #25 item |
|---|---|---|
| `helm.sh/chart` labels | `laminar-0.1.10` → `laminar-0.1.11` | version bump (cosmetic) |
| rabbitmq statefulset pod template | `+ annotations.checksum/config: <sha256 of rabbitmq-configmap>` | auto-rollout on rabbitmq configmap change |
| quickwit-control-plane deployment pod template | `+ annotations.checksum/config: <sha256 of quickwit-configmap>` | auto-rollout on quickwit configmap change |
| quickwit-indexer statefulset pod template | same | same |
| quickwit-searcher statefulset pod template | same | same |
| quickwit-metastore deployment pod template | same | same |
| quickwit-janitor deployment pod template | same | same |

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (openhands 0.7.11 → 0.7.12).
- [x] I have tested the chart upgrade path from the previous version.
- [x] I have verified backwards compatibility with existing values.yaml configurations.
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values.

## Notes

- `Chart.lock` shows three pre-existing entries that have drifted from `Chart.yaml` on `main` (`runtime-api`, `automation`, `plugin-directory`). They are intentionally **not** corrected in this PR to keep the diff scoped to the laminar bump — a follow-up PR will reconcile the lock with `helm dependency update`.

Conversation trace appears in Laminar UI on an upgrade install:
<img width="956" height="806" alt="Screenshot 2026-05-12 at 6 20 43 PM" src="https://github.com/user-attachments/assets/8563724c-e7f6-4f99-afd7-2291fe4f93a0" />
<img width="1512" height="699" alt="Screenshot 2026-05-12 at 6 20 47 PM" src="https://github.com/user-attachments/assets/0187653d-010d-4c3f-9072-74b74d8f0886" />