### PR TITLE
PLTF-2689: upgrade laminar helm chart to 0.1.13 (Quickwit on GCS support)

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.12
+  version: 0.1.13
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -35,5 +35,5 @@ dependencies:
 - name: integrations-hub
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:5f6f403be3c95d5334f04da9e7dccad15d1097dda8f1f467939312e1121ef361
-generated: "2026-05-18T21:56:55.906147-05:00"
+digest: sha256:28d80e6612e672fed0bfcc416ff76124f7eee460bc0732ab1575fa7c2bef96e9
+generated: "2026-05-19T15:00:27.302921-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.19
+version: 0.7.20
 maintainers:
   - name: rbren
   - name: xingyao
@@ -14,7 +14,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.12
+    version: 0.1.13
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.20
+version: 0.7.21
 maintainers:
   - name: rbren
   - name: xingyao


### PR DESCRIPTION
## Summary

Bumps the bundled laminar helm chart from `0.1.12` → `0.1.13` and the openhands chart from `0.7.19` → `0.7.20`.

**This is the chart change that unblocks the active SaaS prod incident** (open since 2026-05-15): the Quickwit indexer on GKE has been unable to authenticate to AWS S3 (no EC2 IMDS available on GKE), and `spans_indexer_queue` has been accumulating ~300–500 msg/min since then. The 0.1.13 chart exposes the values knobs we need to point Quickwit at a GCS bucket via the S3-compatible interop layer, mirroring how ClickHouse already works.

## What changed upstream in laminar 0.1.13

