### PR TITLE
[PLTF-2876] Support custom LLM extra headers in Replicated

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -301,11 +301,6 @@ spec:
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
-        - name: litellm_forward_client_headers
-          title: Forward Client Headers to LLM Providers
-          help_text: Forward client x-* request headers and anthropic-beta through LiteLLM to upstream LLM providers. Leave disabled unless you trust callers and need provider-visible custom headers.
-          type: bool
-          default: "0"
 
     - name: security_secrets
       title: Security & Authentication
@@ -915,12 +910,42 @@ spec:
           when: 'repl{{ ConfigOptionEquals "analytics_enabled" "1" }}'
           required: false
 
-    - name: advanced_options
-      title: Advanced Options
-      description: Optional components and advanced configuration settings
+    - name: automations_configuration
+      title: Automations
+      description: Configure the Automations UI and backend
       items:
         - name: automations_enabled
           title: Enable Automations
           help_text: Deploy the Automations UI and backend. If you use an external PostgreSQL instance, make sure the automations database requirements are satisfied before enabling this option.
           type: bool
           default: "0"
+
+    - name: advanced_options
+      title: Advanced Options
+      description: Optional components and advanced configuration settings
+      items:
+        - name: litellm_forward_client_headers
+          title: Enable Forwarding Client Headers Through LiteLLM to LLM Providers
+          help_text: >-
+            Forward selected headers from each client request through LiteLLM to upstream LLM providers. When enabled, LiteLLM forwards the anthropic-beta header and client x-* headers, except x-stainless-* headers. It does not forward Authorization or non-x-* gateway headers such as Ocp-Apim-Subscription-Key. Leave disabled unless you need provider-visible client headers. Use Custom LLM Extra HTTP Headers for static gateway auth or routing headers.
+          type: bool
+          default: "0"
+        - name: custom_llm_extra_headers_enabled
+          title: Enable Custom LLM Extra HTTP Headers (JSON)
+          help_text: >-
+            Show a JSON field for static headers that the bundled OpenHands LiteLLM Proxy sends on every request to the custom upstream gateway for all users in this deployment. NOTE: This is intended as temporary installer-level configuration until organization-level header settings are available in OpenHands. Use only if your upstream LLM gateway requires static auth or routing headers that cannot be expressed via the standard Authorization bearer header.
+          type: bool
+          default: "0"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
+        - name: custom_llm_extra_headers
+          title: Custom LLM Extra HTTP Headers (JSON)
+          help_text: >-
+            Format: JSON object mapping header names to values. Example: {"Ocp-Apim-Subscription-Key": "abc123", "X-Tenant-Id": "prod"}
+          type: textarea
+          default: ""
+          when: 'repl{{ and (ConfigOptionEquals "llm_provider" "custom") (ConfigOptionEquals "custom_llm_extra_headers_enabled" "1") }}'
+          required: false
+          validation:
+            regex:
+              pattern: '(?s)^\s*(\{\s*\}|\{\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*(,\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*)*\})?\s*$'
+              message: Must be blank or a JSON object with string values, such as {"Header-Name":"value"}

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -676,6 +676,7 @@ spec:
                   model: 'openai/{{repl ConfigOption "custom_model"}}'
                   api_key: os.environ/CUSTOM_API_KEY
                   api_base: os.environ/CUSTOM_API_BASE
+                  extra_headers: repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}repl{{ else }}{}repl{{ end }}
 
     - when: '{{repl ConfigOptionEquals "google_api_type" "vertex" }}'
       recursiveMerge: true


### PR DESCRIPTION
## Description

Closes #664.

Adds a Replicated Advanced Options checkbox for Custom LLM installs. When enabled, it reveals a JSON textarea for static upstream HTTP headers and renders that JSON into the bundled LiteLLM Proxy `custom-llm` model entry as `litellm_params.extra_headers`.

This is temporary installer-level configuration for gateway-style auth/routing headers such as Azure APIM subscription keys. The installer help text calls out that this should be replaced by an org-level OpenHands setting later.

This also moves the existing "Forward Client Headers to LLM Providers" toggle into Advanced Options and clarifies its actual forwarding behavior: LiteLLM forwards client `x-*` headers, except `x-stainless-*`, plus `anthropic-beta`; it does not forward `Authorization` or non-`x-*` gateway headers.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values
- [x] Human tested these changes

## Validation

- `uv run --with pyyaml python ...` YAML + JSON-header regex smoke check
- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- `make lint` passes with only existing info-level `may-contain-secrets` warnings
- Published Replicated branch release `alona/custom-llm-extra-headers`, release sequence `895`, version `0.7.30`
- Deployed to replicated-03 / `alonacorp3` as KOTS app sequence `12` with:
  - `custom_base_url=http://header-capture.openhands.svc.cluster.local:8080/v1`
  - `custom_llm_extra_headers_enabled=1`
  - `custom_llm_extra_headers={"Ocp-Apim-Subscription-Key":"test-key","X-Gateway-Tenant":"poc"}`
- Verified rendered `openhands-litellm-config` contains `extra_headers` for `custom-llm`:
  - `Ocp-Apim-Subscription-Key: test-key`
  - `X-Gateway-Tenant: poc`
- Verified a request through `http://openhands-litellm:4000/v1/chat/completions` returns `200`
- Verified the upstream capture service receives both static headers on `/v1/chat/completions`:
  - `ocp-apim-subscription-key: test-key`
  - `x-gateway-tenant: poc`
- Tested existing forwarded-header behavior on replicated-03:
  - With `litellm_forward_client_headers=0`, client `X-Forwarded-Smoke` and `Anthropic-Beta` did not reach the upstream capture service.
  - With `litellm_forward_client_headers=1`, client `X-Forwarded-Smoke: enabled-client-value-0527` and `Anthropic-Beta: enabled-beta-0527` reached upstream.
  - Client `Ocp-Apim-Subscription-Key` did not forward through this feature; upstream continued to receive the static `extra_headers` value.
  - Restored replicated-03 back to `litellm_forward_client_headers=0` afterward.

## Additional Notes

The new config fields are additive, default off/blank, and are only shown for `llm_provider == custom`; with the checkbox disabled, rendered `extra_headers` is `{}` and preserves existing behavior. Header values are rendered into the LiteLLM ConfigMap as plaintext, matching the issue's temporary installer-level scope rather than the desired long-term secure org-level setting.

The Custom LLM header controls remain in Advanced Options. Automations has its own config section below Analytics, and the header field help text uses folded paragraphs so the admin console can wrap it naturally.

`main` already contains the `charts/openhands/Chart.yaml` bump to `0.7.30`, so after rebasing this PR only contains the Replicated config/render changes.
