### PR TITLE
PLTF-2875: Support org-owned GitHub App creation

### DIFF
--- a/.github/workflows/test-update-openhands-charts.yml
+++ b/.github/workflows/test-update-openhands-charts.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/scripts/create_github_app/README.md
+++ b/scripts/create_github_app/README.md
@@ -11,6 +11,8 @@ Create a GitHub App configured for the Replicated self-hosted install of OpenHan
 
 ```bash
 ./create_github_app.py --base-domain <your-domain>
+./create_github_app.py --base-domain <your-domain> --org <github-org>
+./create_github_app.py --base-domain <your-domain> --callback-port 18080
 ```
 
 ### Options
@@ -19,11 +21,14 @@ Create a GitHub App configured for the Replicated self-hosted install of OpenHan
 |--------|-------------|
 | `--base-domain` | **(Required)** Base domain for your OHE installation (e.g., `mycompany.com`) |
 | `--app-name` | Custom name for the GitHub App (default: `openhands-<random>`) |
+| `--org` | GitHub organization to create the app in (default: your personal account) |
+| `--callback-port` | Local port for the app-creation callback server (default: `9876`) |
 
 ### Example
 
 ```bash
 ./create_github_app.py --base-domain mycompany.com
+./create_github_app.py --base-domain mycompany.com --org MyCompany
 ```
 
 ## How It Works
@@ -36,6 +41,8 @@ Create a GitHub App configured for the Replicated self-hosted install of OpenHan
 
 No manual copy-paste required - the script automatically captures the authorization code!
 
+If port `9876` is already in use, pass `--callback-port <port>`; the script will fail fast when the callback server cannot start.
+
 ### Output
 
 After successful creation, you'll receive:
@@ -44,7 +51,9 @@ After successful creation, you'll receive:
 - **GitHub App Client ID** - Used by the GitHub App authentication flow
 - **GitHub App Client Secret** - Keep this secret!
 - **GitHub App Webhook Secret** - For webhook verification
-- **Private Key** - Saved to `./keys/<app-name>.pem`
+- **Private Key** - Saved to `./keys/<app-name>.pem` with owner-only file permissions
+
+The client secret, webhook secret, and private key are sensitive. Keep terminal output private and store the values in the target OHE configuration system immediately.
 
 ## Permissions
 
@@ -71,4 +80,4 @@ The app is configured with:
 - **Redirect URL** (for app creation): `http://localhost:9876/callback` (local callback server)
 - **Callback URL** (for OAuth): `https://auth.app.<base-domain>/realms/allhands/broker/github/endpoint`
 - **Webhook URL**: `https://app.<base-domain>/integration/github/events`
-- **OAuth on install**: Enabled (users authorize during installation)
+- **OAuth on install**: Disabled (Keycloak handles user OAuth at login time)

--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -8,7 +8,9 @@
 import argparse
 import html
 import json
+import os
 import secrets
+import sys
 import tempfile
 import threading
 import time
@@ -26,6 +28,8 @@ from github import Auth, GithubIntegration
 SCRIPT_DIR = Path(__file__).parent
 
 APP_NAME_PREFIX = "openhands"
+DEFAULT_CALLBACK_PORT = 9876  # Using high port that doesn't require root
+GITHUB_API_TIMEOUT_SECONDS = 30
 
 
 def generate_unique_app_name() -> str:
@@ -61,10 +65,19 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Base domain for the GitHub App (e.g., mycompany.com).",
     )
+    parser.add_argument(
+        "--org",
+        default=None,
+        help="Org to create the app in (default: your personal account).",
+    )
+    parser.add_argument(
+        "--callback-port",
+        type=int,
+        default=DEFAULT_CALLBACK_PORT,
+        help=f"Local port for the app-creation callback server "
+        f"(default: {DEFAULT_CALLBACK_PORT}); use this if that port is in use.",
+    )
     return parser.parse_args()
