### PR TITLE
Bump automation image for Jira and Bitbucket DC event sources

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/automation
-  tag: sha-cf93073
+  tag: sha-265208f
 
 imagePullSecrets: []
 

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.29.1
-version: 0.7.28
+version: 0.7.29
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,7 +42,7 @@ dependencies:
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.1.9
+    version: 0.1.10
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/all-hands-ai/helm-charts


### PR DESCRIPTION
## Summary
- bump the automation chart to `0.1.10`
- pin the automation image to `sha-265208f`
- update the OpenHands chart dependency to automation `0.1.10`

## Automation SHA
- `265208f61cfb96db78cf48da46dddcf8402a1e2f`
- Includes Jira DC automation event source (`d0d8496`, automation #136)
- Includes Bitbucket DC automation event source (`d3e7fac`, automation #137)
- Also includes later merged automation fixes through automation #140

## Notes
- This is intentionally separate from OpenHands-Cloud #661 so we can test the automation image bump independently.
- This PR also bumps the `openhands` chart to `0.7.29` because its automation dependency version changes; if #661 merges first, this will need a small rebase/version adjustment.

## Validation
- automation repo CI/Docker passed for `265208f`
- `make manifests`
- `uv run --with pyyaml python scripts/check_secret_checksum.py`