### PR TITLE
Wire Jira Data Center for Replicated installs

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/jira-dc-app.yaml
+++ b/charts/openhands-secrets/templates/jira-dc-app.yaml
@@ -1,0 +1,18 @@
+{{- if or .Values.config.jira_data_center_base_url .Values.config.jira_data_center_client_id .Values.config.jira_data_center_client_secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jira-dc-app
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- if .Values.config.jira_data_center_base_url }}
+  base-url: {{ .Values.config.jira_data_center_base_url | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.jira_data_center_client_id }}
+  client-id: {{ .Values.config.jira_data_center_client_id | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.jira_data_center_client_secret }}
+  client-secret: {{ .Values.config.jira_data_center_client_secret | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -60,6 +60,11 @@ config:
   bitbucket_data_center_client_id: ""
   bitbucket_data_center_client_secret: ""
 
+  # Jira Data Center credentials (OAuth, optional)
+  jira_data_center_base_url: ""
+  jira_data_center_client_id: ""
+  jira_data_center_client_secret: ""
+
   # GitHub credentials
   github_oauth_client_id: ""
   github_oauth_client_secret: ""

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.25
+version: 0.7.26
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -402,6 +402,11 @@
 {{- if .Values.jiraDc.enabled }}
 - name: ENABLE_JIRA_DC
   value: "true"
+- name: JIRA_DC_WEBHOOKS_ENABLED
+  value: "1"
+{{- if eq .Values.jiraDc.linkMethod "oauth" }}
+- name: JIRA_DC_ENABLE_OAUTH
+  value: "1"
 - name: JIRA_DC_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -417,6 +422,10 @@
     secretKeyRef:
       name: jira-dc-app
       key: base-url
+{{- else }}
+- name: JIRA_DC_ENABLE_OAUTH
+  value: "0"
+{{- end }}
 {{- end }}
 
 {{- if .Values.linear.enabled }}

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -50,6 +50,13 @@ spec:
             name: openhands-integrations-service
             port:
               number: 3000
+      - path: /integration/jira-dc/events
+        pathType: Exact
+        backend:
+          service:
+            name: openhands-integrations-service
+            port:
+              number: 3000
       - path: /api/billing/stripe-webhook
         pathType: Exact
         backend:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -661,6 +661,7 @@ jira:
 
 jiraDc:
   enabled: false
+  linkMethod: oauth
 
 linear:
   enabled: false

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -451,6 +451,49 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
 
+    - name: jira_data_center_integration
+      title: Jira Data Center Integration
+      description: Enable the Jira Data Center issue integration. The service-account token and webhook secret are configured per-workspace in the OpenHands app UI after enabling.
+      items:
+        - name: jira_data_center_enabled
+          title: Enable Jira Data Center Integration
+          help_text: Enable the Jira Data Center issue integration.
+          type: bool
+          default: "0"
+        - name: jira_data_center_link_method
+          title: How should Jira users be linked to OpenHands accounts?
+          help_text: >-
+            OAuth (recommended): each user proves ownership of their Jira account via your server's
+            OAuth 2.0 application. This is the most secure option. Email match: users are linked by
+            matching their Jira email to their OpenHands email. Use this only if your Jira Data Center
+            server does not have an OAuth 2.0 application configured.
+          type: select_one
+          default: oauth
+          when: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
+          items:
+            - name: oauth
+              title: OAuth (verified, recommended)
+            - name: email
+              title: Email match (no OAuth app required)
+        - name: jira_data_center_base_url
+          title: Jira Data Center Base URL
+          help_text: Full base URL of your Jira Data Center server, INCLUDING the https:// scheme (e.g. https://jira.example.com).
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "jira_data_center_enabled" "1") (ConfigOptionEquals "jira_data_center_link_method" "oauth") }}'
+          required: true
+        - name: jira_data_center_client_id
+          title: Jira Data Center OAuth Client ID
+          help_text: Client ID from the OAuth 2.0 application on your Jira Data Center server (callback URL https://app.YOUR-DOMAIN/integration/jira-dc/callback).
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "jira_data_center_enabled" "1") (ConfigOptionEquals "jira_data_center_link_method" "oauth") }}'
+          required: true
+        - name: jira_data_center_client_secret
+          title: Jira Data Center OAuth Client Secret
+          help_text: Client secret from the OAuth 2.0 application on your Jira Data Center server.
+          type: password
+          when: 'repl{{ and (ConfigOptionEquals "jira_data_center_enabled" "1") (ConfigOptionEquals "jira_data_center_link_method" "oauth") }}'
+          required: true
+
     - name: github_authentication
       title: GitHub Authentication
       description: Configure GitHub App integration for user authentication. Note that this is a GitHub App and NOT a GitHub OAuth app.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -27,6 +27,12 @@ spec:
       ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_BILLING_PAGE: true
