### PR TITLE
PLTF-2515: Wire Vertex project/location config options to litellm-env-secrets

### DIFF
--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -37,6 +37,8 @@ spec:
       anthropic_api_key: '{{repl ConfigOption "anthropic_api_key"}}'
       openai_api_key: '{{repl ConfigOption "openai_api_key"}}'
       google_gemini_api_key: '{{repl ConfigOption "google_gemini_api_key"}}'
+      google_vertex_project_id: '{{repl ConfigOption "google_vertex_project_id"}}'
+      google_vertex_location: '{{repl ConfigOption "google_vertex_location"}}'
       google_vertex_credentials: |
         {{repl ConfigOptionData "google_vertex_credentials" | nindent 8}}
       deepseek_api_key: '{{repl ConfigOption "deepseek_api_key"}}'


### PR DESCRIPTION
## Summary
- Add `google_vertex_project_id` and `google_vertex_location` to the values map that `replicated/secrets.yaml` passes to the `openhands-secrets` chart, so `VERTEXAI_PROJECT` and `VERTEXAI_LOCATION` actually land in the `litellm-env-secrets` Secret and are `envFrom`'d into the LiteLLM proxy pod.

## Bug
On Replicated installs with Google Vertex selected as the LLM provider, gemini-2.5-flash requests fail with:

```
litellm.NotFoundError: Vertex_aiException — 404
GET https://none-aiplatform.googleapis.com/v1/projects/<proj>/locations/None/cachedContents
```

`locations/None` is the giveaway — LiteLLM rendered `vertex_location` as the string `None` because `VERTEXAI_LOCATION` was never set in the litellm pod's env. `VERTEXAI_PROJECT` was also unset but coincidentally resolved at runtime because LiteLLM reads `project_id` from the credentials JSON; there is no analogous fallback for `location`.

## Root cause
`replicated/secrets.yaml` builds the `values.config` map handed to the `openhands-secrets` chart and only wired `google_vertex_credentials`. The chart template at `charts/openhands-secrets/templates/litellm-env-secrets.yaml:20-25` guards both env vars with `{{- if .Values.config.google_vertex_X }}`, so the keys were silently dropped from the rendered Secret. The default `us-central1` in `replicated/config.yaml:160` is meaningless because the `ConfigOption "google_vertex_location"` value was never consumed.

The wiring gap has existed since the Vertex feature shipped (PLTF-87, `524f52588`). It became user-visible between releases 0.7.9 → 0.7.16 when the agent-server image bumped from `1.19.0-python` → `1.21.1-python`. The newer agent-server emits Anthropic-style `cache_control: ephemeral` markers, which LiteLLM translates into Vertex `cachedContents` pre-flight calls (`litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py:253`) — the first code path that actually reads `VERTEXAI_LOCATION`. The older agent-server never exercised that path, so the missing env var was latent.

## Test plan
- [x] `make release` to a personal Replicated channel, install with `llm_provider=google`, `google_api_type=vertex`, leaving Vertex Location at its `us-central1` default.
- [x] Confirm `kubectl exec -n openhands deploy/openhands-litellm -- env | grep VERTEXAI` shows both `VERTEXAI_PROJECT` and `VERTEXAI_LOCATION`.
- [x] Confirm Secret `litellm-env-secrets` has the two keys present.
- [x] Start a conversation in the installed app and confirm gemini-2.5-flash requests succeed (no more `locations/None/cachedContents` 404s).

## Verification evidence (release-branch install on `replicated-01`)

**Pod env**
```
$ kubectl exec -n openhands deploy/openhands-litellm -- env | grep VERTEXAI
VERTEXAI_LOCATION=us-central1
VERTEXAI_PROJECT=platform-team-sandbox-62793
```

**Secret `litellm-env-secrets`** (Vertex-relevant keys, decoded)
```
GOOGLE_APPLICATION_CREDENTIALS_JSON={ "type": "service_account", "project_id": "platform-team-sandbox-62793", ... }
VERTEXAI_LOCATION=us-central1
VERTEXAI_PROJECT=platform-team-sandbox-62793
```

**LiteLLM proxy — last 60 min, conversation against gemini-2.5-flash**
```
$ kubectl logs -n openhands deploy/openhands-litellm --since=60m | grep -c 'cachedContents'
0

$ kubectl logs -n openhands deploy/openhands-litellm --since=60m | \
    grep -oE 'POST /chat/completions HTTP/1\.1" [0-9]+' | sort | uniq -c
   3 POST /chat/completions HTTP/1.1" 200
```

Zero occurrences of the previously-failing `…/locations/None/cachedContents` URL; all three completion requests for the test conversation returned `200`.