### PR TITLE
Prepare Replicated release for Jira and Bitbucket DC changes

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.29.1
+appVersion: cloud-1.35.0
 version: 0.7.29
 maintainers:
   - name: rbren

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.28
+version: 0.7.29
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.34.1
+appVersion: cloud-1.34.2
 version: 0.7.29
 maintainers:
   - name: rbren

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.35.0
+appVersion: cloud-1.34.1
 version: 0.7.29
 maintainers:
   - name: rbren

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -124,7 +124,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.35.0
+  tag: cloud-1.34.1
 
 ingress:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -124,7 +124,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.29.1
+  tag: cloud-1.35.0
 
 ingress:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -124,7 +124,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.34.1
+  tag: cloud-1.34.2
 
 ingress:
   enabled: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-be9afb7'
+      tag: 'sha-ae8caca'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-ae8caca'
+      tag: 'sha-a719372'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## Summary
- bump the `openhands` chart to `0.7.29`
- update the chart default app image to `cloud-1.34.2`
- pin the Replicated enterprise-server image override to `sha-a719372`, the OpenHands SHA containing the Jira DC and Bitbucket DC release work plus OpenHands #14570

## Release input SHAs
- OpenHands: `a719372a4ea3cd707958fd280e99dd7f5820ac7c` (`Clarify Jira DC repository access prompt (#14570)`)
- OpenHands release branch/tag: `saas-rel-1.34.2` / `cloud-1.34.2`
- OpenHands-Cloud base: `77ad72758f65581ca6636dcdd3581c110dc8e91f` (`Add Jira DC service account KOTS config`)

## Notes
- Existing `cloud-1.34.0` points at release-branch commit `45b4c6f`, cut from main commit `5c8249bf` for #14557. It does not include OpenHands #14547 or #14570.
- `cloud-1.34.1` is reserved for the separate maintenance release that adds `MAINTENANCE_START_TIME`; our Jira/BBDC patch candidate is `cloud-1.34.2`.
- `cloud-1.34.2` points at `a719372a4ea3cd707958fd280e99dd7f5820ac7c`; it intentionally includes #14547 and #14570 and does not include the later #14566 commit.
- Stable `0.7.25`, Unstable `0.7.28`, and this candidate all inherit automation chart `0.1.9` with `ghcr.io/openhands/automation:sha-cf93073`.

## Validation
- [x] Human tested these changes
- `docker buildx imagetools inspect ghcr.io/openhands/enterprise-server:sha-a719372`
- `docker buildx imagetools inspect ghcr.io/openhands/enterprise-server:cloud-1.34.2`
- Verified `sha-a719372` and `cloud-1.34.2` resolve to `sha256:4b9991347238ff3007150d669017134bfea96e1e5519182db4ad4f2178f1a174`
- OpenHands `Tag Docker images` workflow succeeded for `cloud-1.34.2`: https://github.com/OpenHands/OpenHands/actions/runs/26465337296
- `make manifests`
- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- Created Replicated release `880` and promoted it to `codex/release-jira-bbdc-ae8caca` as channel sequence `4`
- Deployed KOTS sequence `28` on R02
- Cleaned internal R02 automation DB drift back to chart-compatible Alembic revision `004` so the chart-pinned automation image deploys without manual image overrides

## Known local validation gap
- `make lint` previously failed while packaging dependencies because `https://github.com/lmnr-ai/lmnr-helm/releases/download/laminar-0.1.13/laminar-0.1.13.tgz` returned 404. This appears unrelated to this release image/tag change.