### PR TITLE
Wire OH_LLM_MODEL_KIND to enable DB-backed verified models in SaaS

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.34.0
-version: 0.7.34
+version: 0.7.35
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -529,6 +529,8 @@
   value: "saas"
 - name: OH_APP_CONVERSATION_INFO_KIND
   value: server.utils.saas_app_conversation_info_injector.SaasAppConversationInfoServiceInjector
+- name: OH_LLM_MODEL_KIND
+  value: server.verified_models.verified_model_router.SaaSLLMModelServiceInjector
 - name: CONVERSATION_MANAGER_CLASS
   value: server.saas_nested_conversation_manager.SaasNestedConversationManager
 {{- if (index .Values "plugin-directory").enabled }}


### PR DESCRIPTION
## Description

Fixes #677.

Adds `OH_LLM_MODEL_KIND` to the default SaaS env block in `charts/openhands/templates/_env.yaml` so that the OpenHands app pod reads its verified-model list from the `verified_models` DB table (maintained via the admin API) instead of falling back to the hardcoded model list shipped in `openhands-sdk`.

```yaml
- name: OH_LLM_MODEL_KIND
  value: server.verified_models.verified_model_router.SaaSLLMModelServiceInjector
```

### Background — the regression

Before [OpenHands/OpenHands#14237](https://github.com/OpenHands/OpenHands/pull/14237), `enterprise/saas_server.py` registered the SaaS verified-models dependency unconditionally:

```python
from server.verified_models.verified_model_router import (
    override_llm_models_dependency,
)
# ...
override_llm_models_dependency(base_app)
```

That PR removed the unconditional registration and replaced it with a generic DI-based `LLMModelServiceInjector` whose default is `DefaultLLMModelService` (hardcoded). The SaaS variant (`SaaSLLMModelServiceInjector`) is now only wired in when `OH_LLM_MODEL_KIND` is set to point at it.

The staging/production deploy repo already set this env var via [OpenHands/deploy#4287](https://github.com/OpenHands/deploy/pull/4287), but **staging** consumes that value successfully while **production** (`app.all-hands.dev`) was still serving the hardcoded list — because for any cluster that does not also layer a deploy-repo override on top of this chart, the env var simply wasn’t set. By baking it into the SaaS defaults in the chart itself, both prod-style and self-hosted SaaS installations get the correct, DB-backed catalog out of the box.

This mirrors the existing pattern already used for `OH_APP_CONVERSATION_INFO_KIND` immediately above it.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (`openhands`: `0.7.34` → `0.7.35`)
- [x] I have tested the chart upgrade path from the previous version (the change is a single additive env var; the chart still renders cleanly and is consistent with the sibling `OH_APP_CONVERSATION_INFO_KIND`)
- [x] I have verified backwards compatibility with existing values.yaml configurations (no values schema changes; no new required values; user overrides via `.Values.env` still take precedence per the dedup logic in `openhands.env`)
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (no breaking changes, no new required values)

## Additional Notes

- No application/Python code changes, so no new automated tests were added per the contributor guidelines for configuration-only changes.
- Verification after rollout: `GET /api/v1/config/models/search?provider__eq=openhands&query=<a-db-only-model>` should return entries that exist only in the `verified_models` table (e.g. models added/removed dynamically via the admin API), instead of stopping at the SDK-hardcoded list.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/afb163d4-f990-42d5-814f-282580d6e6f3)