### PR TITLE
PLTF-2687: sync Chart.lock with current Chart.yaml dependencies

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -25,12 +25,15 @@ dependencies:
   version: 0.3.3
 - name: automation
   repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.8
+  version: 0.1.9
 - name: crd-check
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
 - name: plugin-directory
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.1
-digest: sha256:ac280b04d306702c555b22657359b56abaa7948ef79665ff8ed7eb70f0ce28bf
-generated: "2026-05-13T16:43:48.312767-05:00"
+- name: integrations-hub
+  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  version: 0.1.0
+digest: sha256:b4a6cc884d6bd7451f5f5bd2ba5f682b9f2f34f9db4f1677e9d7212031c63e6d
+generated: "2026-05-18T21:40:57.959138-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.17
+version: 0.7.18
 maintainers:
   - name: rbren
   - name: xingyao


### PR DESCRIPTION
## Summary

Syncs `charts/openhands/Chart.lock` with the dependency declarations currently in `charts/openhands/Chart.yaml`. Lockfile had been drifting because the recent dependency bumps in [#614](https://github.com/OpenHands/OpenHands-Cloud/pull/614), [#631](https://github.com/OpenHands/OpenHands-Cloud/pull/631), and [#632](https://github.com/OpenHands/OpenHands-Cloud/pull/632) only touched `Chart.yaml`. Same class of drift fixed previously in [#630](https://github.com/OpenHands/OpenHands-Cloud/pull/630).

Regenerated by running `helm dependency update` against `charts/openhands` on main.

## Diff vs current Chart.lock on main

```
- name: automation
  repository: oci://ghcr.io/all-hands-ai/helm-charts
- version: 0.1.8
+ version: 0.1.9

+ - name: integrations-hub
+   repository: oci://ghcr.io/all-hands-ai/helm-charts
+   version: 0.1.0

- digest: sha256:ac280b04d306702c555b22657359b56abaa7948ef79665ff8ed7eb70f0ce28bf
+ digest: sha256:b4a6cc884d6bd7451f5f5bd2ba5f682b9f2f34f9db4f1677e9d7212031c63e6d
- generated: "2026-05-13T16:43:48.312767-05:00"
+ generated: "2026-05-18T21:40:57.959138-05:00"
```

Drift sources, in order:

- `automation` was bumped from `0.1.7` → `0.1.8` in [#631](https://github.com/OpenHands/OpenHands-Cloud/pull/631) (PLTF-2506 Release 1.29.1) and again from `0.1.8` → `0.1.9` in [#632](https://github.com/OpenHands/OpenHands-Cloud/pull/632) (PLTF-2507 external Postgres bootstrap). Lockfile was stale at `0.1.8`.
- `integrations-hub` was added to Chart.yaml in [#614](https://github.com/OpenHands/OpenHands-Cloud/pull/614) at `0.1.0` but never landed in the lockfile.
- Laminar dependency unchanged at `0.1.11`. The upgrade to `0.1.12` is tracked separately in [#638](https://github.com/OpenHands/OpenHands-Cloud/pull/638).

## Why this is its own PR

Keeps the lock-sync diff minimal and reviewable in isolation from the in-flight laminar 0.1.12 upgrade. The 0.1.12 PR can rebase on top of this when it's ready to come out of draft, picking up a clean Chart.lock that only needs the laminar version line touched.

## Risk

Minimal. The lockfile records resolved dependency versions; values weren't already aligned with the declared Chart.yaml, so at runtime `helm dep update` (or the equivalent build-time step) would produce the same resolution anyway. No template, service, or behavior changes.

## Manual intervention

None required.
