### PR TITLE
Add agent-canvas frontend-only subchart for canvas.openhands.dev

### DIFF
--- a/.github/workflows/preview-helm-charts.yml
+++ b/.github/workflows/preview-helm-charts.yml
@@ -20,6 +20,7 @@ jobs:
       automation: ${{ steps.changes.outputs.automation }}
       plugin-directory: ${{ steps.changes.outputs.plugin-directory }}
       integrations-hub: ${{ steps.changes.outputs.integrations-hub }}
+      agent-canvas: ${{ steps.changes.outputs.agent-canvas }}
       openhands: ${{ steps.changes.outputs.openhands }}
       openhands-secrets: ${{ steps.changes.outputs.openhands-secrets }}
     steps:
@@ -42,7 +43,7 @@ jobs:
           echo "$CHANGED_FILES"
 
           # Check each chart for changes
-          for chart in crd-check runtime-api image-loader automation plugin-directory integrations-hub openhands openhands-secrets; do
+          for chart in crd-check runtime-api image-loader automation plugin-directory integrations-hub agent-canvas openhands openhands-secrets; do
             if echo "$CHANGED_FILES" | grep -q "^charts/${chart}/"; then
               echo "${chart}=true" >> $GITHUB_OUTPUT
               echo "Changes detected in charts/${chart}"
@@ -65,7 +66,7 @@ jobs:
       matrix:
         chart:
           # Order matters! Charts that are dependencies must be published first.
-          # crd-check, automation, plugin-directory, integrations-hub, and runtime-api are dependencies of openhands.
+          # crd-check, automation, plugin-directory, integrations-hub, agent-canvas, and runtime-api are dependencies of openhands.
           - name: crd-check
             path: charts/crd-check
           - name: automation
@@ -74,6 +75,8 @@ jobs:
             path: charts/plugin-directory
           - name: integrations-hub
             path: charts/integrations-hub
+          - name: agent-canvas
+            path: charts/agent-canvas
           - name: runtime-api
             path: charts/runtime-api
           - name: image-loader
@@ -94,6 +97,7 @@ jobs:
           HAS_CHANGES_AUTOMATION: ${{ needs.detect-changes.outputs.automation }}
           HAS_CHANGES_PLUGIN_DIRECTORY: ${{ needs.detect-changes.outputs.plugin-directory }}
           HAS_CHANGES_INTEGRATIONS_HUB: ${{ needs.detect-changes.outputs.integrations-hub }}
+          HAS_CHANGES_AGENT_CANVAS: ${{ needs.detect-changes.outputs.agent-canvas }}
           HAS_CHANGES_OPENHANDS: ${{ needs.detect-changes.outputs.openhands }}
           HAS_CHANGES_OPENHANDS_SECRETS: ${{ needs.detect-changes.outputs.openhands-secrets }}
           IS_PUBLISHABLE_CRD_CHECK: ${{ needs.validate-chart-versions.outputs.crd-check-publishable }}
@@ -102,6 +106,7 @@ jobs:
           IS_PUBLISHABLE_AUTOMATION: ${{ needs.validate-chart-versions.outputs.automation-publishable }}
           IS_PUBLISHABLE_PLUGIN_DIRECTORY: ${{ needs.validate-chart-versions.outputs.plugin-directory-publishable }}
           IS_PUBLISHABLE_INTEGRATIONS_HUB: ${{ needs.validate-chart-versions.outputs.integrations-hub-publishable }}
+          IS_PUBLISHABLE_AGENT_CANVAS: ${{ needs.validate-chart-versions.outputs.agent-canvas-publishable }}
           IS_PUBLISHABLE_OPENHANDS: ${{ needs.validate-chart-versions.outputs.openhands-publishable }}
           IS_PUBLISHABLE_OPENHANDS_SECRETS: ${{ needs.validate-chart-versions.outputs.openhands-secrets-publishable }}
         run: |
@@ -130,6 +135,10 @@ jobs:
             integrations-hub)
               HAS_CHANGES="$HAS_CHANGES_INTEGRATIONS_HUB"
               IS_PUBLISHABLE="$IS_PUBLISHABLE_INTEGRATIONS_HUB"
+              ;;
+            agent-canvas)
+              HAS_CHANGES="$HAS_CHANGES_AGENT_CANVAS"
+              IS_PUBLISHABLE="$IS_PUBLISHABLE_AGENT_CANVAS"
               ;;
             openhands)
               HAS_CHANGES="$HAS_CHANGES_OPENHANDS"
@@ -228,6 +237,14 @@ jobs:
 
           yq -i "(.dependencies[] | select(.name == \"integrations-hub\")) |= (.version = \"${INTEGRATIONS_HUB_PREVIEW}\" | .repository = \"${PREVIEW_REPOSITORY}\")" charts/openhands/Chart.yaml
 
+      - name: Update agent-canvas dependency version
+        if: steps.check.outputs.should_publish == 'true' && matrix.chart.name == 'openhands' && needs.detect-changes.outputs.agent-canvas == 'true'
+        run: |
+          AGENT_CANVAS_VERSION=$(yq '.version' charts/agent-canvas/Chart.yaml)
+          AGENT_CANVAS_PREVIEW="${AGENT_CANVAS_VERSION}-alpha.${{ github.event.pull_request.number }}"
+
+          yq -i "(.dependencies[] | select(.name == \"agent-canvas\")) |= (.version = \"${AGENT_CANVAS_PREVIEW}\" | .repository = \"${PREVIEW_REPOSITORY}\")" charts/openhands/Chart.yaml
+
       - name: Test ${{ matrix.chart.name }} chart with default values
         if: steps.check.outputs.should_publish == 'true'
         run: |
@@ -306,6 +323,8 @@ jobs:
             path: charts/plugin-directory
           - name: integrations-hub
             path: charts/integrations-hub
+          - name: agent-canvas
+            path: charts/agent-canvas
           - name: openhands
             path: charts/openhands
           - name: openhands-secrets
@@ -372,6 +391,15 @@ jobs:
 
           echo "Updating openhands integrations-hub dependency to ${INTEGRATIONS_HUB_PREVIEW}"
           yq -i "(.dependencies[] | select(.name == \"integrations-hub\")) |= (.version = \"${INTEGRATIONS_HUB_PREVIEW}\" | .repository = \"${PREVIEW_REPOSITORY}\")" charts/openhands/Chart.yaml
+
+      - name: Update agent-canvas dependency version for openhands
+        if: matrix.chart.name == 'openhands' && needs.detect-changes.outputs.agent-canvas == 'true'
+        run: |
+          AGENT_CANVAS_VERSION=$(yq '.version' charts/agent-canvas/Chart.yaml)
+          AGENT_CANVAS_PREVIEW="${AGENT_CANVAS_VERSION}-alpha.${{ github.event.pull_request.number }}"
+
+          echo "Updating openhands agent-canvas dependency to ${AGENT_CANVAS_PREVIEW}"
+          yq -i "(.dependencies[] | select(.name == \"agent-canvas\")) |= (.version = \"${AGENT_CANVAS_PREVIEW}\" | .repository = \"${PREVIEW_REPOSITORY}\")" charts/openhands/Chart.yaml
 
       - name: Lint ${{ matrix.chart.name }} chart
         run: |

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         chart:
           # Order matters: openhands depends on crd-check, runtime-api, automation,
-          # plugin-directory, and integrations-hub, so those must publish first.
+          # plugin-directory, integrations-hub, and agent-canvas, so those must publish first.
           - name: crd-check
             path: charts/crd-check
           - name: runtime-api
@@ -41,6 +41,8 @@ jobs:
             path: charts/plugin-directory
           - name: integrations-hub
             path: charts/integrations-hub
+          - name: agent-canvas
+            path: charts/agent-canvas
           - name: openhands
             path: charts/openhands
           - name: openhands-secrets

--- a/.github/workflows/tag-chart-versions.yml
+++ b/.github/workflows/tag-chart-versions.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Tag chart versions
         run: |
           # Define the charts to process
-          CHARTS=("automation" "image-loader" "openhands" "openhands-secrets" "runtime-api")
+          CHARTS=("automation" "agent-canvas" "image-loader" "openhands" "openhands-secrets" "runtime-api")
           
           for chart in "${CHARTS[@]}"; do
             CHART_PATH="charts/${chart}/Chart.yaml"

--- a/.github/workflows/validate-chart-versions.yml
+++ b/.github/workflows/validate-chart-versions.yml
@@ -32,6 +32,9 @@ on:
       integrations-hub-publishable:
         description: 'Whether integrations-hub chart is publishable (no changes or version bumped)'
         value: ${{ jobs.validate-chart-versions.outputs.integrations-hub-publishable }}
+      agent-canvas-publishable:
+        description: 'Whether agent-canvas chart is publishable (no changes or version bumped)'
+        value: ${{ jobs.validate-chart-versions.outputs.agent-canvas-publishable }}
       openhands-publishable:
         description: 'Whether openhands chart is publishable (no changes or version bumped)'
         value: ${{ jobs.validate-chart-versions.outputs.openhands-publishable }}
@@ -51,6 +54,7 @@ jobs:
       automation-publishable: ${{ steps.validate.outputs.automation-publishable }}
       plugin-directory-publishable: ${{ steps.validate.outputs.plugin-directory-publishable }}
       integrations-hub-publishable: ${{ steps.validate.outputs.integrations-hub-publishable }}
