### PR TITLE
Update helm chart OCI repositories after org rename

### DIFF
--- a/charts/infra/Chart.lock
+++ b/charts/infra/Chart.lock
@@ -6,7 +6,7 @@ dependencies:
   repository: oci://quay.io/jetstack/charts
   version: 0.22.1
 - name: crd-check
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.0
-digest: sha256:3e28e70aa364756fd5869cfe1dc85275396e4b87149932c1be8bef39b10ac6c5
-generated: "2026-05-13T15:45:12.067552-05:00"
+digest: sha256:ee6c9e0ba7c097cc59f0dc12409169a11831b548283b77ec7f8f90a94869ebf5
+generated: "2026-05-27T10:31:04.277099-04:00"

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra
 description: Cluster-wide infrastructure (cert-manager, trust-manager) that the OpenHands application chart depends on
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0.0"
 maintainers:
   - name: all-hands-ai

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -16,5 +16,5 @@ dependencies:
     repository: oci://quay.io/jetstack/charts
     condition: trust-manager.enabled
   - name: crd-check
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -21,19 +21,19 @@ dependencies:
   repository: oci://registry.replicated.com/library
   version: 1.9.0
 - name: runtime-api
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.3.3
+  repository: oci://ghcr.io/openhands/helm-charts
+  version: 0.3.4
 - name: automation
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
-  version: 0.1.9
+  repository: oci://ghcr.io/openhands/helm-charts
+  version: 0.1.10
 - name: crd-check
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.0
 - name: plugin-directory
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.1
 - name: integrations-hub
-  repository: oci://ghcr.io/all-hands-ai/helm-charts
+  repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.0
-digest: sha256:69dda3ea1b463d7b6623250ad4eb6e4b940d3ca03dbd83ec4806881d5075b28c
-generated: "2026-05-22T11:24:47.82372-04:00"
+digest: sha256:1f4476080a68f1cd331046e59f312836700958ac2a23bf95a6368abf28656712
+generated: "2026-05-27T10:30:34.584689-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -37,21 +37,21 @@ dependencies:
     version: 1.9.0
     condition: replicated.enabled
   - name: runtime-api
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.3.4
     condition: runtime-api.enabled
   - name: automation
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.10
     condition: automation.enabled
   - name: crd-check
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0
   - name: plugin-directory
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.1
     condition: plugin-directory.enabled
   - name: integrations-hub
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0
     condition: integrations-hub.enabled

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.34.0
-version: 0.7.29
+version: 0.7.30
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -334,7 +334,7 @@ Now we can install the helm chart.
 
 ```bash
 helm dependency update
-helm upgrade --install openhands --namespace openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands -f site-values.yaml
+helm upgrade --install openhands --namespace openhands oci://ghcr.io/openhands/helm-charts/openhands -f site-values.yaml
 ```
 
 ### Verify your Setup
@@ -388,7 +388,7 @@ litellm-helm:
 Upgrade the release:
 
 ```bash
-helm upgrade --install openhands --namespace openhands oci://ghcr.io/all-hands-ai/helm-charts/openhands -f site-values.yaml
+helm upgrade --install openhands --namespace openhands oci://ghcr.io/openhands/helm-charts/openhands -f site-values.yaml
 ```
 
 ## Hardening

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -251,7 +251,7 @@ maintainers:
   - name: test
 dependencies:
   - name: runtime-api
-    repository: oci://ghcr.io/all-hands-ai/helm-charts
+    repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.10
     condition: runtime-api.enabled
   - name: other-dep


### PR DESCRIPTION
## Description

The runtime-api 0.3.4 helm chart was never published at the old `oci://ghcr.io/all-hands-ai/helm-charts` path after the GitHub org was renamed to `openhands`, breaking `helm dependency update` on main.

This points the chart dependencies, install docs, and a test fixture at the new path.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

The rendered chart output is unchanged (same dependency packages, just pulled from a different OCI URL). Version bumps on `openhands` (0.7.29 → 0.7.30) and `infra` (0.1.1 → 0.1.2) are purely to satisfy the chart-version validator.

The `maintainers: - name: all-hands-ai` label in `charts/infra/Chart.yaml` and `charts/crd-check/Chart.yaml` is left as-is; it's a free-form label, not a URL.