### PR TITLE
[PLTF-2876] Support custom LLM extra headers in Replicated

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -919,6 +919,28 @@ spec:
       title: Advanced Options
       description: Optional components and advanced configuration settings
       items:
+        - name: custom_llm_extra_headers
+          title: Custom LLM Extra HTTP Headers (JSON, stopgap)
+          help_text: |
+            STOPGAP. This setting will be replaced by an organization-level
+            setting in the OpenHands application in a future release. Use only
+            if your upstream LLM gateway requires static auth or routing
+            headers that cannot be expressed via the standard Authorization
+            bearer header.
+
+            Format: JSON object mapping header names to values. These headers
+            are applied to every request from LiteLLM Proxy to the upstream
+            gateway for all users in this deployment. Leave blank for none.
+
+            Example: {"Ocp-Apim-Subscription-Key": "abc123", "X-Tenant-Id": "prod"}
+          type: textarea
+          default: ""
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
+          required: false
+          validation:
+            regex:
+              pattern: '(?s)^\s*(\{\s*\}|\{\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*(,\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*)*\})?\s*$'
+              message: Must be blank or a JSON object with string values, such as {"Header-Name":"value"}
         - name: automations_enabled
           title: Enable Automations
           help_text: Deploy the Automations UI and backend. If you use an external PostgreSQL instance, make sure the automations database requirements are satisfied before enabling this option.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -676,6 +676,7 @@ spec:
                   model: 'openai/{{repl ConfigOption "custom_model"}}'
                   api_key: os.environ/CUSTOM_API_KEY
                   api_base: os.environ/CUSTOM_API_BASE
+                  extra_headers: repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}
 
     - when: '{{repl ConfigOptionEquals "google_api_type" "vertex" }}'
       recursiveMerge: true


### PR DESCRIPTION
## Description

Closes #664.

Adds a Replicated Advanced Options textarea for Custom LLM installs to configure static upstream HTTP headers as JSON, then renders that JSON into the bundled LiteLLM Proxy `custom-llm` model entry as `litellm_params.extra_headers`.

This is intentionally a stopgap for gateway-style auth/routing headers such as Azure APIM subscription keys. The installer help text calls out that this should be replaced by an org-level OpenHands setting later.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values
- [x] Human tested these changes

## Validation

- `uv run --with pyyaml python ...` YAML + JSON-header regex smoke check
- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- `make lint` passes with only existing info-level `may-contain-secrets` warnings
- Published Replicated branch release `codex/custom-llm-extra-headers`, sequence `885`, version `0.7.30`
- Deployed to replicated-03 / `alonacorp3` and configured Custom LLM with:
  - `custom_base_url=http://header-capture.openhands.svc.cluster.local:8080/v1`
  - `custom_llm_extra_headers={"Ocp-Apim-Subscription-Key":"amd-test-key","X-Gateway-Tenant":"amd-poc"}`
- Verified rendered `openhands-litellm-config` contains `extra_headers` for `custom-llm`
- Verified non-streaming and streaming requests through `http://openhands-litellm:4000/v1/chat/completions` return `200`
- Verified the upstream capture service received both headers on `/v1/chat/completions`:
  - `ocp-apim-subscription-key: amd-test-key`
  - `x-gateway-tenant: amd-poc`

## Additional Notes

The new config field is additive, defaults to blank, and is only shown when `llm_provider == custom`; blank input renders as `{}` and preserves existing behavior. Header values are rendered into the LiteLLM ConfigMap as plaintext, matching the issue's stopgap scope rather than the desired long-term secure org-level setting.

`main` already contains the `charts/openhands/Chart.yaml` bump to `0.7.30`, so after rebasing this PR only contains the Replicated config/render changes.