+      agent-canvas-publishable: ${{ steps.validate.outputs.agent-canvas-publishable }}
       openhands-publishable: ${{ steps.validate.outputs.openhands-publishable }}
       openhands-secrets-publishable: ${{ steps.validate.outputs.openhands-secrets-publishable }}
 

--- a/charts/agent-canvas/Chart.yaml
+++ b/charts/agent-canvas/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: agent-canvas
+description: Frontend-only deployment of OpenHands Agent Canvas (UI shell pointing at user-managed backends)
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/agent-canvas/README.md
+++ b/charts/agent-canvas/README.md
@@ -1,0 +1,32 @@
+# agent-canvas
+
+Frontend-only deployment of [OpenHands Agent
+Canvas](https://github.com/OpenHands/agent-canvas).
+
+This chart runs the pre-built static frontend bundled in the
+`ghcr.io/openhands/agent-canvas` image, served by
+`scripts/static-server.mjs` in `--auth-required` mode. All backend paths
+(`/api`, `/sockets`, etc.) are rejected with `503` so the UI is forced
+into the in-app "Manage Backends" workflow — users supply their own
+agent-server URL and API key from the browser.
+
+It is intended to be deployed as a subchart of the umbrella `openhands`
+chart so the parent chart provides the `Ingress`, hostname, and TLS
+secret for the frontend (see
+`templates/ingress-agent-canvas.yaml`). The `host` and `ingress.enabled`
+flags on this chart are placeholders for stand-alone use.
+
+## Usage as a subchart
+
+```yaml
+agent-canvas:
+  enabled: true
+  image:
+    tag: sha-2ad6f84
+  ingress:
+    enabled: true
+    host: canvas.openhands.dev
+    tls:
+      enabled: true
+      secretName: agent-canvas-tls
+```

--- a/charts/agent-canvas/templates/deployment.yaml
+++ b/charts/agent-canvas/templates/deployment.yaml
@@ -1,0 +1,83 @@
+{{- $port := int .Values.service.port -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-canvas
+  labels:
+    app: agent-canvas
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: agent-canvas
+  template:
+    metadata:
+      labels:
+        app: agent-canvas
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent-canvas
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The agent-canvas image is the all-in-one combined build.
+          # Override the entrypoint so the container runs ONLY the static
+          # frontend behind static-server.mjs — no agent-server, no
+          # automation. Users connect this UI to their own backends via
+          # the in-app "Manage Backends" screen.
+          command: ["node", "/opt/agent-canvas/static-server.mjs"]
+          args:
+            - --port
+            - {{ $port | quote }}
+            - --host
+            - "::"
+            - --dir
+            - /opt/agent-canvas/frontend
+            {{- if .Values.staticServer.authRequired }}
+            - --auth-required
+            {{- end }}
+            {{- range .Values.staticServer.rejectPrefixes }}
+            - --reject-prefix
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $port }}
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}

--- a/charts/agent-canvas/templates/service-account.yaml
+++ b/charts/agent-canvas/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app: agent-canvas
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-canvas/templates/service.yaml
+++ b/charts/agent-canvas/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-canvas
+  labels:
+    app: agent-canvas
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: agent-canvas

--- a/charts/agent-canvas/values.yaml
+++ b/charts/agent-canvas/values.yaml
@@ -1,0 +1,84 @@
+# Agent Canvas Helm Chart Values
+#
+# Frontend-only deployment of OpenHands Agent Canvas. This chart runs the
+# pre-built static frontend bundled in the ghcr.io/openhands/agent-canvas
+# image, served by scripts/static-server.mjs in --auth-required mode with
+# /api, /sockets, /server_info, and other backend paths rejected. Users
+# point the UI at their own backend(s) via the in-app "Manage Backends"
+# screen.
+
+image:
+  repository: ghcr.io/openhands/agent-canvas
+  # Tag is supplied at deploy time via the OpenHands deploy workflow.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+deployment:
+  replicas: 1
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 50m
+    limits:
+      memory: 256Mi
+      cpu: 250m
+
+service:
+  port: 8000
+
+# Ingress for the agent-canvas service. When deployed as a subchart of
+# `openhands`, the parent chart's `templates/ingress-agent-canvas.yaml`
+# renders the Ingress resource using these values.
+ingress:
+  enabled: false
+  host: ""
+  tls:
+    enabled: true
+    secretName: agent-canvas-tls
+
+# Static-server runtime flags. By default the deployment runs in
+# frontend-only / auth-required mode and rejects any path that would
+# normally proxy to a local backend (since this deployment has none).
+staticServer:
+  authRequired: true
+  rejectPrefixes:
+    - /api
+    - /server_info
+    - /sockets
+    - /alive
+    - /health
+    - /ready
+    - /docs
+    - /redoc
+    - /openapi.json
+
+# Pod-level security context
+securityContext:
+  runAsUser: 42420
+  runAsGroup: 42420
+  runAsNonRoot: true
+
+# Service account configuration
+serviceAccount:
+  create: true
+  name: agent-canvas-sa
+  annotations: {}
+
+# Liveness / readiness probes hit the static server on / (SPA fallback).
+probes:
+  startup:
+    failureThreshold: 30
+    periodSeconds: 5
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 2
+    periodSeconds: 10
+    failureThreshold: 3
+
+# Extra environment variables to pass to the container.
+env: {}

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -55,3 +55,7 @@ dependencies:
     repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.1
     condition: integrations-hub.enabled
