### PR TITLE
Fix support bundle errors and warnings, add runtime pod telemetry

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.11
+version: 0.7.12
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.12
+version: 0.7.13
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.13
+version: 0.7.12
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   collectors: {{- include "troubleshoot.collectors.shared" .  | nindent 4 }}
     - secret:
-        name: {{ .Release.Name }}-postgresql
+        name: postgres-password
         namespace: {{ .Release.Namespace }}
         key: postgres-password
         includeValue: false
     - secret:
-        name: {{ .Release.Name }}-redis
+        name: redis
         namespace: {{ .Release.Namespace }}
         key: redis-password
         includeValue: false
@@ -126,23 +126,17 @@ spec:
         namespace: ingress-nginx
         limits:
           maxAge: 168h
-    {{- if .Values.postgresql.enabled }}
+    {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://postgres:@{{ .Release.Name }}-postgresql:5432/openhands?sslmode=disable
+        uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
         tls:
           disabled: true
-        password:
-          secretName: {{ .Release.Name }}-postgresql
-          secretKey: postgres-password
     {{- end }}
-    {{- if .Values.redis.enabled }}
+    {{- if and .Values.redis.enabled .Values.replicated.enabled }}
     - redis:
         collectorName: redis
-        uri: redis://{{ .Release.Name }}-redis-master:6379
-        password:
-          secretName: {{ .Release.Name }}-redis
-          secretKey: redis-password
+        uri: redis://default:{{ .Values.replicated.redisPassword | urlquery }}@{{ .Release.Name }}-redis-master:6379
     {{- end }}
   analyzers: {{- include "troubleshoot.analyzers.shared" .  | nindent 4 }}
     - deploymentStatus:
@@ -263,7 +257,7 @@ spec:
           - pass:
               when: ">= 1"
               message: "Ingress NGINX controller deployment is ready"
-    {{- if .Values.postgresql.enabled }}
+    {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
     - postgresql:
         checkName: "PostgreSQL Database Health"
         collectorName: postgresql
@@ -281,7 +275,7 @@ spec:
               when: "connected == true"
               message: "PostgreSQL database is healthy"
     {{- end }}
-    {{- if .Values.redis.enabled }}
+    {{- if and .Values.redis.enabled .Values.replicated.enabled }}
     - redis:
         checkName: "Redis Cache Health"
         collectorName: redis

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -106,11 +106,10 @@ spec:
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
           maxAge: 168h
-    # Runtime sandbox pod logs. runtime-api spawns these in dynamic
-    # runtime-api-* namespaces with a runtime_id label per sandbox; an empty
-    # namespace searches all namespaces, and a bare label key matches "exists
-    # with any value". Pod/event metadata is already captured by the top-level
-    # clusterResources collector.
+    # Runtime sandbox pod logs. Pod names are dynamic (runtime-*) and the
+    # logs collector has no glob-name support, so select by the runtime_id
+    # label — a bare key matches "label exists with any value". Pod/event
+    # metadata is already captured by the top-level clusterResources collector.
     - logs:
         name: runtime-sandboxes/logs
         selector:

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -156,11 +156,8 @@ spec:
           - fail:
               when: "< 1"
               message: "OpenHands integrations deployment is not ready"
-          - warn:
-              when: "< 2"
-              message: "OpenHands integrations deployment is ready but not at full capacity"
           - pass:
-              when: ">= 2"
+              when: ">= 1"
               message: "OpenHands integrations deployment is ready"
     - deploymentStatus:
         name: openhands-mcp
@@ -169,11 +166,8 @@ spec:
           - fail:
               when: "< 1"
               message: "OpenHands MCP deployment is not ready"
-          - warn:
-              when: "< 2"
-              message: "OpenHands MCP deployment is ready but not at full capacity"
           - pass:
-              when: ">= 2"
+              when: ">= 1"
               message: "OpenHands MCP deployment is ready"
     {{- if and (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
     - deploymentStatus:

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -106,6 +106,18 @@ spec:
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
           maxAge: 168h
+    # Runtime sandbox pod logs. runtime-api spawns these in dynamic
+    # runtime-api-* namespaces with a runtime_id label per sandbox; an empty
+    # namespace searches all namespaces, and a bare label key matches "exists
+    # with any value". Pod/event metadata is already captured by the top-level
+    # clusterResources collector.
+    - logs:
+        name: runtime-sandboxes/logs
+        selector:
+          - runtime_id
+        limits:
+          maxAge: 168h
+        timestamps: true
     {{- end }}
     {{- if and (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
     # LiteLLM logs

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -251,6 +251,20 @@ spec:
           - pass:
               when: ">= 1"
               message: "Ingress NGINX controller deployment is ready"
+    # No `name` => all-deployments mode: auto-fails any deployment whose ready
+    # count doesn't match desired. Named blocks above guard "must exist at all".
+    - deploymentStatus:
+        namespaces:
+          - {{ .Release.Namespace }}
+          - ingress-nginx
+    - clusterPodStatuses:
+        namespaces:
+          - {{ .Release.Namespace }}
+          - ingress-nginx
+        outcomes:
+          - fail:
+              when: "!= Healthy"
+              message: "Pod {{`{{ .Namespace }}/{{ .Name }}`}} is not Healthy: {{`{{ .Status.Reason }}`}}"
     {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
     - postgresql:
         checkName: "PostgreSQL Database Health"

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -140,14 +140,14 @@ spec:
     {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
+        uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
         tls:
           disabled: true
     {{- end }}
     {{- if and .Values.redis.enabled .Values.replicated.enabled }}
     - redis:
         collectorName: redis
-        uri: redis://default:{{ .Values.replicated.redisPassword | urlquery }}@{{ .Release.Name }}-redis-master:6379
+        uri: redis://default:{{ .Values.replicated.redisPassword | urlquery }}@{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379
     {{- end }}
   analyzers: {{- include "troubleshoot.analyzers.shared" .  | nindent 4 }}
     - deploymentStatus:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -868,6 +868,15 @@ automation:
 
 replicated:
   enabled: false
+  # Database credentials below are rendered only into the support-bundle Secret
+  # (gated on replicated.enabled), following the same convention as the rest of
+  # replicated/openhands.yaml — the Replicated installer templates ConfigOption
+  # values into Secrets at install time. The troubleshoot v1beta2 redis/postgres
+  # collectors have no secretRef field, so auth must be inlined into the URI.
+  redisPassword: ""
+  postgresUsername: ""
+  postgresPassword: ""
+  postgresDatabase: ""
 
 global:
   security:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -320,6 +320,10 @@ spec:
 
     replicated:
       enabled: true
+      redisPassword: 'repl{{ ConfigOption "redis_password" }}'
+      postgresUsername: 'repl{{ ConfigOption "postgres_username" }}'
+      postgresPassword: 'repl{{ ConfigOption "postgres_password" }}'
+      postgresDatabase: 'repl{{ ConfigOption "postgres_database" }}'
       image:
         registry: images.r9.all-hands.dev
         repository: library/replicated-sdk-image


### PR DESCRIPTION
## Description

Fixes support bundle embedded postgres and redis health checks, which were always failing due to a missing auth token and mismatched hostname.

Starts collecting logs and events for runtime pods.

Removes warnings about deployments not being ready due to a mismatch in the expected pod count.

Before:
<img width="1268" height="449" alt="image" src="https://github.com/user-attachments/assets/e4928180-6553-4d41-9d96-02f4b7cc93bc" />


After:
<img width="1268" height="449" alt="image" src="https://github.com/user-attachments/assets/c9ab4c47-4246-44f3-b805-d76861bda30c" />


## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes
