### PR TITLE
PLTF-2687: upgrade laminar helm chart to 0.1.12

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.11
+  version: 0.1.12
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -35,5 +35,5 @@ dependencies:
 - name: integrations-hub
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:b4a6cc884d6bd7451f5f5bd2ba5f682b9f2f34f9db4f1677e9d7212031c63e6d
-generated: "2026-05-18T21:40:57.959138-05:00"
+digest: sha256:5f6f403be3c95d5334f04da9e7dccad15d1097dda8f1f467939312e1121ef361
+generated: "2026-05-18T21:56:55.906147-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.18
+version: 0.7.19
 maintainers:
   - name: rbren
   - name: xingyao
@@ -14,7 +14,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.11
+    version: 0.1.12
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai


### PR DESCRIPTION
## Summary

Bumps the bundled laminar helm chart from `0.1.11` → `0.1.12`.

**Tested in a Replicated environment end-to-end** — clean upgrade, traces flow through to the Laminar UI post-upgrade. Ready for review.

The 0.1.12 changeset is confined to three Deployments (`app-server`, `app-server-consumer`, `frontend`), all of which apply via routine rolling update.

## What changed upstream in laminar 0.1.12

Two PRs landed in [`lmnr-ai/lmnr-helm`](https://github.com/lmnr-ai/lmnr-helm):

- [`#27`](https://github.com/lmnr-ai/lmnr-helm/pull/27) — **feat: unify LLM provider env vars, default SIGNALS_ENABLED=true** (the breaking change):
  - Image references renamed from `app-server`/`frontend`/`query-engine` to the `-ee` suffixed variants. Active development moved to `-ee`; the non-ee image stream is no longer being updated (`app-server:latest` last published 2026-04-27, `app-server-ee:latest` published 2026-05-18).
  - LLM provider env vars unified across frontend, app-server, and app-server-consumer:
    - `LLM_PROVIDER` (default `"gemini"`)
    - `LLM_API_KEY` (replaces `GOOGLE_GENERATIVE_AI_API_KEY` in `secrets.data`)
    - `LLM_BASE_URL` (optional, for OpenAI-compatible gateways)
    - `LLM_MODEL_SMALL` / `LLM_MODEL_MEDIUM` / `LLM_MODEL_LARGE` (optional per-tier overrides)
    - For Bedrock: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` via `secrets.data` (unchanged)
  - Legacy keys removed: `BEDROCK_ENABLED`, `SIGNALS_LLM_PROVIDER`, `SIGNALS_LLM_MODEL`. Operators carrying those in their values must rename to the unified scheme.
  - `frontend.env.signalsEnabled` now defaults to `"true"`.
- [`#28`](https://github.com/lmnr-ai/lmnr-helm/pull/28) — docs-only: container image pinning guide + upgrade notes documenting the StatefulSet immutability gotcha for `<= 0.1.11` → `>= 0.1.12` (relevant only when going from a chart older than 0.1.10).

## Changes in this PR

- `charts/openhands/Chart.yaml`: `dependencies.laminar.version` `0.1.11` → `0.1.12`, openhands `version` `0.7.18` → `0.7.19`.
- `charts/openhands/Chart.lock`: regenerated via `helm dependency update`. Only the laminar version line and digest/timestamp refresh — clean diff.

No template, values, or replicated-yaml changes in this PR.

## Replicated test results — 2026-05-19 03:09 UTC

Tested against a Replicated Embedded Cluster install (k0s v1.33.6 on a single control-plane node), upgrading from `openhands-0.7.17` (laminar `0.1.11`) to `openhands-0.7.19` (laminar `0.1.12`).

**Helm upgrade applied cleanly:**

```
REVISION  UPDATED                   STATUS    CHART             APP VERSION
4         Tue May 19 03:05:15 2026  superseded openhands-0.7.17  cloud-1.29.1
5         Tue May 19 03:09:59 2026  deployed   openhands-0.7.19  cloud-1.29.1
```

No `Forbidden: updates to statefulset spec` error of the class observed in #625.

**Pod transitions (final state, ~4 min after upgrade trigger):**

```
laminar-app-server-6cf4fc6748-szjwk         2/2  Running  0  (new, app-server-ee:latest)
laminar-app-server-consumer-84d56f745d-f2zmd 1/1  Running  0  (new)
laminar-frontend-677b7549b7-l25js            1/1  Running  0  (new, frontend-ee:latest)
laminar-query-engine-5bc858746-qvq87         1/1  Running  0  (new, query-engine-ee:latest)
laminar-rabbitmq-0                           1/1  Running  0  (restarted, see below)
laminar-clickhouse-0                         1/1  Running  0  (NOT restarted)
laminar-postgres-0                           1/1  Running  0  (NOT restarted)
laminar-quickwit-* (5 pods)                  1/1  Running  0  (NOT restarted)
laminar-redis-*                              1/1  Running  0  (NOT restarted)
```

**Image switch confirmed**: producer Deployment now references `ghcr.io/lmnr-ai/app-server-ee:latest`.

**Producer startup logs (clean):**

```
INFO app_server: HTTP payload limit: 26214400
INFO app_server: Using Redis cache / pub/sub
INFO app_server::mq::connection: RabbitMQ publisher connection established
INFO app_server: Quickwit client connected successfully
INFO app_server: Signals feature disabled - skipping LLM client initialization
INFO app_server: Spinning up gRPC server
INFO app_server: Spinning up full HTTP server
```

`Signals feature disabled` is expected — the Replicated KOTS values do not set the new `appServer.env.llmProvider` / `LLM_API_KEY` keys, so the producer skips LLM client init. This does **not** block trace ingest; signals is an opt-in feature on the consumer/frontend.

**End-to-end trace flow validated.** Conversation `aa5d20408da943e3ad1da24bd71b6a13` from the Replicated OpenHands install was emitted as an OTLP trace and arrived at the Replicated laminar instance's UI (visible in the project `traces` view past-24h). Full path producer → RabbitMQ → consumer → ClickHouse → Quickwit → frontend works post-upgrade.

## Unexpected observation (non-blocking)

**`laminar-rabbitmq-0` did restart during this upgrade**, even though our chart-template diff between 0.1.11 and 0.1.12 shows zero changes to `rabbitmq-statefulset.yaml` or `rabbitmq-configmap.yaml`. The trigger was a `checksum/config` annotation change on the pod template — meaning the rendered `rabbitmq-configmap.yaml` produced different content this time. Likely a Replicated/KOTS templating artifact (e.g., a re-rendered value substitution) rather than an upstream chart change.

Practical effect was a ~4-minute window during the rolling upgrade where:

1. Old `app-server` + `app-server-consumer` pods hit `CrashLoopBackOff` with `Os { code: 111, kind: ConnectionRefused }` panics when RabbitMQ restarted out from under them.
2. New pods waited in `Init:3/4` on their `wait-for-rabbitmq` init container until RabbitMQ came back Ready.
3. Resolved automatically once RabbitMQ settled; new pods came up cleanly.

Trace ingestion is unavailable during that window. Any OpenHands runtime that's actively emitting will see retries from the OTel exporter (default OTel-Python retry budget tolerates this).

## Risks

- **Image registry pull**: chart 0.1.12 switches to `app-server-ee`/`frontend-ee`/`query-engine-ee` images. These are public on `ghcr.io/lmnr-ai`. Replicated installs behind a strict proxy/mirror may need to pre-mirror the new image names. The Laminar 0.1.12 docs at `lmnr-helm/CONFIGURATION.md` cover this (image override + private mirror guide).
- **LLM env rename is breaking for any install carrying `BEDROCK_ENABLED`/`SIGNALS_LLM_PROVIDER`/`SIGNALS_LLM_MODEL` values overrides.** Our `replicated/openhands.yaml` does not set these (analytics-enabled installs use `LMNR_BASE_URL`/`LMNR_PROJECT_API_KEY` only), so no rename is required for the bundled values — Replicated test confirmed signals gracefully disables itself when the new keys are absent.
- **~4 min trace ingest gap during the upgrade** due to the RabbitMQ restart (see above).