### PR TITLE
Fix BBDC Keycloak id-mapper to use sub (numeric) instead of preferred_username

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.21
+version: 0.7.22
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/files/allhands-realm-github-provider.json.tmpl
+++ b/charts/openhands/files/allhands-realm-github-provider.json.tmpl
@@ -1875,7 +1875,7 @@
       "identityProviderMapper": "oidc-user-attribute-idp-mapper",
       "config": {
         "syncMode": "FORCE",
-        "claim": "preferred_username",
+        "claim": "sub",
         "user.attribute": "bitbucket_data_center_id"
       }
     },


### PR DESCRIPTION
## What

Flip the `bitbucket_data_center` Keycloak `id-mapper` claim back from `preferred_username` to `sub`.

```diff
-        "claim": "preferred_username",
+        "claim": "sub",
```

## Why

#640 switched this id-mapper to `claim: preferred_username` to pair with OpenHands #14461's slug-based mentioner lookup. But after further research

- **It diverges from GitHub and GitLab**, which both key on the numeric id (`github_id` via `sender.id`, `gitlab_id` via `sub`). BBDC was the lone username-keyed provider.
- **`preferred_username` is not a stable/unique identifier** per the OIDC spec — it can change on rename and be reassigned, silently breaking mentioner resolution and falling back to the webhook installer.

The companion OpenHands change resolves the @-mentioning user by the numeric `actor['id']`, which is exactly what OIDC `sub` provides. This realigns the chart with that change and with the enterprise-repo realm template, which already uses `sub`.
