### PR TITLE
Clarify Jira DC OAuth setup help and harden Keycloak mapper sync

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.34.0
-version: 0.7.32
+version: 0.7.33
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -167,7 +167,7 @@ data:
       for alias in $(jq -r '.identityProviders[].alias' $REALM_JSON); do
         EXISTING_MAPPERS=$(curl -s "$KC_REALM/identity-provider/instances/$alias/mappers" \
           -H "Authorization: Bearer $ACCESS_TOKEN")
-        if echo "$EXISTING_MAPPERS" | jq -e 'type == "object" and has("error")' >/dev/null; then
+        if ! echo "$EXISTING_MAPPERS" | jq -e 'type == "array"' >/dev/null 2>&1; then
           echo "  Skipping mappers for $alias: $EXISTING_MAPPERS"
           continue
         fi

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -167,6 +167,10 @@ data:
       for alias in $(jq -r '.identityProviders[].alias' $REALM_JSON); do
         EXISTING_MAPPERS=$(curl -s "$KC_REALM/identity-provider/instances/$alias/mappers" \
           -H "Authorization: Bearer $ACCESS_TOKEN")
+        if echo "$EXISTING_MAPPERS" | jq -e 'type == "object" and has("error")' >/dev/null; then
+          echo "  Skipping mappers for $alias: $EXISTING_MAPPERS"
+          continue
+        fi
         for mapper_name in $(jq -r --arg a "$alias" \
           '.identityProviderMappers[] | select(.identityProviderAlias == $a) | .name' $REALM_JSON); do
 
@@ -175,7 +179,7 @@ data:
             $REALM_JSON > /tmp/mapper.json
 
           EXISTING_ID=$(echo "$EXISTING_MAPPERS" | jq -r --arg n "$mapper_name" \
-            '.[] | select(.name == $n) | .id')
+            '.[] | objects | select(.name == $n) | .id')
 
           if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
             jq --arg id "$EXISTING_ID" '. + {id: $id}' /tmp/mapper.json > /tmp/mapper-update.json

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -540,7 +540,7 @@ spec:
           required: true
         - name: jira_data_center_client_id
           title: Jira Data Center OAuth Client ID
-          help_text: Client ID from the OAuth 2.0 application on your Jira Data Center server (callback URL https://app.YOUR-DOMAIN/integration/jira-dc/callback).
+          help_text: Client ID from the OAuth 2.0 application on your Jira Data Center server.
           type: text
           when: 'repl{{ and (ConfigOptionEquals "jira_data_center_enabled" "1") (ConfigOptionEquals "jira_data_center_link_method" "oauth") }}'
           required: true

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -502,7 +502,9 @@ spec:
           title: How should Jira users be linked to OpenHands accounts?
           help_text: >-
             OAuth (recommended): each user proves ownership of their Jira account via your server's
-            OAuth 2.0 application. This is the most secure option. Email match: users are linked by
+            OAuth 2.0 application. When creating the OAuth app in Jira, use
+            https://app.<your-openhands-domain>/integration/jira-dc/callback as the callback URL,
+            then enter the app's client ID and secret below. Email match: users are linked by
             matching their Jira email to their OpenHands email. Use this only if your Jira Data Center
             server does not have an OAuth 2.0 application configured.
           type: select_one

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -447,12 +447,12 @@ spec:
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true
         - name: bitbucket_data_center_bot_token
-          title: Bitbucket Data Center Bot Token (optional but strongly recommended)
+          title: Bitbucket Data Center Bot Token (strongly recommended)
           help_text: >-
-            HTTP access token for a dedicated bot user (e.g. openhands-bot)
-            with repo access. When set, OpenHands posts comments and reactions
-            as the bot instead of as the mentioning user or installer; jobs still
-            run on the invoking user's workspace.
+            HTTP access token for a dedicated bot user with repo access. When
+            set, OpenHands posts comments and reactions as the bot instead of
+            as the mentioning user or installer; jobs still run on the invoking
+            user's workspace.
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
 


### PR DESCRIPTION
## Summary
- remove the callback URL from the Jira Data Center OAuth Client ID field help so the field clearly expects only a Client ID
- move callback URL guidance into the OAuth linking-method help text, where it is framed as part of creating the Jira OAuth app
- clarify the Bitbucket Data Center bot token label/help text so it says strongly recommended without implying the field is required
- harden the Keycloak identity-provider mapper sync when an existing provider endpoint returns a non-list error response
- bump the OpenHands chart version for the chart template change

## Callback URL discoverability
The Jira Data Center OAuth callback URL is still surfaced in KOTS, but no longer inside the Client ID field help. It now appears in the OAuth linking-method help text as setup guidance: create the Jira OAuth app with `https://app.<your-openhands-domain>/integration/jira-dc/callback`, then enter the generated client ID and secret. The companion docs PR is OpenHands/docs#528 and includes the same callback URL in the Jira Data Center OAuth application setup step.

## Test
- `git diff --check -- replicated/config.yaml`
- `ruby -e 'require "yaml"; YAML.load_file("replicated/config.yaml"); puts "yaml ok"'`
- `make lint`
- local reproduction of `validate-chart-versions` passed after bumping `charts/openhands/Chart.yaml` from `0.7.32` to `0.7.33`

## Deployment validation
- Published Replicated release 894 to channel `alona/remove-jira-dc-client-id-callback-help`.
- Deployed KOTS sequence 31 to R02.
- Verified R02 app endpoint returns 200, Admin Console returns 302, and `openhands`, `openhands-integrations`, `openhands-mcp`, `automation`, and `replicated` deployments are available.