### PR TITLE
fix: propagate external Postgres port in OHE charts

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.37.2
-version: 0.7.38
+version: 0.7.39
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.6
+    version: 0.3.7
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -345,7 +345,7 @@
 - name: DB_HOST
   value: "{{ .Release.Name }}-postgresql"
 - name: DB_PORT
-  value: "{{ .Values.postgresql.service.ports.postgresql | default 5432 }}"
+  value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -344,6 +344,8 @@
 {{- if .Values.postgresql.enabled }}
 - name: DB_HOST
   value: "{{ .Release.Name }}-postgresql"
+- name: DB_PORT
+  value: "{{ .Values.postgresql.service.ports.postgresql | default 5432 }}"
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME
@@ -351,6 +353,8 @@
 {{- else }}
 - name: DB_HOST
   value: "{{ .Values.externalDatabase.host }}"
+- name: DB_PORT
+  value: "{{ .Values.externalDatabase.port | default 5432 }}"
 - name: DB_USER
   value: "{{ .Values.externalDatabase.username }}"
 - name: DB_NAME

--- a/charts/openhands/templates/_init-containers.yaml
+++ b/charts/openhands/templates/_init-containers.yaml
@@ -5,10 +5,10 @@
   command: ['sh', '-c']
   args:
     - |
-      echo "Waiting for PostgreSQL at $DB_HOST to be ready..."
+      echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT to be ready..."
       # pg_isready succeeds even if the database doesn't exist yet;
       # we pass credentials and database to avoid failed auth log entries.
-      until PGPASSWORD=$DB_PASS pg_isready -h $DB_HOST -p 5432 -U $DB_USER -d $DB_NAME > /dev/null 2>&1; do
+      until PGPASSWORD=$DB_PASS pg_isready -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME > /dev/null 2>&1; do
         echo "PostgreSQL is unavailable - sleeping for 2 seconds"
         sleep 2
       done
@@ -23,7 +23,7 @@
   args:
     - |
       export PGPASSWORD=$DB_PASS
-      PSQL="psql -h $DB_HOST -p 5432 -U $DB_USER"
+      PSQL="psql -h $DB_HOST -p $DB_PORT -U $DB_USER"
 
       for db in $DB_NAME $DATABASES; do
         echo "Ensuring database \"$db\" exists..."

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -549,12 +549,12 @@ postgresql:
       scriptsConfigMap: ""
     persistence:
       enabled: false
+    service:
+      ports:
+        postgresql: 5432
     # Add the following if using Karpenter with persistence
     # podAnnotations:
     #   karpenter.sh/do-not-evict: "true"
-  service:
-    ports:
-      postgresql: 5432
   image:
     repository: bitnamilegacy/postgresql
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -560,6 +560,7 @@ postgresql:
 
 externalDatabase:
   enabled: false
+  port: "5432"
   existingSecret: postgres-password
 
 redis:
@@ -664,6 +665,7 @@ runtime-api:
     tls: true
   env:
     DB_HOST: oh-main-postgresql
+    DB_PORT: "5432"
     DB_USER: postgres
     DB_NAME: runtime_api_db
     K8S_NAMESPACE: "openhands"

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.6 # Change this to trigger a new helm chart version being published
+version: 0.3.7 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -42,7 +42,7 @@
 - name: DB_HOST
   value: "{{ .Release.Name }}-postgresql"
 - name: DB_PORT
-  value: "{{ .Values.postgresql.service.ports.postgresql | default 5432 }}"
+  value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -41,6 +41,8 @@
 {{- if .Values.postgresql.enabled }}
 - name: DB_HOST
   value: "{{ .Release.Name }}-postgresql"
+- name: DB_PORT
+  value: "{{ .Values.postgresql.service.ports.postgresql | default 5432 }}"
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME

--- a/charts/runtime-api/templates/_init-containers.yaml
+++ b/charts/runtime-api/templates/_init-containers.yaml
@@ -5,10 +5,10 @@
   command: ['sh', '-c']
   args:
     - |
-      echo "Waiting for PostgreSQL at $DB_HOST to be ready..."
+      echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT to be ready..."
       # pg_isready succeeds even if the database doesn't exist yet;
       # we pass credentials and database to avoid failed auth log entries.
-      until PGPASSWORD=$DB_PASS pg_isready -h $DB_HOST -p 5432 -U $DB_USER -d $DB_NAME > /dev/null 2>&1; do
+      until PGPASSWORD=$DB_PASS pg_isready -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME > /dev/null 2>&1; do
         echo "PostgreSQL is unavailable - sleeping for 2 seconds"
         sleep 2
       done
@@ -23,7 +23,7 @@
   args:
     - |
       export PGPASSWORD=$DB_PASS