+  - name: agent-canvas
+    repository: oci://ghcr.io/openhands/helm-charts
+    version: 0.1.0
+    condition: agent-canvas.enabled

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.53
+version: 0.7.54
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ingress-agent-canvas.yaml
+++ b/charts/openhands/templates/ingress-agent-canvas.yaml
@@ -1,0 +1,43 @@
+{{- /*
+  Ingress entry for the agent-canvas frontend-only deployment.
+
+  Unlike the other openhands subchart ingresses (plugin-directory,
+  integrations-hub, automation, mcp) which mount additional paths under
+  the main `.Values.ingress.host`, agent-canvas is served on its own
+  dedicated host (e.g. `canvas.openhands.dev`) supplied via
+  `agent-canvas.ingress.host`. This keeps the UI separate from the main
+  OpenHands app while reusing the same in-cluster ingress controller and
+  cert-manager.
+*/}}
+{{- $agentCanvas := index .Values "agent-canvas" -}}
+{{- if and .Values.enabled .Values.ingress.enabled $agentCanvas.enabled $agentCanvas.ingress.enabled $agentCanvas.ingress.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openhands-agent-canvas-ingress
+  annotations:
+    {{- if .Values.ingress.root.annotations }}
+    {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}
+    {{- else }}
+    {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- if $agentCanvas.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ $agentCanvas.ingress.host }}
+    secretName: {{ $agentCanvas.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+  - host: {{ $agentCanvas.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: agent-canvas
+            port:
+              number: {{ default 8000 (index $agentCanvas "service" "port") }}
+{{- end }}

--- a/charts/openhands/templates/ingress-agent-canvas.yaml
+++ b/charts/openhands/templates/ingress-agent-canvas.yaml
@@ -10,7 +10,7 @@
   cert-manager.
 */}}
 {{- $agentCanvas := index .Values "agent-canvas" -}}
-{{- if and .Values.enabled .Values.ingress.enabled $agentCanvas.enabled $agentCanvas.ingress.enabled $agentCanvas.ingress.host }}
+{{- if and $agentCanvas.enabled $agentCanvas.ingress.enabled $agentCanvas.ingress.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -22,7 +22,7 @@ metadata:
     {{ .Values.ingress.annotations | toYaml | nindent 4 }}
     {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.class }}
+  ingressClassName: {{ default "traefik" .Values.ingress.class }}
   {{- if $agentCanvas.ingress.tls.enabled }}
   tls:
   - hosts:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1168,3 +1168,26 @@ integrations-hub:
   # PostgreSQL subchart - disabled when using parent's PostgreSQL
   postgresql:
     enabled: false
+
+# ───────────────────────────────────────────────────────────────────────
+# Agent Canvas (subchart): frontend-only deployment
+# ───────────────────────────────────────────────────────────────────────
+# When enabled, the agent-canvas subchart deploys the static frontend
+# behind its own ingress (rendered by `templates/ingress-agent-canvas.yaml`
+# below). `ingress.host` here is read by that template; the subchart's
+# `ingress.enabled` is left off because the parent renders the Ingress.
+agent-canvas:
+  enabled: false
+
+  image:
+    repository: ghcr.io/openhands/agent-canvas
+    # tag: supplied at deploy time via the OpenHands deploy workflow.
+
+  ingress:
+    enabled: false
+    # Hostname for the agent-canvas ingress, e.g. canvas.openhands.dev
+    host: ""
+    tls:
+      enabled: true
+      secretName: agent-canvas-tls
+


### PR DESCRIPTION
## Summary
Add agent-canvas frontend-only subchart for canvas.openhands.dev.

## Related
- Fixes https://github.com/OpenHands/OpenHands-Cloud/issues/686
- Related: https://github.com/OpenHands/deploy/issues/4527