### PR TITLE
Add --force-conflicts to openhands HelmChart upgrade flags

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -8,7 +8,7 @@ spec:
   releaseName: openhands
   namespace: openhands
   weight: 10
-  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
+  helmUpgradeFlags: ["--wait", "--timeout", "600s", "--force-conflicts"]
   values:
     global:
       imageRegistry: 'images.r9.all-hands.dev'


### PR DESCRIPTION
## What

Adds `--force-conflicts` to the `openhands` HelmChart's `helmUpgradeFlags` in `replicated/openhands.yaml`, matching what `openhands-secrets` (`replicated/secrets.yaml`) already does.

## Background — how we ran into this

While testing an unrelated BBDC change (OpenHands/OpenHands#14509), I needed to deploy a custom enterprise-server image (a PR build) to a Replicated embedded-cluster test install. That install had accumulated out-of-band edits from earlier debugging sessions — the enterprise-server image had been pinned with a manual `kubectl set image`, and a few files were overlaid onto the running deployments via ConfigMap `kubectl patch` mounts (a fast-iteration trick to avoid a ~15-20-min image rebuild).

Every KOTS upgrade of the chart then failed on the `openhands` Helm release with:

```
UPGRADE FAILED: conflict occurred while applying object .../openhands Deployment:
Apply failed with 1 conflict: conflict with "kubectl-patch" using apps/v1:
.spec.template.spec.containers[name="openhands"].image
```

The image never rolled and KOTS marked the version `failed`. I first went after the cause directly — removed the overlay mounts, deleted the debug ConfigMaps, and even reset the Deployments' `managedFields` — but the conflict just reappeared under the synthetic `before-first-apply` field manager. What finally pointed at the fix was noticing that `openhands-secrets` upgraded cleanly in the *same* deploy while `openhands` failed: the only difference was that secrets.yaml already passes `--force-conflicts`. Adding the same flag to the openhands HelmChart let Helm take ownership of the contested field and the upgrade applied cleanly.

## Why

KOTS deploys the chart with `helm upgrade` via **server-side apply**. If any field on the `openhands` / `openhands-integrations` Deployments has been set **out-of-band** — a manual `kubectl set image` pin, a debug ConfigMap-overlay `kubectl patch`, a support hotfix — a competing field manager (`kubectl-patch` / `kubectl-set` / `before-first-apply`) owns that field and the upgrade fails as above. `openhands-secrets` already passes `--force-conflicts` for exactly this reason; the `openhands` chart didn't. Adding it lets Helm forcibly take ownership and makes upgrades robust to prior out-of-band edits.

This isn't specific to test VMs — any long-lived install that's ever been operated on directly can land in this state, and without the flag the next upgrade silently fails.

## Scope

Single-line change to `replicated/openhands.yaml`. No chart contents change, so no `charts/openhands/Chart.yaml` version bump is required (the version-bump checks key off `charts/**`).