-
-
-DEFAULT_CALLBACK_PORT = 9876  # Using high port that doesn't require root
 
 
 def build_app_manifest(
@@ -105,17 +118,22 @@ def build_app_manifest(
     }
 
 
-def generate_manifest_html(manifest: dict[str, Any]) -> str:
+def generate_manifest_html(manifest: dict[str, Any], org: str | None = None) -> str:
     """Generate HTML form that POSTs to GitHub to create app from manifest."""
     manifest_json = json.dumps(manifest)
     # HTML-escape the JSON to safely embed in the value attribute
     escaped_json = html.escape(manifest_json)
+    action = (
+        f"https://github.com/organizations/{org}/settings/apps/new"
+        if org
+        else "https://github.com/settings/apps/new"
+    )
     return f"""<!DOCTYPE html>
 <html>
 <head><title>Creating GitHub App...</title></head>
 <body>
 <p>Redirecting to GitHub to create your app...</p>
-<form id="manifest-form" action="https://github.com/settings/apps/new" method="post">
+<form id="manifest-form" action="{html.escape(action)}" method="post">
 <input type="hidden" name="manifest" value="{escaped_json}">
 </form>
 <script>document.getElementById('manifest-form').submit();</script>
@@ -127,14 +145,20 @@ def open_manifest_in_browser(
     base_domain: str,
     app_name: str | None = None,
     callback_port: int = DEFAULT_CALLBACK_PORT,
+    org: str | None = None,
 ) -> str:
     """Write manifest HTML to temp file and open in browser. Returns file path."""
     manifest = build_app_manifest(base_domain, app_name, callback_port=callback_port)
-    html = generate_manifest_html(manifest)
+    html = generate_manifest_html(manifest, org=org)
     with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
         f.write(html)
         filepath = f.name
-    webbrowser.open(f"file://{filepath}")
+    try:
+        webbrowser.open(f"file://{filepath}")
+    except Exception:
+        # No browser (for example, headless shell): do not leak the temp file.
+        Path(filepath).unlink(missing_ok=True)
+        raise
     return filepath
 
 
@@ -216,7 +240,9 @@ class ServerHandle:
         self.thread = thread
 
 
-def start_callback_server(port: int = 80) -> tuple[ServerHandle, CodeHolder]:
+def start_callback_server(
+    port: int = DEFAULT_CALLBACK_PORT,
+) -> tuple[ServerHandle, CodeHolder]:
     """Start the callback server in a background thread."""
     app, code_holder = create_callback_app()
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
@@ -225,6 +251,20 @@ def start_callback_server(port: int = 80) -> tuple[ServerHandle, CodeHolder]:
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
 
+    # Fail fast when the port is unavailable instead of waiting for the
+    # 5-minute GitHub callback timeout.
+    deadline = time.time() + 10
+    while not server.started:
+        if not thread.is_alive():
+            raise RuntimeError(
+                f"Callback server failed to start on port {port} (already in use?)."
+            )
+        if time.time() > deadline:
+            raise RuntimeError(
+                f"Callback server did not start on port {port} within 10s (already in use?)."
+            )
+        time.sleep(0.05)
+
     return ServerHandle(server, thread), code_holder
 
 
@@ -232,6 +272,8 @@ def stop_callback_server(handle: ServerHandle) -> None:
     """Stop the callback server."""
     handle.server.should_exit = True
     handle.thread.join(timeout=5)
+    if handle.thread.is_alive():
+        print("Warning: Callback server thread did not exit within 5s; cleanup may be incomplete.")
 
 
 def exchange_code_for_credentials(code: str) -> dict:
@@ -239,6 +281,7 @@ def exchange_code_for_credentials(code: str) -> dict:
     response = requests.post(
         f"https://api.github.com/app-manifests/{code}/conversions",
         headers={"Accept": "application/vnd.github+json"},
+        timeout=GITHUB_API_TIMEOUT_SECONDS,
     )
     response.raise_for_status()
     return response.json()
@@ -258,14 +301,16 @@ def wait_for_app_installation(
         print(f"Warning: Could not authenticate with GitHub API: {exc}")
         return False
 
-    deadline = time.time() + timeout
+    start = time.time()
+    deadline = start + timeout
     while time.time() < deadline:
         try:
-            if list(gi.get_installations()):
+            # get_installations() returns a PaginatedList: iterable, not always
+            # an iterator, so wrap it before checking for the first result.
+            if next(iter(gi.get_installations()), None) is not None:
                 return True
         except Exception as exc:
             print(f"Warning: Error checking installations: {exc}")
-            return False
         time.sleep(poll_interval)
     return False
 
@@ -286,23 +331,35 @@ def main(
     github_client: GithubClient | None = None,
     app_name: str | None = None,
     callback_port: int = DEFAULT_CALLBACK_PORT,
+    org: str | None = None,
 ) -> None:
     """Main entry point for creating a GitHub App."""
     if app_name is None:
         app_name = generate_unique_app_name()
+    # app_name becomes a filename (keys/<app_name>.pem); reject path components.
+    if not app_name or "/" in app_name or "\\" in app_name or app_name in (".", ".."):
+        print(f"Error: invalid --app-name '{app_name}': must be a plain name without '/', '\\', or '..'.")
+        sys.exit(1)
+    target = f"the {org} org" if org else "your personal account"
     if dry_run:
-        print(f"Would create GitHub App '{app_name}' for domain '{base_domain}'")
+        print(f"Would create GitHub App '{app_name}' for domain '{base_domain}' on {target}")
         return
 
     # Start callback server to capture the code from GitHub redirect
     server_handle, code_holder = start_callback_server(port=callback_port)
+    manifest_file = None
 
     try:
         # Open browser for user to create app (they're already logged into GitHub)
-        print(f"\nOpening browser to create GitHub App '{app_name}'...")
+        print(f"\nOpening browser to create GitHub App '{app_name}' on {target}...")
         print("Click 'Create GitHub App for <your-username>' to continue.")
         print("Waiting for GitHub callback...\n")
-        open_manifest_in_browser(base_domain, app_name, callback_port=callback_port)
+        manifest_file = open_manifest_in_browser(
+            base_domain,
+            app_name,
+            callback_port=callback_port,
+            org=org,
+        )
 
         # Wait for the code to be received via callback
         print("Waiting for authorization code...")
@@ -311,11 +368,16 @@ def main(
 
         if code is None:
             print("Error: Timed out waiting for authorization code.")
-            return
+            sys.exit(1)
 
         print("Authorization code received!")
 
-        credentials = exchange_code_for_credentials(code)
+        try:
+            credentials = exchange_code_for_credentials(code)
+        except (requests.RequestException, ValueError) as exc:
+            # ValueError covers json.JSONDecodeError (HTTP 200 with non-JSON body).
+            print(f"Error: failed to exchange the code for app credentials: {exc}")
+            sys.exit(1)
         print(f"\nGitHub App created successfully!")
 
         if "slug" in credentials:
@@ -330,34 +392,40 @@ def main(
                 print("GitHub App installed successfully!")
             else:
                 print("Warning: Timed out waiting for app installation.")
+
+        # Save pem to keys/ directory relative to script location
+        pem_path = None
+        if "pem" in credentials:
+            keys_dir = SCRIPT_DIR / "keys"
+            keys_dir.mkdir(exist_ok=True)
+            pem_path = keys_dir / f"{app_name}.pem"
+            # Create the private key 0o600 from the first byte; chmod too in
+            # case the file already existed with looser permissions.
+            fd = os.open(pem_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(credentials["pem"])
+            pem_path.chmod(0o600)
+
+        print(f"\nCredentials:")
+        display_names = {
+            "id": "GitHub App ID",
+            "slug": "GitHub App Slug",
+            "client_id": "GitHub App Client ID",
+            "client_secret": "GitHub App Client Secret",
+            "webhook_secret": "GitHub App Webhook Secret",
+        }
+        for key in ["client_id", "client_secret", "id", "slug", "webhook_secret"]:
+            if key in credentials:
+                display_key = display_names.get(key, key)
+                print(f"  {display_key}: {credentials[key]}")
+        if pem_path:
+            display_path = f"./scripts/create_github_app/keys/{app_name}.pem"
+            print(f"  GitHub App Private Key: {display_path}")
     finally:
         # Always stop the callback server
         stop_callback_server(server_handle)
-
-    # Save pem to keys/ directory relative to script location
-    pem_path = None
-    if "pem" in credentials:
-        script_dir = Path(__file__).parent
-        keys_dir = script_dir / "keys"
-        keys_dir.mkdir(exist_ok=True)
-        pem_path = keys_dir / f"{app_name}.pem"
-        pem_path.write_text(credentials["pem"])
-
-    print(f"\nCredentials:")
-    display_names = {
-        "id": "GitHub App ID",
-        "slug": "GitHub App Slug",
-        "client_id": "GitHub App Client ID",
-        "client_secret": "GitHub App Client Secret",
-        "webhook_secret": "GitHub App Webhook Secret",
-    }
-    for key in ["client_id", "client_secret", "id", "slug", "webhook_secret"]:
-        if key in credentials:
-            display_key = display_names.get(key, key)
-            print(f"  {display_key}: {credentials[key]}")
-    if pem_path:
-        display_path = f"./scripts/create_github_app/keys/{app_name}.pem"
-        print(f"  GitHub App Private Key: {display_path}")
+        if manifest_file:
+            Path(manifest_file).unlink(missing_ok=True)
 
 
 if __name__ == "__main__":
@@ -366,4 +434,6 @@ if __name__ == "__main__":
         base_domain=args.base_domain,
         dry_run=args.dry_run,
         app_name=args.app_name,
+        callback_port=args.callback_port,
+        org=args.org,
     )

--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -352,7 +352,6 @@ def main(
 
     # Start callback server to capture the code from GitHub redirect
     server_handle, code_holder = start_callback_server(port=callback_port)
-    manifest_html_path = None
 
     try:
         # Open browser for user to create app (they're already logged into GitHub)

--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -37,6 +37,11 @@ def generate_unique_app_name() -> str:
     return f"{APP_NAME_PREFIX}-{secrets.token_hex(4)}"
 
 
+def is_safe_app_name(app_name: str) -> bool:
+    """Check if app_name is safe for use as a filename (no path separators or special values)."""
+    return bool(app_name) and "/" not in app_name and "\\" not in app_name and app_name not in (".", "..")
+
+
 class GithubClient(Protocol):
     """Protocol for GitHub client to enable dependency injection."""
 
@@ -336,8 +341,7 @@ def main(
     """Main entry point for creating a GitHub App."""
     if app_name is None:
         app_name = generate_unique_app_name()
-    # app_name becomes a filename (keys/<app_name>.pem); reject path components.
-    if not app_name or "/" in app_name or "\\" in app_name or app_name in (".", ".."):
+    if not is_safe_app_name(app_name):
         print(f"Error: invalid --app-name '{app_name}': must be a plain name without '/', '\\', or '..'.")
         sys.exit(1)
     target = f"the {org} org" if org else "your personal account"
@@ -347,14 +351,14 @@ def main(
 
     # Start callback server to capture the code from GitHub redirect
     server_handle, code_holder = start_callback_server(port=callback_port)
-    manifest_file = None
+    manifest_html_path = None
 
     try:
         # Open browser for user to create app (they're already logged into GitHub)
         print(f"\nOpening browser to create GitHub App '{app_name}' on {target}...")
         print("Click 'Create GitHub App for <your-username>' to continue.")
         print("Waiting for GitHub callback...\n")
-        manifest_file = open_manifest_in_browser(
+        manifest_html_path = open_manifest_in_browser(
             base_domain,
             app_name,
             callback_port=callback_port,
@@ -424,8 +428,8 @@ def main(
     finally:
         # Always stop the callback server
         stop_callback_server(server_handle)
-        if manifest_file:
-            Path(manifest_file).unlink(missing_ok=True)
+        if manifest_html_path:
+            Path(manifest_html_path).unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -316,6 +316,7 @@ def wait_for_app_installation(
                 return True
         except Exception as exc:
             print(f"Warning: Error checking installations: {exc}")
+            # Retry on transient errors rather than failing immediately.
         time.sleep(poll_interval)
     return False
 

--- a/scripts/create_github_app/test_create_github_app.py
+++ b/scripts/create_github_app/test_create_github_app.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["PyGithub", "requests", "fastapi", "uvicorn"]
+# dependencies = ["PyGithub", "requests", "fastapi", "uvicorn", "pytest", "httpx"]
 # ///
 """Unit tests for create_github_app.py."""
 
 import os
+import requests
 import sys
 import threading
 import time
@@ -320,6 +321,21 @@ class TestOpenManifestInBrowser:
             mock_open.assert_called_once_with(f"file://{filepath}")
             os.unlink(filepath)
 
+    def test_cleans_up_temp_file_when_browser_open_fails(self):
+        """Test that a headless/browser failure does not leave the manifest temp file behind."""
+        captured = {}
+
+        def fail_open(url):
+            captured["url"] = url
+            raise RuntimeError("no browser available")
+
+        with patch("create_github_app.webbrowser.open", side_effect=fail_open):
+            with pytest.raises(RuntimeError):
+                open_manifest_in_browser(base_domain="example.com")
+
+        path = captured["url"].removeprefix("file://")
+        assert not os.path.exists(path)
+
 
 class TestExchangeCodeForCredentials:
     """Tests for exchange_code_for_credentials function."""
@@ -335,6 +351,7 @@ class TestExchangeCodeForCredentials:
             mock_post.assert_called_once_with(
                 "https://api.github.com/app-manifests/test-code/conversions",
                 headers={"Accept": "application/vnd.github+json"},
+                timeout=create_github_app.GITHUB_API_TIMEOUT_SECONDS,
             )
 
     def test_returns_credentials(self):
@@ -569,6 +586,38 @@ class TestParseArgs:
         args = parse_args()
         assert args.base_domain == "mycompany.com"
 
+    def test_org_defaults_to_none(self, monkeypatch):
+        """Test that apps are created in the personal account unless --org is set."""
+        monkeypatch.setattr(sys, "argv", ["script", "--base-domain", "example.com"])
+        args = parse_args()
+        assert args.org is None
+
+    def test_org_can_be_set(self, monkeypatch):
+        """Test that --org directs manifest creation to an organization."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["script", "--base-domain", "example.com", "--org", "OpenHands"],
+        )
+        args = parse_args()
+        assert args.org == "OpenHands"
+
+    def test_callback_port_defaults_to_9876(self, monkeypatch):
+        """Test that the local callback port defaults to the manifest redirect port."""
+        monkeypatch.setattr(sys, "argv", ["script", "--base-domain", "example.com"])
+        args = parse_args()
+        assert args.callback_port == 9876
+
+    def test_callback_port_can_be_overridden(self, monkeypatch):
+        """Test that --callback-port lets operators avoid a busy local port."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["script", "--base-domain", "example.com", "--callback-port", "18080"],
+        )
+        args = parse_args()
+        assert args.callback_port == 18080
+
 
 class TestCallbackServer:
     """Tests for the FastAPI callback server that captures the GitHub OAuth code."""
@@ -699,6 +748,34 @@ class TestCallbackServerLifecycle:
         with pytest.raises(httpx.ConnectError):
             httpx.get("http://localhost:18235/callback?code=test", timeout=0.1)
 
+    def test_start_callback_server_fails_fast_when_server_thread_exits(self):
+        """Test that callback startup failure is reported immediately instead of timing out later."""
+        fake_server = MagicMock()
+        fake_server.started = False
+        fake_server.run.return_value = None
+
+        with patch("create_github_app.uvicorn.Server", return_value=fake_server):
+            with pytest.raises(RuntimeError) as exc_info:
+                start_callback_server(port=18080)
+
+        assert "failed to start" in str(exc_info.value).lower()
+        assert "18080" in str(exc_info.value)
+
+    def test_stop_callback_server_warns_if_thread_does_not_exit(self, capsys):
+        """Test that cleanup trouble is visible when the callback thread keeps running."""
+        mock_thread = MagicMock()
+        mock_thread.is_alive.return_value = True
+        handle = MagicMock()
+        handle.thread = mock_thread
+
+        stop_callback_server(handle)
+
+        mock_thread.join.assert_called_once()
+        mock_thread.is_alive.assert_called()
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "did not exit within 5s" in captured.out
+
 
 class TestManifestRedirectUrl:
     """Tests for manifest redirect_url with callback port."""
@@ -770,6 +847,104 @@ class TestMainWithCallbackServer:
         # input() should never be called
         mock_input.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "exc",
+        [requests.RequestException("boom"), ValueError("non-JSON body")],
+    )
+    def test_main_exits_nonzero_on_credential_exchange_failure(self, capsys, exc):
+        """Test that a failed manifest-code exchange is a clean CLI failure."""
+        code_holder = make_mock_code_holder()
+        with patch("create_github_app.start_callback_server", return_value=(MagicMock(), code_holder)):
+            with patch("create_github_app.open_manifest_in_browser", return_value="/tmp/_manifest.html"):
+                with patch("create_github_app.stop_callback_server") as mock_stop:
+                    with patch("create_github_app.exchange_code_for_credentials", side_effect=exc):
+                        with pytest.raises(SystemExit) as exit_info:
+                            main(base_domain="example.com", dry_run=False, app_name="my-app")
+
+        assert exit_info.value.code == 1
+        assert "failed to exchange" in capsys.readouterr().out.lower()
+        mock_stop.assert_called_once()
+
+    def test_main_exits_nonzero_on_auth_code_timeout(self, capsys):
+        """Test that never receiving GitHub's callback fails the command."""
+        code_holder = make_mock_code_holder(code=None)
+        with patch("create_github_app.start_callback_server", return_value=(MagicMock(), code_holder)):
+            with patch("create_github_app.open_manifest_in_browser", return_value="/tmp/_manifest.html"):
+                with patch("create_github_app.stop_callback_server") as mock_stop:
+                    with pytest.raises(SystemExit) as exit_info:
+                        main(base_domain="example.com", dry_run=False, app_name="my-app")
+
+        assert exit_info.value.code == 1
+        assert "timed out" in capsys.readouterr().out.lower()
+        mock_stop.assert_called_once()
+
+    @pytest.mark.parametrize("bad", ["", "../evil", "a/b", r"a\b", "..", "."])
+    def test_main_rejects_unsafe_app_name_before_io(self, capsys, bad):
+        """Test that app names cannot escape the keys directory when saved."""
+        with patch("create_github_app.start_callback_server") as mock_start:
+            with pytest.raises(SystemExit) as exit_info:
+                main(base_domain="example.com", dry_run=True, app_name=bad)
+
+        assert exit_info.value.code == 1
+        assert "invalid" in capsys.readouterr().out.lower()
+        mock_start.assert_not_called()
+
+    def test_main_passes_org_and_callback_port_to_browser_manifest(self):
+        """Test that main creates org-owned apps and keeps callback URLs in sync."""
+        with mock_main_dependencies({"id": 123}) as mocks:
+            main(
+                base_domain="example.com",
+                dry_run=False,
+                app_name="my-app",
+                org="OpenHands",
+                callback_port=18080,
+            )
+
+        mocks["start_server"].assert_called_once_with(port=18080)
+        mocks["open_browser"].assert_called_once_with(
+            "example.com",
+            "my-app",
+            callback_port=18080,
+            org="OpenHands",
+        )
+
+    def test_main_deletes_temp_manifest_file_after_flow(self, tmp_path):
+        """Test that the temporary manifest page is removed once it has been loaded."""
+        manifest = tmp_path / "manifest.html"
+        manifest.write_text("<html></html>")
+
+        with mock_main_dependencies({"id": 123}) as mocks:
+            mocks["open_browser"].return_value = str(manifest)
+            main(base_domain="example.com", dry_run=False, app_name="my-app")
+
+        assert not manifest.exists()
+
+
+class TestOrgManifestHtml:
+    """Tests for creating apps under an organization account."""
+
+    def test_html_posts_to_personal_account_by_default(self):
+        """Test that the default manifest form creates a user-owned app."""
+        page = generate_manifest_html(build_app_manifest(base_domain="example.com"))
+        assert 'action="https://github.com/settings/apps/new"' in page
+
+    def test_html_posts_to_org_when_org_set(self):
+        """Test that --org switches GitHub's manifest endpoint to the org path."""
+        page = generate_manifest_html(
+            build_app_manifest(base_domain="example.com"),
+            org="OpenHands",
+        )
+        assert 'action="https://github.com/organizations/OpenHands/settings/apps/new"' in page
+
+    def test_html_escapes_org_in_action_url(self):
+        """Test that an org name cannot break the HTML form attribute."""
+        page = generate_manifest_html(
+            build_app_manifest(base_domain="example.com"),
+            org='ev"il',
+        )
+        assert 'organizations/ev"il/' not in page
+        assert "ev&quot;il" in page
+
 
 class TestWaitForAppInstallation:
     """Tests for wait_for_app_installation()."""