-      PSQL="psql -h $DB_HOST -p 5432 -U $DB_USER"
+      PSQL="psql -h $DB_HOST -p $DB_PORT -U $DB_USER"
 
       echo "Ensuring database \"$DB_NAME\" exists..."
       $PSQL -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1 || \

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-8eec12a
+  tag: sha-53e1769
   pullPolicy: Always
 
 imagePullSecrets:
@@ -117,14 +117,14 @@ postgresql:
   primary:
     persistence:
       enabled: false
+    service:
+      ports:
+        postgresql: 5432
   auth:
     username: postgres
     password: "" # This should be set externally for security reasons
     existingSecret: postgres-password
     database: runtime_api_db
-  service:
-    ports:
-      postgresql: 5432
   image:
     repository: bitnamilegacy/postgresql
 

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-53e1769
+  tag: sha-0385b6b
   pullPolicy: Always
 
 imagePullSecrets:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -136,6 +136,7 @@ externalDatabase:
 database:
   create: false # Will only be true for AWS as it can't create the DB in terraform
   secretName: runtime-api-db-credentials # Secret containing external database credentials
+  port: "5432"
   poolSize:
     api: 5 # Pool size for API deployment (default)
     cronjobs: 2 # Pool size for cronjobs (default)

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-f74dce0
+  tag: sha-8eec12a
   pullPolicy: Always
 
 imagePullSecrets:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -94,6 +94,7 @@ spec:
               {{repl ConfigOptionData "tls_certificate" | nindent 14}}
       externalDatabase:
         host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
         existingSecret: postgres-password
         existingSecretUserKey: username
         existingSecretPasswordKey: password
@@ -136,6 +137,7 @@ spec:
       db:
         # TODO: should the fallback be openhands-postgresql here?
         endpoint: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}/$(DATABASE_NAME)'
         secret:
           name: postgres-password
           usernameKey: username
@@ -239,6 +241,7 @@ spec:
         dead_seconds: repl{{ ConfigOption "sandbox_dead_seconds" }}
       env:
         DB_HOST: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+        DB_PORT: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
@@ -415,14 +418,17 @@ spec:
           # existingSecretPasswordKey: password
         keycloak:
           externalDatabase:
+            port: '{{repl ConfigOption "external_postgres_port"}}'
             database: '{{repl ConfigOption "external_postgres_keycloak_database"}}'
         litellm-helm:
           db:
+            url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl ConfigOption "external_postgres_port"}}/$(DATABASE_NAME)'
             database: '{{repl ConfigOption "external_postgres_litellm_database"}}'
         runtime-api:
           databaseMigrations:
             createDatabases: repl{{ ConfigOptionEquals "external_postgres_create_databases" "1" }}
           env:
+            DB_PORT: '{{repl ConfigOption "external_postgres_port"}}'
             DB_NAME: '{{repl ConfigOption "external_postgres_runtime_api_database"}}'
         plugin-directory:
           databaseMigrations:
@@ -490,6 +496,7 @@ spec:
           database:
             createDatabaseUser: true
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'
+            port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
             superuserName: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
 
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
@@ -847,6 +854,7 @@ spec:
             MARKETPLACE_SOURCE: '{{repl ConfigOption "plugin_directory_marketplace_source"}}'
           database:
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
+            port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
           oidc:
             issuerUrl: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
           client:


### PR DESCRIPTION
## Summary
- Emit `DB_PORT` for the OpenHands app chart and use it in DB wait/create init containers.
- Use `DB_PORT` in the in-repo runtime-api chart init containers and embedded DB env path.
- Wire Replicated `external_postgres_port` into Keycloak, LiteLLM, runtime-api, automation, plugin-directory, and the main external DB values.
- Set LiteLLM `db.url` explicitly so the configured port is present in `DATABASE_URL`.
- Bump `charts/runtime-api` from `0.3.6` to `0.3.7` and `charts/openhands` from `0.7.38` to `0.7.39`.

## Validation
- `helm lint charts/runtime-api`
- `make clean charts`
- `helm lint build/openhands-0.7.39.tgz`
- `helm lint build/openhands-secrets-0.1.21.tgz`
- Rendered `build/openhands-0.7.39.tgz` with external Postgres `5433`; confirmed LiteLLM `DATABASE_URL` includes `:5433`, runtime-api wait/create init containers use `$DB_PORT`, and OpenHands wait/create init containers use `$DB_PORT` with `DB_PORT: "5433"`.
- `make manifests`
- `replicated release lint --yaml-dir build` (passed; existing informational `may-contain-secrets` warnings only)

Customer-side confirmation: when Fujitsu moved their test Postgres listener from `5433` to `5432`, the install came up immediately, which matches the partial port propagation bug this fixes.

Companion runtime-api app-code PR: https://github.com/OpenHands/runtime-api/pull/570