[`lmnr-ai/lmnr-helm#29`](https://github.com/lmnr-ai/lmnr-helm/pull/29) (LAM-1618) is the only behavior-affecting PR in 0.1.13:

- **New `quickwit.s3.flavor` and `quickwit.s3.endpoint` knobs**, rendered into `quickwit-configmap.yaml`'s `node.yaml`. Auto-fills based on `global.cloudProvider`:
  - `gcp` → `flavor: "gcs"`, `endpoint: "https://storage.googleapis.com"`
  - `aws` → emits nothing, AWS SDK defaults apply (existing behavior preserved)
- **New `quickwit.extraEnv` (chart-wide)** and **`quickwit.<component>.extraEnv` (per-pod)** propagated to all five Quickwit components (control-plane, indexer, janitor, metastore, searcher) via a helper. Primary use case: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from a `secretKeyRef` for GCS HMAC keys.
- New `examples/quickwit-gcs-storage.yaml` and a Quickwit Storage Backend section in `CONFIGURATION.md` documenting the GCS path.

**AWS-default render is byte-identical to 0.1.12** — EKS / AWS-resident installs see no change.

## Changes in this PR

- `charts/openhands/Chart.yaml`: `dependencies.laminar.version` `0.1.12` → `0.1.13`, openhands `version` `0.7.19` → `0.7.20`.
- `charts/openhands/Chart.lock`: regenerated via `helm dependency update`. Only the laminar version line and digest/timestamp refresh — clean diff.

No template, values, or `replicated/openhands.yaml` changes. The deploy-repo follow-up (with the actual `quickwit.extraEnv` HMAC credentials + the bucket URI override) lands in `OpenHands/deploy` once the new chart version is published.

## Risks

- **AWS users unaffected.** Default render is byte-identical to 0.1.12; no change for installs that haven't opted into the new knobs.
- **Replicated installs unaffected.** Default cloudProvider is configured per-environment; if it's not `gcp`, no auto-fill happens and the existing AWS-defaults code path renders as before. We do still want to retest in a Replicated environment before promoting to SaaS prod (same pattern as #638).
- **No StatefulSet immutability concerns.** The chart-template changes are additive (new keys rendered into existing configmap + new env lines in existing deployments/statefulsets). No `volumeClaimTemplates` or other immutable fields touched.

## Replicated test plan

Same flow as #638:

1. Cut a Replicated release on a feature channel pointing at this branch.
2. Promote to a Replicated install currently running `openhands-0.7.19` (laminar `0.1.12`).
3. Apply the upgrade via the admin console.
4. Expected: clean upgrade. Quickwit configmap re-renders (no operative change since cloudProvider on Replicated is not `gcp` in our test installs) but the `checksum/config` annotation will trip a rolling restart of Quickwit indexer + RabbitMQ — same ~4 min ingest gap pattern we observed during the 0.1.12 rollout.
5. Verify trace flow end-to-end.

## Replicated test results (2026-05-19, instance-1)

Promoted from sequence 5 on `Unstable` (running `openhands-0.7.19` / `laminar-0.1.12` with analytics enabled and a Laminar ingest key configured) to sequence 6 on `av/laminar-chart-upgrade-0-1-13` via the admin console.

### Confirmed as predicted

| Claim | Result |
|---|---|
| openhands chart 0.7.19 → 0.7.20 | ✅ helm release v6 metadata shows `openhands 0.7.20`, deps `laminar 0.1.13` |
| Quickwit configmap re-renders, no operative change on AWS | ✅ stronger than claimed — `laminar-quickwit` ConfigMap data is byte-identical (`diff` exit 0) and resourceVersion didn't even bump (9922 unchanged). Helm noticed the rendered output was identical and skipped the write. |
| Clean upgrade, no StatefulSet immutability errors | ✅ all 13 laminar pods Ready post-rollout, no errors |
| Trace flow survives the upgrade | ✅ post-upgrade conversation in OpenHands produced a trace visible in the Laminar UI |

### Diverged from prediction — worth a follow-up

**Rolling-restart blast radius is wider than the test plan predicts.** The plan calls out only `quickwit-indexer` + `rabbitmq`. In practice **all 5 Quickwit components were replaced**, plus rabbitmq — six pods rolling, not two:

```
Pre-upgrade  (sequence 5, born 2026-05-20T00:03:19Z):
  laminar-quickwit-control-plane-68df4584dd-gw67f
  laminar-quickwit-indexer-0
  laminar-quickwit-janitor-65b47f6b8b-7c56q
  laminar-quickwit-metastore-6fc7d66d9c-qc4jh
  laminar-quickwit-searcher-0
  laminar-rabbitmq-0

Post-upgrade (sequence 6, born 2026-05-20T00:38:12-14Z, all UIDs changed):
  laminar-quickwit-control-plane-ff4ccfc5c-56wj7
  laminar-quickwit-indexer-0
  laminar-quickwit-janitor-59dc9d8999-mnqcc
  laminar-quickwit-metastore-69d9897f6b-tsj7k
  laminar-quickwit-searcher-0
  laminar-rabbitmq-0
```

Likely cause: the new `quickwit.extraEnv` / `quickwit.<component>.extraEnv` helper is rendered into *all five* Quickwit Deployment/StatefulSet templates in 0.1.13, even with no values set. That alters the templated pod spec (probably from "no `env:` block" to `env: []` or vice versa, or a whitespace-driven diff in the helper), which is enough for K8s to roll the Deployment / StatefulSet. The configmap claim ("byte-identical AWS render") holds; the *pod template* claim does not.

**Operational impact for SaaS prod**: the ingest gap window is broader than the test plan implies, and any monitoring tied to those pod identities (PVC mounts on the searcher/indexer StatefulSets, pod-disruption-budget headroom, etc.) needs to account for 6 simultaneous rollouts rather than 2.

### Undocumented side-effect: `laminar-rabbitmq-config` content changed

The PR description only enumerates Quickwit changes from LAM-1618, but `laminar-rabbitmq-config` ConfigMap was rewritten during the upgrade (resourceVersion bumped to 23846). Post-upgrade content includes:

```
disk_free_limit.absolute = 2GB
vm_memory_high_watermark.absolute = 2GB
log.console = true
```

These look like additive self-protection settings (block publishers via flow-control before ENOSPC / OOM) and a stdout logging switch — almost certainly an improvement, but should be noted in the PR description so reviewers / oncall aren't surprised that *rabbitmq's* config also changed. Worth checking the lmnr-helm 0.1.13 changelog for the rabbitmq diff that's not called out in LAM-1618.

### Test environment

- Replicated instance: `instance-1` workspace, `replicated-02.aws.aivong.platform-team.all-hands.dev`
- Embedded cluster (k0s) on AWS EC2, external RDS Postgres in us-east-1
- Customer assigned to `av/laminar-chart-upgrade-0-1-13` channel for the upgrade step
- Pre-upgrade state: clean install from `Unstable` sequence 821, analytics enabled via kotsadm config edit, Laminar ingest key supplied after first laminar boot
