### PR TITLE
PLTF-2506: update Chart.lock to match current Chart.yaml dependencies

### DIFF
--- a/charts/infra/Chart.lock
+++ b/charts/infra/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: trust-manager
   repository: oci://quay.io/jetstack/charts
   version: 0.22.1
-digest: sha256:53ec2e40f09b02a8a35b3ae76b83532421464dbb622c8aa557f30d7ce48baed6
-generated: "2026-04-23T11:39:49.389284-04:00"
+- name: crd-check
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.0
+digest: sha256:3e28e70aa364756fd5869cfe1dc85275396e4b87149932c1be8bef39b10ac6c5
+generated: "2026-05-13T15:45:12.067552-05:00"

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra
 description: Cluster-wide infrastructure (cert-manager, trust-manager) that the OpenHands application chart depends on
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"
 maintainers:
   - name: all-hands-ai

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -22,12 +22,15 @@ dependencies:
   version: 1.9.0
 - name: runtime-api
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.3.0
+  version: 0.3.2
 - name: automation
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.4
+  version: 0.1.7
 - name: crd-check
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
+- name: plugin-directory
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.1
 digest: sha256:d78078e8a928bd23523b17c2541023691f94853c851c394fcd2ef69210e7f6e0
-generated: "2026-05-12T17:49:51.563833-05:00"
+generated: "2026-05-13T15:46:55.928149-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.26.1
-version: 0.7.13
+version: 0.7.14
 maintainers:
   - name: rbren
   - name: xingyao


### PR DESCRIPTION
## Summary

Regenerate `charts/openhands/Chart.lock` and `charts/infra/Chart.lock` via `helm dep update` so the locks reflect the dependencies currently declared in each chart's `Chart.yaml`. Dependencies were resolved from the existing `oci://` repositories — no repository changes.

### `charts/infra/Chart.lock`
- adds `crd-check 0.1.0` (already declared in `Chart.yaml` but missing from the lock)

### `charts/openhands/Chart.lock`
- `runtime-api`: `0.3.0` → `0.3.2`
- `automation`: `0.1.4` → `0.1.7`
- adds `plugin-directory 0.1.1` (already declared in `Chart.yaml` but missing from the lock)

## Test plan

- [ ] CI `validate-replicated` job passes (its `yq` rewrite to `file://` for PR validation still applies; the resolved versions match what's published on `oci://ghcr.io/all-hands-ai/helm-charts`)
- [ ] `helm dep build` on a fresh checkout succeeds for both charts