### PR TITLE
Emit LMNR_* env vars unconditionally to fix warm-runtime matching

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -18,7 +18,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.3.0
 - name: replicated
-  repository: oci://charts.shortrib.io/library
+  repository: oci://registry.replicated.com/library
   version: 1.9.0
 - name: runtime-api
   repository: oci://ghcr.io/all-hands-ai/helm-charts
@@ -35,5 +35,5 @@ dependencies:
 - name: integrations-hub
   repository: oci://ghcr.io/all-hands-ai/helm-charts
   version: 0.1.0
-digest: sha256:28d80e6612e672fed0bfcc416ff76124f7eee460bc0732ab1575fa7c2bef96e9
-generated: "2026-05-19T15:00:27.302921-05:00"
+digest: sha256:69dda3ea1b463d7b6623250ad4eb6e4b940d3ca03dbd83ec4806881d5075b28c
+generated: "2026-05-22T11:24:47.82372-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: replicated
-    repository: oci://charts.shortrib.io/library
+    repository: oci://registry.replicated.com/library
     version: 1.9.0
     condition: replicated.enabled
   - name: runtime-api

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.24
+version: 0.7.25
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -353,32 +353,32 @@
 - name: DD_TRACE_SAMPLING_RULES
   value: '[{"service":"deploy","name":"fastapi.request","resource":"/integration/*","sample_rate":0.05}, {"service":"deploy","name":"fastapi.request","resource":"/slack/on-*","sample_rate":0.05}]'
 {{- end }}
-{{- if .Values.laminar.enabled }}
-{{- if .Values.laminar.apiKeyFromSecret }}
+{{- if and .Values.laminar.enabled .Values.laminar.apiKeyFromSecret }}
 - name: LMNR_PROJECT_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .Values.laminar.apiKeyFromSecret.name }}
       key: {{ .Values.laminar.apiKeyFromSecret.key }}
       optional: true
+{{- else }}
+- name: LMNR_PROJECT_API_KEY
+  value: ""
 {{- end }}
-{{- if .Values.laminar.baseUrlFromSecret }}
+{{- if and .Values.laminar.enabled .Values.laminar.baseUrlFromSecret }}
 - name: LMNR_BASE_URL
   valueFrom:
     secretKeyRef:
       name: {{ .Values.laminar.baseUrlFromSecret.name }}
       key: {{ .Values.laminar.baseUrlFromSecret.key }}
       optional: true
+{{- else }}
+- name: LMNR_BASE_URL
+  value: ""
 {{- end }}
-{{- if .Values.laminar.forceHttp }}
 - name: LMNR_FORCE_HTTP
-  value: {{ .Values.laminar.forceHttp | quote }}
-{{- end }}
-{{- if .Values.laminar.httpPort }}
+  value: {{ if and .Values.laminar.enabled .Values.laminar.forceHttp }}{{ .Values.laminar.forceHttp | quote }}{{ else }}""{{ end }}
 - name: LMNR_HTTP_PORT
-  value: {{ .Values.laminar.httpPort | quote }}
-{{- end }}
-{{- end }}
+  value: {{ if and .Values.laminar.enabled .Values.laminar.httpPort }}{{ .Values.laminar.httpPort | quote }}{{ else }}""{{ end }}
 - name: DB_PASS
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Description

This PR contains two related changes:

### 1. Fix warm-runtime matching when analytics is disabled

New conversations on instance-4 were never reusing warm runtimes — every request started a cold pod. Investigation showed the runtime-api was rejecting all warm candidates with `Warm runtime does not match the request` because the environment key sets differed.

The warm-runtime spec in `replicated/openhands.yaml` emits `LMNR_BASE_URL`, `LMNR_FORCE_HTTP`, `LMNR_HTTP_PORT`, and `LMNR_PROJECT_API_KEY` as keys unconditionally (with empty string values when `analytics_enabled = "0"`). The OpenHands controller's helm chart, by contrast, gated the entire LMNR_* block behind `{{- if .Values.laminar.enabled }}` — so when analytics was disabled, the controller had no LMNR_* vars in its environment, and `get_agent_server_env()` auto-forwarded none.

Result: warm-runtime env = `{..., LMNR_BASE_URL: "", ...}`, request env = `{...}` (no LMNR_*). Different key sets → no match.

This emits all four LMNR_* keys on the OpenHands controller unconditionally, falling back to `value: ""` when laminar isn't enabled. The Laminar SDK's `should_enable_observability()` treats empty values as falsy and skips initialization, so this is a safe no-op when analytics is disabled.

When `analytics_enabled = "1"`, the kotskind's `.Values.env.LMNR_*` overrides already populate these with real values via the existing `openhands.env` dedup wrapper, so behavior is unchanged in that mode.

### 2. Source the `replicated` chart from the official registry

The `replicated` subchart was being pulled from `oci://charts.shortrib.io/library`. That host has been unreachable from GitHub Actions runners, breaking CI on every PR that runs `helm dep build`. Switched to `oci://registry.replicated.com/library`, which is the source Replicated's [own docs](https://docs.replicated.com/vendor/replicated-sdk-installing) point at. Same chart, same version (1.9.0).

Unclear why this was set as the registry. The original PR from replicated pointed `shortrib`, but their docs say to use `registry.replicated.com`.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Verified the LMNR change via `helm template` in both modes:
- Laminar disabled (default): all four LMNR_* keys render with `value: ""`.
- Laminar enabled with kotskind overrides: each key renders exactly once with the configured value (dedup wrapper drops the defaults in favor of `.Values.env`).