### PR TITLE
[APP-1961] Enable automation event forwarding for Replicated installs

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -460,6 +460,9 @@ spec:
           enabled: true
           existingSecret: automation-service-key
           secretKey: automation-service-key
+        automationService:
+          url: http://automation/api/automation
+          eventForwardingEnabled: true
         automationWebhookSecret:
           enabled: true
           existingSecret: automation-webhook-secret


### PR DESCRIPTION
## Summary

Wires Replicated installs so enabling automations also enables OpenHands event forwarding to the in-cluster automation service.

- sets `automationService.url` to the in-cluster automation service route
- sets `automationService.eventForwardingEnabled` for Replicated automation installs
- keeps the existing automation service key and webhook secret wiring unchanged

## Validation

- Current diff is one Replicated values change: `replicated/openhands.yaml` adds the `automationService` block.
- Earlier validation release `862` (`0.7.22-jira-dc.12`) deployed to `replicated-02` with temporary image pins.
- Verified deployed env on `replicated-02`: `ENABLE_JIRA_DC=true`, `AUTOMATION_SERVICE_URL=http://automation/api/automation`, and `AUTOMATION_EVENT_FORWARDING_ENABLED=true`.
- OHE E2E on `replicated-02`: Jira DC `comment_created` produced built-in `jira_dc` automation run `17b66b18-8e16-4660-9fa4-5510cc0ca8e7`.
- OHE E2E on `replicated-02`: Jira DC `jira:issue_updated` on `KAN-18` produced built-in `jira_dc` automation run `4c17c4b2-e7e1-4c37-a11a-39c06cc49258`.

---
Linear: APP-1961

_AI-generated metadata update by OpenHands on behalf of ak684._
