### PR TITLE
[PLTF-2868] Wire up Custom/Local LLM provider in Replicated installer

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/litellm-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/litellm-env-secrets.yaml
@@ -63,3 +63,6 @@ data:
   {{- if .Values.config.custom_api_key }}
   CUSTOM_API_KEY: {{ .Values.config.custom_api_key | b64enc | quote }}
   {{- end }}
+  {{- if .Values.config.custom_base_url }}
+  CUSTOM_API_BASE: {{ .Values.config.custom_base_url | b64enc | quote }}
+  {{- end }}

--- a/charts/openhands-secrets/templates/openhands-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/openhands-env-secrets.yaml
@@ -52,3 +52,9 @@ stringData:
   {{- if .Values.config.custom_api_key }}
   LLM_API_KEY: {{ .Values.config.custom_api_key }}
   {{- end }}
+  {{- if .Values.config.custom_base_url }}
+  LLM_BASE_URL: '{{ .Values.config.custom_base_url }}'
+  {{- end }}
+  {{- if .Values.config.custom_model }}
+  LLM_MODEL: 'openai/{{ .Values.config.custom_model }}'
+  {{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -48,6 +48,8 @@ config:
   aws_region_name: "us-west-2"
   bedrock_model_id: ""
   custom_api_key: ""
+  custom_base_url: ""
+  custom_model: ""
   
   # S3 credentials
   external_s3_access_key: ""

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -285,7 +285,7 @@ spec:
           required: true
         - name: custom_base_url
           title: Custom LLM Base URL
-          help_text: Base URL for your custom or local LLM endpoint
+          help_text: Base URL of your OpenAI-compatible LLM endpoint (e.g., https://openrouter.ai/api/v1, http://my-vllm:8000/v1)
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
@@ -295,6 +295,12 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: false
+        - name: custom_model
+          title: Custom LLM Model Name
+          help_text: Model identifier as accepted by the endpoint (e.g., anthropic/claude-sonnet-4-5 for OpenRouter, llama-3.1-70b-instruct for vLLM)
+          type: text
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
+          required: true
 
     - name: security_secrets
       title: Security & Authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -627,6 +627,26 @@ spec:
                   client_id: os.environ/AZURE_CLIENT_ID
                   client_secret: os.environ/AZURE_CLIENT_SECRET
 
+    # Custom / Local LLM — any OpenAI-compatible endpoint (OpenRouter, vLLM,
+    # Ollama, LM Studio, LiteLLM gateway, etc.). LiteLLM routes via the
+    # generic `openai/<model>` provider, which forwards the request body to
+    # <custom_base_url>/chat/completions with `Authorization: Bearer
+    # <custom_api_key>` headers.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "custom" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/custom-llm'
+          OH_AGENT_SERVER_ENV: '{{repl printf "{\"CUSTOM_API_KEY\": \"%s\", \"CUSTOM_API_BASE\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOption "custom_api_key") (ConfigOption "custom_base_url") }}'
+        litellm-helm:
+          proxy_config:
+            model_list:
+              - model_name: 'custom-llm'
+                litellm_params:
+                  model: 'openai/{{repl ConfigOption "custom_model"}}'
+                  api_key: os.environ/CUSTOM_API_KEY
+                  api_base: os.environ/CUSTOM_API_BASE
+
     - when: '{{repl ConfigOptionEquals "google_api_type" "vertex" }}'
       recursiveMerge: true
       values:

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -57,6 +57,8 @@ spec:
       aws_region_name: '{{repl ConfigOption "aws_region_name"}}'
       bedrock_model_id: '{{repl ConfigOption "bedrock_model_id"}}'
       custom_api_key: '{{repl ConfigOption "custom_api_key"}}'
+      custom_base_url: '{{repl ConfigOption "custom_base_url"}}'
+      custom_model: '{{repl ConfigOption "custom_model"}}'
 
       # Bitbucket Data Center secrets
       bitbucket_data_center_domain: '{{repl ConfigOption "bitbucket_data_center_domain"}}'


### PR DESCRIPTION
Adds a custom_model field to the KOTS config, plumbs the existing custom_base_url / custom_api_key + new custom_model through to:
- OpenHands env (LLM_API_KEY, LLM_BASE_URL, LLM_MODEL=openai/<model>)
- LiteLLM env secrets (CUSTOM_API_KEY, CUSTOM_API_BASE)
- LiteLLM proxy model_list entry under model_name 'custom-llm', routed via the generic openai/* provider so any OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, LM Studio, LiteLLM gateway) works.

Sets LITELLM_DEFAULT_MODEL=litellm_proxy/custom-llm so new users land on the configured model by default.

Tested and validated end-to-end on an embedded-cluster VM (EC2 m8i.2xlarge) with an OpenRouter OpenAI-compatible endpoint and api key.


## Description
<!-- Provide a brief description of the changes in this PR -->

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
<img width="1274" height="680" alt="Screenshot 2026-05-12 at 2 21 11 PM" src="https://github.com/user-attachments/assets/612ca4ad-c4f1-4f16-97d6-65347bd5e293" />
<img width="1245" height="682" alt="Screenshot 2026-05-12 at 1 57 57 PM" src="https://github.com/user-attachments/assets/ac4d4a54-7b15-4f65-aa3a-ec0c8cc2a95b" />

---
Linear: PLTF-2868

_AI-generated metadata update by OpenHands on behalf of ak684._