+      # Frontend feature flags must be set via the structured OH_WEB_CLIENT_FEATURE_FLAGS_*
+      # form. Once any of these is present, from_env(AppServerConfig, 'OH') builds
+      # feature_flags from them and the plain ENABLE_JIRA_DC env (set in _env.yaml) is
+      # ignored, so the flag falls back to the model default (false) and the Jira DC
+      # integration card never renders. Mirror jira_data_center_enabled here.
+      OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA_DC: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       OH_AGENT_SERVER_ENV: '{"SSL_CERT_FILE": "/etc/openhands/ca-bundle/ca-bundle.crt", "REQUESTS_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "GIT_SSL_CAINFO": "/etc/openhands/ca-bundle/ca-bundle.crt", "CURL_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "NODE_EXTRA_CA_CERTS": "/etc/openhands/ca-bundle/ca-bundle.crt"}'
 
@@ -316,11 +322,14 @@ spec:
     # config.yaml; CI (check-secret-checksum) fails if a password field is missing here.
     # Grouped in order: LLM provider keys; app/infra secrets (admin, postgres,
     # redis, jwt, keycloak, litellm, sandbox, plugin-directory, automation); then
-    # auth/integration secrets (bitbucket DC, github, gitlab, slack, laminar).
-    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key")) }}'
+    # auth/integration secrets (bitbucket DC, jira DC, github, gitlab, slack, laminar).
+    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "jira_data_center_client_secret") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key")) }}'
     bitbucketDataCenter:
       enabled: repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}
       host: 'repl{{ ConfigOption "bitbucket_data_center_domain" }}'
+    jiraDc:
+      enabled: repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}
+      linkMethod: 'repl{{ ConfigOption "jira_data_center_link_method" }}'
     github:
       enabled: repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}
     gitlab:

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -68,6 +68,11 @@ spec:
       bitbucket_data_center_client_secret: '{{repl ConfigOption "bitbucket_data_center_client_secret"}}'
       bitbucket_data_center_bot_token: '{{repl ConfigOption "bitbucket_data_center_bot_token"}}'
 
+      # Jira Data Center secrets (OAuth, optional)
+      jira_data_center_base_url: '{{repl ConfigOption "jira_data_center_base_url"}}'
+      jira_data_center_client_id: '{{repl ConfigOption "jira_data_center_client_id"}}'
+      jira_data_center_client_secret: '{{repl ConfigOption "jira_data_center_client_secret"}}'
+
       # GitHub credentials
       github_oauth_client_id: '{{repl ConfigOption "github_oauth_client_id"}}'
       github_oauth_client_secret: '{{repl ConfigOption "github_oauth_client_secret"}}'


### PR DESCRIPTION
## Summary

Adds the Replicated/KOTS wiring needed to enable Jira Data Center in OHE installs.

- adds a Jira Data Center KOTS config section with OAuth and email-match linking modes
- wires `jiraDc` chart values, Jira DC env vars, webhook ingress route, and the frontend Jira DC feature flag
- adds the `jira-dc-app` secret template and Replicated secret values for OAuth settings
- includes `jira_data_center_client_secret` in the Replicated secret checksum so OAuth secret changes roll pods
- bumps `openhands` to `0.7.26` and `openhands-secrets` to `0.1.19`

## Stack notes

The automation forwarding PR remains separate and stacked on this branch: #653

## Validation
Tested end to end successfully:
<img width="764" height="733" alt="Screenshot 2026-05-21 at 9 34 43 PM" src="https://github.com/user-attachments/assets/bd9f825e-7b87-4398-8a10-b1c06c99751d" />

- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- `make lint` passed; Replicated reported only existing `may-contain-secrets` informational messages.
