### PR TITLE
Mark Bitbucket DC bot token as recommended in KOTS config

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -442,7 +442,7 @@ spec:
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true
         - name: bitbucket_data_center_bot_token
-          title: Bitbucket Data Center Bot Token (optional but recommended)
+          title: Bitbucket Data Center Bot Token (optional but strongly recommended)
           help_text: >-
             HTTP access token for a dedicated bot user (e.g. openhands-bot)
             with repo access. When set, OpenHands posts comments and reactions

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -442,11 +442,11 @@ spec:
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true
         - name: bitbucket_data_center_bot_token
-          title: Bitbucket Data Center Bot Token (optional)
+          title: Bitbucket Data Center Bot Token (optional but recommended)
           help_text: >-
             HTTP access token for a dedicated bot user (e.g. openhands-bot)
             with repo access. When set, OpenHands posts comments and reactions
-            as the bot instead of the mentioning user or installer; jobs still
+            as the bot instead of as the mentioning user or installer; jobs still
             run on the invoking user's workspace.
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'


### PR DESCRIPTION
## What

Relabels the `bitbucket_data_center_bot_token` KOTS config item from **"(optional)"** to **"(optional but recommended)"** (plus a small grammar fix in the help text). The field stays technically optional — no `required: true` — so existing installs are unaffected.

## Why

Without a dedicated bot token, OpenHands falls back to posting Bitbucket Data Center comments and reactions using the **installer's OAuth credentials**. Those credentials expire over time, and once they do OpenHands can no longer post comments or reactions — the integration's fallback responses silently stop working. A dedicated bot user's HTTP access token can be made long-lived, so steering installers toward provisioning one keeps the integration healthy.

## Scope

- `replicated/config.yaml` — title/help-text wording only. No behavioral, schema, or template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)