### PR TITLE
Add top-level `enabled` flag to openhands chart

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.34.0
-version: 0.7.30
+version: 0.7.31
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ca-bundle.yaml
+++ b/charts/openhands/templates/ca-bundle.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.caBundle.enabled }}
+{{- if and .Values.enabled .Values.caBundle.enabled }}
 {{- $userCA := .Values.caBundle.userCA | trim }}
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle

--- a/charts/openhands/templates/certificate.yaml
+++ b/charts/openhands/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certificate.enabled }}
+{{- if and .Values.enabled .Values.certificate.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/openhands/templates/crd-check-hook.yaml
+++ b/charts/openhands/templates/crd-check-hook.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.enabled }}
 {{- include "crd-check.hook" . }}
+{{- end }}

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,3 +127,4 @@ spec:
         env:
         {{- include "openhands.env" . | nindent 8 }}
         {{- include "openhands.caBundle.env" . | nindent 8 }}
+{{- end }}

--- a/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
+++ b/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
@@ -1,5 +1,5 @@
 
-{{- if .Values.enrichUserInteractionData.enabled }}
+{{- if and .Values.enabled .Values.enrichUserInteractionData.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openhands/templates/gitlab-webhook-verify-cronjob.yaml
+++ b/charts/openhands/templates/gitlab-webhook-verify-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gitlabWebhookInstallation.enabled }}
+{{- if and .Values.enabled .Values.gitlabWebhookInstallation.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openhands/templates/hpa.yaml
+++ b/charts/openhands/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.enabled .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/openhands/templates/ingress-automation.yaml
+++ b/charts/openhands/templates/ingress-automation.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.automation.enabled }}
+{{- if and .Values.enabled .Values.ingress.enabled .Values.automation.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -17,7 +17,7 @@
   rule, container probes, and the SPA bundle's baked-in
   `NEXT_PUBLIC_BASE_PATH` always agree.
 */}}
-{{- if and .Values.ingress.enabled (index .Values "integrations-hub" "enabled") }}
+{{- if and .Values.enabled .Values.ingress.enabled (index .Values "integrations-hub" "enabled") }}
 {{- $rootPath := index .Values "integrations-hub" "rootPath" | default "/integrations-hub" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.enabled .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openhands/templates/ingress-mcp.yaml
+++ b/charts/openhands/templates/ingress-mcp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.enabled .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openhands/templates/ingress-plugin-directory.yaml
+++ b/charts/openhands/templates/ingress-plugin-directory.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (index .Values "plugin-directory").enabled }}
+{{- if and .Values.enabled .Values.ingress.enabled (index .Values "plugin-directory").enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openhands/templates/ingress-root.yaml
+++ b/charts/openhands/templates/ingress-root.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.enabled .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openhands/templates/integration-events-deployment.yaml
+++ b/charts/openhands/templates/integration-events-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,3 +83,4 @@ spec:
         env:
         {{- include "openhands.env" . | nindent 8 }}
         {{- include "openhands.caBundle.env" . | nindent 8 }}
+{{- end }}

--- a/charts/openhands/templates/integration-events-service.yaml
+++ b/charts/openhands/templates/integration-events-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
   selector:
     app: openhands-integrations
   type: ClusterIP
+{{- end }}

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keycloak.enabled }}
+{{- if and .Values.enabled .Values.keycloak.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/openhands/templates/keycloak-realm-template.yaml
+++ b/charts/openhands/templates/keycloak-realm-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keycloak.enabled }}
+{{- if and .Values.enabled .Values.keycloak.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/openhands/templates/litellm-config-script.yaml
+++ b/charts/openhands/templates/litellm-config-script.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -55,3 +56,4 @@ data:
         echo "ERROR: Unexpected response code: $HTTP_CODE"
         exit 1
     fi
+{{- end }}

--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.maintenanceTasks.enabled }}
+{{- if and .Values.enabled .Values.maintenanceTasks.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openhands/templates/mcp-events-deployment.yaml
+++ b/charts/openhands/templates/mcp-events-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,3 +83,4 @@ spec:
         env:
         {{- include "openhands.env" . | nindent 8 }}
         {{- include "openhands.caBundle.env" . | nindent 8 }}
+{{- end }}

--- a/charts/openhands/templates/mcp-events-service.yaml
+++ b/charts/openhands/templates/mcp-events-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
   selector:
     app: openhands-mcp
   type: ClusterIP
+{{- end }}

--- a/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
+++ b/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proactiveConvoClean.enabled }}
+{{- if and .Values.enabled .Values.proactiveConvoClean.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openhands/templates/resend-sync-cronjob.yaml
+++ b/charts/openhands/templates/resend-sync-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.resendSync.enabled }}
+{{- if and .Values.enabled .Values.resendSync.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openhands/templates/service-account.yaml
+++ b/charts/openhands/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/openhands/templates/service.yaml
+++ b/charts/openhands/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,7 +14,8 @@ spec:
   selector:
     app: openhands
   type: ClusterIP
-{{- if and (index .Values "runtime-api") (index .Values "runtime-api" "enabled") }}
+{{- end }}
+{{- if and .Values.enabled (index .Values "runtime-api") (index .Values "runtime-api" "enabled") }}
 ---
 apiVersion: v1
 kind: Service
@@ -30,7 +32,7 @@ spec:
     app.kubernetes.io/name: runtime-api
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-{{- if .Values.postgresql.enabled }}
+{{- if and .Values.enabled .Values.postgresql.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -49,7 +51,7 @@ spec:
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/component: primary
 {{- end }}
-{{- if and (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
+{{- if and .Values.enabled (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/openhands/templates/tlsstore.yaml
+++ b/charts/openhands/templates/tlsstore.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tlsStore.enabled }}
+{{- if and .Values.enabled .Values.tlsStore.enabled }}
 apiVersion: traefik.io/v1alpha1
 kind: TLSStore
 metadata:

--- a/charts/openhands/templates/troubleshoot/secrets.yaml
+++ b/charts/openhands/templates/troubleshoot/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.replicated.enabled }}
+{{- if and .Values.enabled .Values.replicated.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/openhands/templates/user-waitlist-configmap.yaml
+++ b/charts/openhands/templates/user-waitlist-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.allowedUsers }}
+{{- if and .Values.enabled .Values.allowedUsers }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1,5 +1,13 @@
 allowedUsers: null
 
+# When false, the OpenHands chart's own templates (deployment, services,
+# ingresses, cronjobs, etc.) are skipped. Subcharts (litellm-helm, runtime-api,
+# postgresql, redis, minio, keycloak, automation, plugin-directory,
+# integrations-hub, laminar, replicated) still respect their individual
+# `enabled` flags, so this umbrella chart can be used to deploy any subset of
+# them without the OpenHands app itself.
+enabled: true
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Description

Changing the cloud release process so all dependency updates flow through the openhands chart, giving us a single source of truth for which dependency combinations have been vetted. Some dependencies will still be managed as separate Helm releases — this flag lets the umbrella chart install just those dependencies without also installing the openhands app.

`enabled: true` is the default, so existing installs are unaffected.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Verified `helm template` with defaults renders byte-identical to main (no spurious config-checksum change, so no surprise pod rollout). With `enabled: false`, no resources from `charts/openhands/templates/` render; subcharts continue to respect their own `enabled` flags so any subset can be installed alone.

minio still gates on `filestore.ephemeral` (not its own `enabled`) — left as-is to preserve existing semantics. crd-check is a library chart with no resources, so no condition is needed there.