@@ -783,17 +958,37 @@ class TestWaitForAppInstallation:
         assert "could not authenticate with github api" in captured.out.lower()
         assert "bad auth" in captured.out
 
-    def test_returns_false_when_installation_check_fails(self, capsys):
-        """Test that installation polling errors are surfaced as warnings instead of crashing."""
+    def test_retries_when_installation_check_fails_once(self, capsys):
+        """Test that transient post-creation API errors do not abort installation polling."""
+        mock_integration = MagicMock()
+        mock_integration.get_installations.side_effect = [
+            RuntimeError("api unavailable"),
+            iter([MagicMock()]),
+        ]
+
+        with patch("create_github_app.Auth.AppAuth"):
+            with patch("create_github_app.GithubIntegration", return_value=mock_integration):
+                with patch("create_github_app.time.time", side_effect=[0, 0, 0]):
+                    with patch("create_github_app.time.sleep") as mock_sleep:
+                        assert wait_for_app_installation(app_id=123, private_key="pem", timeout=1) is True
+
+        mock_sleep.assert_called_once()
+        captured = capsys.readouterr()
+        assert "error checking installations" in captured.out.lower()
+        assert "api unavailable" in captured.out
+
+    def test_returns_false_when_installation_check_keeps_failing_until_timeout(self, capsys):
+        """Test that repeated installation polling errors eventually time out."""
         mock_integration = MagicMock()
         mock_integration.get_installations.side_effect = RuntimeError("api unavailable")
 
         with patch("create_github_app.Auth.AppAuth"):
             with patch("create_github_app.GithubIntegration", return_value=mock_integration):
