### PR TITLE
Bump openhands-secrets chart to 0.1.18

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "1.0"


### PR DESCRIPTION
## What

Bumps the openhands-secrets chart version `0.1.17` to `0.1.18`.

## Why

#649 bumped openhands-secrets `0.1.16` to `0.1.17`, but #650 had already taken it to `0.1.17` on main just before #649 merged. The two collided, so the `validate-chart-versions` job failed on the #649 merge commit (the chart had changes but its version matched the base), and the openhands-secrets chart did not publish.

This is a version bump only. The actual content change (the `bot-token` key on the `bitbucket-data-center-app` secret) is already on main from #649; it just needs a fresh version to publish under and to make the main check green.

Note: KOTS/Replicated installs are not affected, since those bundle the chart via `make release` rather than pulling from the Helm chart registry. This fixes the registry publish and the main CI.