### PR TITLE
Allow overriding the sandbox image and its pull secret via Replicated config

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/sandbox-image-pull-secret.yaml
+++ b/charts/openhands-secrets/templates/sandbox-image-pull-secret.yaml
@@ -1,0 +1,16 @@
+{{- $server := .Values.config.custom_sandbox_image_registry_server | default "" | trim }}
+{{- $user   := .Values.config.custom_sandbox_image_registry_username | default "" | trim }}
+{{- $pass   := .Values.config.custom_sandbox_image_registry_password | default "" | trim }}
+{{- if and $server $user $pass }}
+{{- $auth   := printf "%s:%s" $user $pass | b64enc }}
+{{- $entry  := dict "username" $user "password" $pass "auth" $auth }}
+{{- $cfg    := dict "auths" (dict $server $entry) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sandbox-image-pull-secret
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $cfg | toJson | b64enc | quote }}
+{{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -73,6 +73,11 @@ config:
   slack_client_secret: ""
   slack_signing_secret: ""
 
+  # Custom sandbox image registry credentials
+  custom_sandbox_image_registry_server: ""
+  custom_sandbox_image_registry_username: ""
+  custom_sandbox_image_registry_password: ""
+
   # Plugin Directory secrets
   plugin_directory_identity_shared_secret: ""
   plugin_directory_session_secret: ""

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -705,6 +705,56 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
+        - name: custom_sandbox_image_enabled
+          title: Use a Custom Sandbox Image
+          help_text: |
+            Override the agent-server image used by new and warm sandboxes.
+            Use this if you mirror the image to your own registry. Leave
+            disabled to use the image bundled with this release.
+          type: bool
+          default: "0"
+        - name: custom_sandbox_image_repository
+          title: Sandbox Image Repository
+          help_text: 'Full repository path with no tag, e.g. my-registry.example.com/openhands/agent-server'
+          type: text
+          when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
+          required: true
+        - name: custom_sandbox_image_tag
+          title: Sandbox Image Tag
+          help_text: Image tag, e.g. 1.21.1-python
+          type: text
+          default: "1.21.1-python"
+          when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
+          required: true
+        - name: custom_sandbox_image_registry_server
+          title: Registry Server
+          help_text: |
+            Host (and optional port) of the registry, e.g. my-registry.example.com.
+            Leave blank if the registry is public, or if your cluster authenticates
+            to the registry via a credential provider (EKS IRSA, GKE Workload
+            Identity, AKS managed identity) — those bypass pull secrets entirely.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
+          required: false
+        - name: custom_sandbox_image_registry_username
+          title: Registry Username
+          help_text: |
+            Registry username. Some registries use sentinel values: _json_key
+            for GCP Artifact Registry, AWS for ECR static creds, $oauthtoken
+            for Quay robot accounts.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
+          required: false
+        - name: custom_sandbox_image_registry_password
+          title: Registry Password or Credentials
+          help_text: |
+            Password, PAT, or credentials string. This field is single-line —
+            for GCP Artifact Registry, minify the service-account JSON first
+            (e.g. `jq -c . key.json`) and paste the one-line result, with
+            username set to _json_key.
+          type: password
+          when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
+          required: false
 
     - name: proxy_configuration
       title: Proxy Configuration

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -707,10 +707,7 @@ spec:
               message: Must be a non-negative integer
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
-          help_text: |
-            Override the agent-server image used by new and warm sandboxes.
-            Use this if you mirror the image to your own registry. Leave
-            disabled to use the image bundled with this release.
+          help_text: Use this if you bundle a custom agent-server image.
           type: bool
           default: "0"
         - name: custom_sandbox_image_repository
@@ -731,8 +728,8 @@ spec:
           help_text: |
             Host (and optional port) of the registry, e.g. my-registry.example.com.
             Leave blank if the registry is public, or if your cluster authenticates
-            to the registry via a credential provider (EKS IRSA, GKE Workload
-            Identity, AKS managed identity) — those bypass pull secrets entirely.
+            via a credential provider (EKS IRSA, GKE Workload Identity, AKS managed
+            identity).
           type: text
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: false
@@ -748,8 +745,8 @@ spec:
         - name: custom_sandbox_image_registry_password
           title: Registry Password or Credentials
           help_text: |
-            Password, PAT, or credentials string. This field is single-line —
-            for GCP Artifact Registry, minify the service-account JSON first
+            Password, PAT, or credentials string. This field is single-line.
+            For GCP Artifact Registry, minify the service-account JSON first
             (e.g. `jq -c . key.json`) and paste the one-line result, with
             username set to _json_key.
           type: password

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -52,10 +52,12 @@ spec:
 
     runtime:
       image:
-        # this is what we need to use for real deployments
-        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
-        # repository: 'ghcr.io/openhands/agent-server'
-        tag: '1.21.1-python'
+        # Defaults to the Replicated-proxied agent-server image. When
+        # custom_sandbox_image_enabled=1, an admin-supplied repository/tag
+        # takes over — both for new sandboxes (via AGENT_SERVER_IMAGE_*
+        # env on the openhands server) and for the warm pool below.
+        repository: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server{{repl end}}'
+        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.21.1-python{{repl end}}'
 
     keycloak:
       enabled: true
@@ -230,7 +232,7 @@ spec:
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
-        RUNTIME_IMAGE_PULL_SECRETS: '{{repl ImagePullSecretName }}'
+        RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"
         RUNTIME_CLASS: ""
@@ -247,7 +249,7 @@ spec:
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
-            image: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.21.1-python'
+            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.21.1-python{{repl end}}'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -232,7 +232,7 @@ spec:
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
-        RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
+        RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_server") "") (ne (ConfigOption "custom_sandbox_image_registry_username") "") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"
         RUNTIME_CLASS: ""

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -89,6 +89,11 @@ spec:
       slack_client_secret: '{{repl ConfigOption "slack_client_secret"}}'
       slack_signing_secret: '{{repl ConfigOption "slack_signing_secret"}}'
 
+      # Custom sandbox image registry credentials
+      custom_sandbox_image_registry_server: '{{repl ConfigOption "custom_sandbox_image_registry_server"}}'
+      custom_sandbox_image_registry_username: '{{repl ConfigOption "custom_sandbox_image_registry_username"}}'
+      custom_sandbox_image_registry_password: '{{repl ConfigOption "custom_sandbox_image_registry_password"}}'
+
       # TLS certificates
       tls_certificate: |
         {{repl ConfigOptionData "tls_certificate" | nindent 8}}


### PR DESCRIPTION
## Description

Customers who bundle a custom agent-server image (e.g. a hardened or vendored build mirrored to their own registry) currently have no way to configure that through the admin console. The default proxy-through-Replicated path is the only option.

This PR adds opt-in config under **Sandbox Configuration** so admins can:

1. Override the agent-server image used for both newly-launched and warm sandboxes.
2. Supply registry credentials, rendered as a `dockerconfigjson` Secret that the runtime-api attaches to each sandbox pod's ServiceAccount.

When the toggle is off, everything continues to use the Replicated proxy image and `ImagePullSecretName`, so existing installs are unaffected.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

A few design choices worth flagging for review:

- **Image override flows to three places**: `runtime.image.repository/tag` on the openhands chart (which the server passes to runtime-api as `image` in the `/start` payload), `runtime-api.warmRuntimes.configs[0].image`, and `RUNTIME_IMAGE_PULL_SECRETS`. All three switch together off the same `custom_sandbox_image_enabled` toggle so the warm pool can't drift from on-demand sandboxes.

- **Pull secret only flips when a password is supplied**. If the admin enables the override but leaves credentials blank (e.g. a public mirror, or a cluster using EKS IRSA / GKE Workload Identity), `RUNTIME_IMAGE_PULL_SECRETS` stays on the Replicated default rather than pointing at a non-existent secret.

- **Registry password is a single-line `type: password`** rather than a textarea, so it stays masked in the admin console. The trade-off is GCP Artifact Registry's multi-line service-account JSON needs to be minified first; help text calls this out.

- **Pull-secret Secret rendered by `openhands-secrets`**, which already runs at `weight: 1` before the openhands chart at `weight: 10`, so the secret exists before runtime-api comes up. Both live in the openhands namespace, matching where sandbox pods land.

Depends on upstream runtime-api support for `RUNTIME_IMAGE_PULL_SECRETS` (OpenHands/runtime-api#364), already in the 0.3.4 chart this repo pulls.