-                with patch("create_github_app.time.time", side_effect=[0, 0]):
-                    with patch("create_github_app.time.sleep"):
+                with patch("create_github_app.time.time", side_effect=[0, 0, 2]):
+                    with patch("create_github_app.time.sleep") as mock_sleep:
                         assert wait_for_app_installation(app_id=123, private_key="pem", timeout=1) is False
 
+        mock_sleep.assert_called_once()
         captured = capsys.readouterr()
         assert "error checking installations" in captured.out.lower()
         assert "api unavailable" in captured.out
@@ -860,6 +1055,24 @@ class TestMainInstallationFlow:
 
         captured = capsys.readouterr()
         assert "GitHub App Client ID: Iv1.abc" in captured.out
+
+
+class TestSavesPrivateKeySecurely:
+    """Tests for private key file handling."""
+
+    def test_private_key_is_written_with_owner_only_permissions(self, capsys, monkeypatch, tmp_path):
+        """Test that the generated pem file is not group/world-readable."""
+        monkeypatch.chdir(tmp_path)
+        pem_path = SCRIPT_DIR / "keys" / "secure-app.pem"
+        pem_content = "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+
+        with temporary_pem_file(pem_path):
+            with mock_main_dependencies({"id": 123, "pem": pem_content}):
+                main(base_domain="example.com", dry_run=False, app_name="secure-app")
+
+            assert pem_path.exists()
+            assert pem_path.read_text() == pem_content
+            assert (pem_path.stat().st_mode & 0o777) == 0o600
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add org-owned GitHub App creation support to create_github_app via --org, posting the manifest to GitHub's organization app endpoint
- add configurable --callback-port support so operators can avoid busy local ports while keeping redirect URLs in sync
- hardening: fail-fast callback startup, API timeout, clean nonzero exits, temp-file cleanup, secure app-name validation, 0600 private-key writes, and retrying installation polling
- expand tests, document the new options, fix the OAuth-on-install README mismatch, and add a script-test workflow timeout

## Test plan
- uv run scripts/create_github_app/test_create_github_app.py
- uv run --with pytest --with requests --with PyGithub --with fastapi --with uvicorn --with httpx --with ruamel.yaml python -m pytest scripts/create_github_app/test_create_github_app.py scripts/test_keycloak_realm_template.py scripts/update_openhands_charts/test_update_openhands_charts.py scripts/create_slack_app/test_create_slack_app.py -q

## Additional Notes

Validated that the script still creates a github app on the personal account as before as the default:
```
% ./scripts/create_github_app/create_github_app.py --base-domain <BASE_DOMAIN>

Opening browser to create GitHub App 'openhands-a05839c6' on your personal account...
Click 'Create GitHub App for <your-username>' to continue.
Waiting for GitHub callback...

Waiting for authorization code...
Authorization code received!

GitHub App created successfully!

Install URL: https://github.com/apps/openhands-a05839c6/installations/new

Waiting for app installation...
GitHub App installed successfully!
```