### PR TITLE
Make LiteLLM client header forwarding configurable

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.24
+version: 0.7.25
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -303,6 +303,19 @@ env:
   LITELLM_DEFAULT_MODEL: "litellm_proxy/<your-model>"
 ```
 
+#### Forward client headers to LLM providers
+
+By default, the bundled LiteLLM proxy does not forward arbitrary client request headers to upstream LLM providers. If you trust callers and need provider-visible custom headers, enable LiteLLM's client header forwarding explicitly:
+
+```yaml
+litellm-helm:
+  proxy_config:
+    general_settings:
+      forward_client_headers_to_llm_api: true
+```
+
+This forwards LiteLLM-supported client headers such as `x-*` request headers and `anthropic-beta`. Leave this disabled unless you specifically need it.
+
 #### LiteLLM Team Configuration
 
 To use an existing team, provide the team ID.

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -90,6 +90,11 @@ litellm-helm:
     #   litellm_params:
     #     model: "anthropic/claude-3-7-sonnet-20250219"
     #     api_key: os.environ/ANTHROPIC_API_KEY
+    #
+    # Enable only when you trust callers and need custom x-* request headers
+    # forwarded to upstream LLM providers.
+    # general_settings:
+    #   forward_client_headers_to_llm_api: true
 
 runtime-api:
   enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -491,6 +491,10 @@ litellm-helm:
     #   litellm_params:
     #     model: "anthropic/claude-3-7-sonnet-20250219"
     #     api_key: os.environ/ANTHROPIC_API_KEY
+    general_settings:
+      # When true, LiteLLM forwards client x-* headers and anthropic-beta to upstream LLM providers.
+      # Keep false unless you trust callers and need provider-visible custom headers.
+      forward_client_headers_to_llm_api: false
     litellm_settings:
       num_retries: 3
       request_timeout: 600

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -301,6 +301,11 @@ spec:
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
+        - name: litellm_forward_client_headers
+          title: Forward Client Headers to LLM Providers
+          help_text: Forward client x-* request headers and anthropic-beta through LiteLLM to upstream LLM providers. Leave disabled unless you trust callers and need provider-visible custom headers.
+          type: bool
+          default: "0"
 
     - name: security_secrets
       title: Security & Authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -181,6 +181,8 @@ spec:
         environment_variables:
           OR_APP_NAME: "OpenHands"
           OR_SITE_URL: "https://docs.all-hands.dev"
+        general_settings:
+          forward_client_headers_to_llm_api: repl{{ ConfigOptionEquals "litellm_forward_client_headers" "1" }}
         model_list:
           # LiteLLM 1.83.14 workaround: expose this model through the
           # proxy for openhands/claude-opus-4-7 because direct Anthropic calls


### PR DESCRIPTION
## Summary
- Add a safe default (`false`) for LiteLLM `forward_client_headers_to_llm_api` in the bundled Helm chart.
- Expose the same setting in Replicated/KOTS config as `litellm_forward_client_headers`.
- Document how Helm users can enable custom `x-*`/`anthropic-beta` header forwarding when they trust callers and need provider-visible headers.

## Testing
- Verified the expected setting appears in Helm values, Replicated config, and documentation.
- Ran `git diff --check` successfully.

## Notes
- This complements All-Hands-AI/infra#1255, where staging keeps this enabled and production/evaluation keep it disabled.

_Created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cb4ad743-b43e-4aed-b6ba-db7c4354c31a)