### PR TITLE
chore: bump runtime-api chart to 0.3.4

### DIFF
--- a/.github/workflows/preview-helm-charts.yml
+++ b/.github/workflows/preview-helm-charts.yml
@@ -187,6 +187,7 @@ jobs:
           RUNTIME_API_PREVIEW="${RUNTIME_API_VERSION}-alpha.${{ github.event.pull_request.number }}"
 
           yq -i "(.dependencies[] | select(.name == \"runtime-api\")).version = \"${RUNTIME_API_PREVIEW}\"" charts/openhands/Chart.yaml
+          yq -i "(.dependencies[] | select(.name == \"runtime-api\")).repository = \"oci://ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')/helm-charts\"" charts/openhands/Chart.yaml
 
       - name: Update automation dependency version
         if: steps.check.outputs.should_publish == 'true' && matrix.chart.name == 'openhands' && needs.detect-changes.outputs.automation == 'true'
@@ -322,6 +323,7 @@ jobs:
 
           echo "Updating openhands runtime-api dependency to ${RUNTIME_API_PREVIEW}"
           yq -i "(.dependencies[] | select(.name == \"runtime-api\")).version = \"${RUNTIME_API_PREVIEW}\"" charts/openhands/Chart.yaml
+          yq -i "(.dependencies[] | select(.name == \"runtime-api\")).repository = \"oci://ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')/helm-charts\"" charts/openhands/Chart.yaml
 
       - name: Update automation dependency version for openhands
         if: matrix.chart.name == 'openhands' && needs.detect-changes.outputs.automation == 'true'

--- a/.github/workflows/validate-replicated.yml
+++ b/.github/workflows/validate-replicated.yml
@@ -47,8 +47,10 @@ jobs:
           #
           # Check if runtime-api is a dependency in openhands chart and update it to use local path
           if yq -e '.dependencies[] | select(.name == "runtime-api")' charts/openhands/Chart.yaml > /dev/null 2>&1; then
-            echo "Updating openhands chart to use local runtime-api dependency"
+            RUNTIME_API_VERSION=$(yq '.version' charts/runtime-api/Chart.yaml)
+            echo "Updating openhands chart to use local runtime-api dependency ${RUNTIME_API_VERSION}"
             yq -i '(.dependencies[] | select(.name == "runtime-api")).repository = "file://../runtime-api"' charts/openhands/Chart.yaml
+            yq -i "(.dependencies[] | select(.name == \"runtime-api\")).version = \"${RUNTIME_API_VERSION}\"" charts/openhands/Chart.yaml
           fi
 
       - name: Lint Replicated release

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.3 # Change this to trigger a new helm chart version being published
+version: 0.3.4 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Summary
- Bump the `runtime-api` Helm chart version from `0.3.3` to `0.3.4` so the chart publish workflow can release the new chart from `main`.
- Update Replicated PR validation to use the local `runtime-api` chart version when rewriting the `openhands` dependency to `file://../runtime-api`.
- Update preview Helm chart validation so `openhands` resolves PR-preview `runtime-api` charts from the PR owner GHCR namespace.

## Validation
- `git diff --check`
- CI rerun pending after the workflow fixes

This PR was updated by an AI agent (OpenHands) on behalf of the user.

Related issue: #643
