### PR TITLE
Validate TLS cert/key PEM file uploads in Replicated config

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -76,17 +76,36 @@ spec:
           help_text: Upload your TLS certificate file (.crt or .pem)
           type: file
           required: true
+          # Validation runs against the base64-decoded file contents, so we can
+          # check for the PEM header directly. This catches the common mistake of
+          # uploading the private key (or a key/cert swap) into the certificate field.
+          validation:
+            regex:
+              pattern: '-----BEGIN CERTIFICATE-----'
+              message: 'This file does not look like a PEM certificate (expected a "-----BEGIN CERTIFICATE-----" block).'
         - name: tls_private_key
           title: TLS Private Key
           help_text: Upload your TLS private key file (.key or .pem)
           type: file
           required: true
+          # Matches PRIVATE KEY, RSA/EC/DSA/ENCRYPTED/OPENSSH PRIVATE KEY, but NOT
+          # "BEGIN CERTIFICATE" -- so a cert accidentally uploaded here is rejected.
+          validation:
+            regex:
+              pattern: '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+              message: 'This file does not look like a PEM private key (expected a "-----BEGIN PRIVATE KEY-----" block).'
         - name: tls_ca_certificate
           title: Additional Trusted CA Certificates
           help_text: Upload a root CA certificate in PEM format. Concatenate multiple PEM-encoded certificates in the same file to add them all to the cluster's default trust store. If the TLS certificate provided above is self-signed, include the CA that signed it here so components inside the cluster can validate it.
           type: file
           required: false
           recommended: true
+          # Optional, so this only runs when a file is provided (empty values skip
+          # validation). Guards against pasting a key into the CA bundle field.
+          validation:
+            regex:
+              pattern: '-----BEGIN CERTIFICATE-----'
+              message: 'This file does not look like a PEM certificate (expected a "-----BEGIN CERTIFICATE-----" block).'
 
     - name: llm_configuration
       title: LLM Configuration


### PR DESCRIPTION
## Description

Customers have accidentally uploaded their public certificate into the **TLS Private Key** field in the Replicated installer. That produces a broken install that's hard to diagnose after the fact.

This adds `validation.regex` to the TLS file items in `replicated/config.yaml`. The admin console now blocks Save/Deploy when an uploaded file doesn't contain the expected PEM block, with a message pointing at the likely mistake.

- `tls_private_key` must contain a `BEGIN ... PRIVATE KEY` block (rejects a cert pasted here - the reported bug)
- `tls_certificate` must contain a `BEGIN CERTIFICATE` block (catches the reverse swap)
- `tls_ca_certificate` (optional) must contain a `BEGIN CERTIFICATE` block, only checked when a file is provided

I went with config-item validation rather than a preflight on purpose. It blocks *before* config is saved, and it never copies private-key material into a preflight or support bundle the way an analyzer-based check would.

The non-obvious part is why a plain PEM-header regex works on a file upload. KOTS validates the **base64-decoded** file contents (not the raw blob), and matching is unanchored substring via Go's `regexp.MatchString`. I confirmed that against the kots source rather than the docs, since the docs don't state either behavior.

## Helm Chart Checklist

N/A - this only touches the Replicated KOTS config (`replicated/config.yaml`). No helm charts were modified.

## Additional Notes

Verification:
- `make lint` / `replicated release lint` pass clean (only pre-existing `may-contain-secrets` info notices).
- Released to the `jl/validate-tls-private-key` channel (sequence 912) for manual admin-console testing.
- I scripted the regexes against sample PKCS8/RSA/EC/encrypted/OpenSSH keys and cert chains: every real key/cert passes in its own field, and both swap directions fail.

Scope worth flagging: this is a header check. It catches wrong-file and cert/key swaps, but it does not verify cryptographic validity or that the cert and key actually pair. Cross-field pairing would need a preflight, with the secret-handling trade-off noted above.

I haven't yet clicked through the swap case in a live admin console - that's the one thing left to confirm on the test channel.