### PR TITLE
fix: add external Postgres SSL mode config

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/templates/_env.yaml
+++ b/charts/automation/templates/_env.yaml
@@ -14,6 +14,10 @@
   value: {{ .Values.database.host | quote }}
 - name: AUTOMATION_DB_PORT
   value: {{ .Values.database.port | quote }}
+- name: AUTOMATION_DB_SSL_MODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
+- name: PGSSLMODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
 - name: AUTOMATION_DB_USER
   value: {{ .Values.database.user | quote }}
 - name: AUTOMATION_DB_NAME

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
             value: {{ .Values.database.host | quote }}
           - name: DB_PORT
             value: {{ .Values.database.port | quote }}
+          - name: PGSSLMODE
+            value: {{ .Values.database.sslMode | default "prefer" | quote }}
           - name: DB_NAME
             value: {{ .Values.database.name | quote }}
           - name: DB_USER

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -68,6 +68,7 @@ database:
   #   - Feature env: "openhands-feature-branch-postgresql"
   host: ""
   port: "5432"
+  sslMode: "prefer"
   user: "automation_user"
   name: "automations"
   # Secret containing the automation database password

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/automation
-  tag: sha-3a35409
+  tag: sha-eac5478
 
 imagePullSecrets: []
 

--- a/charts/integrations-hub/Chart.yaml
+++ b/charts/integrations-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: integrations-hub
 description: OpenHands Integrations Hub - Agent context layer with managed connectors and MCP integrations
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/integrations-hub/templates/_env.yaml
+++ b/charts/integrations-hub/templates/_env.yaml
@@ -36,6 +36,10 @@
   value: {{ .Values.database.host | quote }}
 - name: INTHUB_DB_PORT
   value: {{ .Values.database.port | quote }}
+- name: INTHUB_DB_SSL_MODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
+- name: PGSSLMODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
 - name: INTHUB_DB_USER
   value: {{ .Values.database.user | quote }}
 - name: INTHUB_DB_NAME
@@ -46,7 +50,7 @@
       name: {{ .Values.database.secretName }}
       key: {{ .Values.database.secretKey }}
 - name: INTHUB_POSTGRES_URL
-  value: "postgresql://$(INTHUB_DB_USER):$(INTHUB_DB_PASS)@$(INTHUB_DB_HOST):$(INTHUB_DB_PORT)/$(INTHUB_DB_NAME)"
+  value: "postgresql://$(INTHUB_DB_USER):$(INTHUB_DB_PASS)@$(INTHUB_DB_HOST):$(INTHUB_DB_PORT)/$(INTHUB_DB_NAME)?sslmode=$(INTHUB_DB_SSL_MODE)"
 {{- end }}
 
 # OpenHands identity provider used to validate session cookies / API keys.

--- a/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/integrations-hub/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
             value: {{ .Values.database.host | quote }}
           - name: DB_PORT
             value: {{ .Values.database.port | quote }}
+          - name: PGSSLMODE
+            value: {{ .Values.database.sslMode | default "prefer" | quote }}
           - name: DB_NAME
             value: {{ .Values.database.name | quote }}
           - name: DB_USER

--- a/charts/integrations-hub/values.yaml
+++ b/charts/integrations-hub/values.yaml
@@ -129,6 +129,7 @@ database:
   #   - Feature env: "integrations-hub-feature-branch-postgresql"
   host: ""
   port: "5432"
+  sslMode: "prefer"
   user: "integrations_hub_user"
   name: "integrations_hub"
   # Secret containing the database password

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.37.2
+appVersion: sha-d765b0b
 version: 0.7.40
 maintainers:
   - name: rbren

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.37.2
-version: 0.7.39
+version: 0.7.40
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,20 +38,20 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.7
+    version: 0.3.8
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.11
+    version: 0.1.12
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0
   - name: plugin-directory
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.1
+    version: 0.1.2
     condition: plugin-directory.enabled
   - name: integrations-hub
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.0
+    version: 0.1.1
     condition: integrations-hub.enabled

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -346,6 +346,10 @@
   value: "{{ .Release.Name }}-postgresql"
 - name: DB_PORT
   value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
+- name: DB_SSL_MODE
+  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
+- name: PGSSLMODE
+  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME
@@ -355,6 +359,10 @@
   value: "{{ .Values.externalDatabase.host }}"
 - name: DB_PORT
   value: "{{ .Values.externalDatabase.port | default 5432 }}"
+- name: DB_SSL_MODE
+  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
+- name: PGSSLMODE
+  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
 - name: DB_USER
   value: "{{ .Values.externalDatabase.username }}"
 - name: DB_NAME

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -341,15 +341,15 @@
   value: "1"
 {{- end }}
 
+{{- $dbSslMode := "prefer" }}
+{{- if not .Values.postgresql.enabled }}
+{{- $dbSslMode = .Values.externalDatabase.sslMode | default "prefer" }}
+{{- end }}
 {{- if .Values.postgresql.enabled }}
 - name: DB_HOST
   value: "{{ .Release.Name }}-postgresql"
 - name: DB_PORT
   value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
-- name: DB_SSL_MODE
-  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
-- name: PGSSLMODE
-  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
 - name: DB_USER
   value: "{{ .Values.postgresql.auth.username }}"
 - name: DB_NAME
@@ -359,15 +359,15 @@
   value: "{{ .Values.externalDatabase.host }}"
 - name: DB_PORT
   value: "{{ .Values.externalDatabase.port | default 5432 }}"
-- name: DB_SSL_MODE
-  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
-- name: PGSSLMODE
-  value: {{ .Values.externalDatabase.sslMode | default "prefer" | quote }}
 - name: DB_USER
   value: "{{ .Values.externalDatabase.username }}"
 - name: DB_NAME
   value: "{{ .Values.externalDatabase.database }}"
 {{- end }}
+- name: DB_SSL_MODE
+  value: {{ $dbSslMode | quote }}
+- name: PGSSLMODE
+  value: {{ $dbSslMode | quote }}
 {{- if .Values.datadog.enabled }}
 # Datadog configuration
 - name: DD_AGENT_HOST

--- a/charts/openhands/templates/troubleshoot/_shared.tpl
+++ b/charts/openhands/templates/troubleshoot/_shared.tpl
@@ -6,9 +6,7 @@
 {{- if .host }}
 - postgresql:
     collectorName: external-postgresql
-    uri: postgresql://{{ .username | default "postgres" }}:@{{ .host }}:{{ .port | default 5432 }}/{{ .database | default "openhands" }}?sslmode=disable
-    tls:
-      disabled: true
+    uri: postgresql://{{ .username | default "postgres" }}:@{{ .host }}:{{ .port | default 5432 }}/{{ .database | default "openhands" }}?sslmode={{ .sslMode | default "prefer" }}
     password:
       secretName: {{ .existingSecret | default "postgres-password" }}
       secretKey: {{ .existingSecretPasswordKey | default "password" }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -338,6 +338,8 @@ keycloak:
       value: "xforwarded"
     - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
       value: "true"
+    # Bitnami Keycloak renders extraEnvVars with common.tplvalues.render, so
+    # this is evaluated in the Keycloak subchart context at render time.
     - name: KC_DB_URL_PROPERTIES
       value: 'sslmode={{ .Values.externalDatabase.sslMode | default "prefer" }}'
   image:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -324,6 +324,7 @@ keycloak:
     enabled: false
   externalDatabase:
     host: oh-main-postgresql
+    sslMode: "prefer"
     database: bitnami_keycloak
     existingSecret: postgres-password
     existingSecretUserKey: username
@@ -337,6 +338,8 @@ keycloak:
       value: "xforwarded"
     - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
       value: "true"
+    - name: KC_DB_URL_PROPERTIES
+      value: 'sslmode={{ .Values.externalDatabase.sslMode | default "prefer" }}'
   image:
     repository: bitnamilegacy/keycloak
   waitForDb:
@@ -376,6 +379,8 @@ keycloak:
             secretKeyRef:
               name: postgres-password
               key: password
+        - name: PGSSLMODE
+          value: '{{ .Values.externalDatabase.sslMode | default "prefer" }}'
 
 laminar:
   # Enable this if you want to use laminar
@@ -561,6 +566,7 @@ postgresql:
 externalDatabase:
   enabled: false
   port: "5432"
+  sslMode: "prefer"
   existingSecret: postgres-password
 
 redis:
@@ -666,6 +672,8 @@ runtime-api:
   env:
     DB_HOST: oh-main-postgresql
     DB_PORT: "5432"
+    DB_SSL_MODE: "prefer"
+    PGSSLMODE: "prefer"
     DB_USER: postgres
     DB_NAME: runtime_api_db
     K8S_NAMESPACE: "openhands"
@@ -730,6 +738,7 @@ plugin-directory:
     # When deployed as subchart, this is set by parent chart
     host: ""
     port: "5432"
+    sslMode: "prefer"
     user: "postgres"
     name: "plugindir"
     secretName: "postgres-password"
@@ -853,6 +862,7 @@ automation:
     #   - Feature env: "openhands-feature-branch-postgresql"
     host: ""
     port: "5432"
+    sslMode: "prefer"
     user: "automation_user"
     name: "automations"
     # Secret containing the automation database password
@@ -1105,6 +1115,7 @@ integrations-hub:
     url: ""
     host: ""
     port: "5432"
+    sslMode: "prefer"
     user: "integrations_hub_user"
     name: "integrations_hub"
     secretName: "integrations-hub-db-secret"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.37.2
+  tag: sha-d765b0b
 
 ingress:
   enabled: false

--- a/charts/plugin-directory/Chart.yaml
+++ b/charts/plugin-directory/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: plugin-directory
 description: OpenHands Plugin Directory — marketplace for discovering and reviewing agent plugins
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.1.0"

--- a/charts/plugin-directory/templates/_env.yaml
+++ b/charts/plugin-directory/templates/_env.yaml
@@ -7,6 +7,10 @@
   value: {{ .Values.database.host | quote }}
 - name: DB_PORT
   value: {{ .Values.database.port | quote }}
+- name: DB_SSL_MODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
+- name: PGSSLMODE
+  value: {{ .Values.database.sslMode | default "prefer" | quote }}
 - name: DB_USER
   value: {{ .Values.database.user | quote }}
 - name: DB_NAME
@@ -17,7 +21,7 @@
       name: {{ .Values.database.secretName }}
       key: {{ .Values.database.secretKey }}
 - name: DATABASE_URL
-  value: "postgresql://$(DB_USER):$(DB_PASS)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+  value: "postgresql://$(DB_USER):$(DB_PASS)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSL_MODE)"
 
 # Application configuration
 - name: MARKETPLACE_SOURCE

--- a/charts/plugin-directory/values.yaml
+++ b/charts/plugin-directory/values.yaml
@@ -101,6 +101,7 @@ database:
   # Full hostname of the PostgreSQL server
   host: ""
   port: "5432"
+  sslMode: "prefer"
   user: "postgres"
   name: "plugindir"
   # Secret containing the database password

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.7 # Change this to trigger a new helm chart version being published
+version: 0.3.8 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -1,7 +1,16 @@
 {{- define "runtime-api.env" }}
+{{- $dbSslMode := (get .Values.env "DB_SSL_MODE") | default (.Values.database.sslMode | default "prefer") }}
 {{- range $key, $value := .Values.env }}
 - name: {{ $key }}
   value: {{ $value | quote }}
+{{- end }}
+{{- if not (hasKey .Values.env "DB_SSL_MODE") }}
+- name: DB_SSL_MODE
+  value: {{ $dbSslMode | quote }}
+{{- end }}
+{{- if not (hasKey .Values.env "PGSSLMODE") }}
+- name: PGSSLMODE
+  value: {{ $dbSslMode | quote }}
 {{- end }}
 - name: RUNTIME_IDLE_SECONDS
   value: {{ .Values.cleanup.idle_seconds | default 1200 | quote }}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-0385b6b
+  tag: sha-573b515
   pullPolicy: Always
 
 imagePullSecrets:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -137,6 +137,7 @@ database:
   create: false # Will only be true for AWS as it can't create the DB in terraform
   secretName: runtime-api-db-credentials # Secret containing external database credentials
   port: "5432"
+  sslMode: "prefer"
   poolSize:
     api: 5 # Pool size for API deployment (default)
     cronjobs: 2 # Pool size for cronjobs (default)

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -699,6 +699,19 @@ spec:
           type: text
           default: "5432"
           when: 'repl{{ ConfigOptionEquals "postgres_type" "external_postgres" }}'
+        - name: external_postgres_ssl_mode
+          title: External PostgreSQL SSL Mode
+          help_text: Choose whether OpenHands should require SSL when connecting to your external PostgreSQL server.
+          type: select_one
+          default: "prefer"
+          when: 'repl{{ ConfigOptionEquals "postgres_type" "external_postgres" }}'
+          items:
+            - name: "prefer"
+              title: "Prefer SSL"
+            - name: "require"
+              title: "Require SSL"
+            - name: "disable"
+              title: "Disable SSL"
         - name: external_postgres_username
           title: External PostgreSQL Username
           help_text: Username for connecting to your external PostgreSQL server

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-82744a0'
+      tag: 'sha-d765b0b'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -95,6 +95,7 @@ spec:
       externalDatabase:
         host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
         port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
+        sslMode: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
         existingSecret: postgres-password
         existingSecretUserKey: username
         existingSecretPasswordKey: password
@@ -120,6 +121,8 @@ spec:
           value: "true"
         - name: KC_TRUSTSTORE_PATHS
           value: /etc/openhands/ca-bundle/ca-bundle.crt
+        - name: KC_DB_URL_PROPERTIES
+          value: 'sslmode={{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
       extraVolumes:
         - name: openhands-ca-bundle
           configMap:
@@ -137,7 +140,7 @@ spec:
       db:
         # TODO: should the fallback be openhands-postgresql here?
         endpoint: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
-        url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}/$(DATABASE_NAME)'
+        url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}/$(DATABASE_NAME)?sslmode={{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
         secret:
           name: postgres-password
           usernameKey: username
@@ -242,6 +245,8 @@ spec:
       env:
         DB_HOST: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
         DB_PORT: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
+        DB_SSL_MODE: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
+        PGSSLMODE: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
@@ -410,6 +415,7 @@ spec:
         externalDatabase:
           host: '{{repl ConfigOption "external_postgres_host"}}'
           port: '{{repl ConfigOption "external_postgres_port"}}'
+          sslMode: '{{repl ConfigOption "external_postgres_ssl_mode"}}'
           database: '{{repl ConfigOption "external_postgres_database"}}'
           username: '{{repl ConfigOption "external_postgres_username"}}'
           password: '{{repl ConfigOption "external_postgres_password"}}'
@@ -419,20 +425,25 @@ spec:
         keycloak:
           externalDatabase:
             port: '{{repl ConfigOption "external_postgres_port"}}'
+            sslMode: '{{repl ConfigOption "external_postgres_ssl_mode"}}'
             database: '{{repl ConfigOption "external_postgres_keycloak_database"}}'
         litellm-helm:
           db:
-            url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl ConfigOption "external_postgres_port"}}/$(DATABASE_NAME)'
+            url: 'postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):{{repl ConfigOption "external_postgres_port"}}/$(DATABASE_NAME)?sslmode={{repl ConfigOption "external_postgres_ssl_mode"}}'
             database: '{{repl ConfigOption "external_postgres_litellm_database"}}'
         runtime-api:
           databaseMigrations:
             createDatabases: repl{{ ConfigOptionEquals "external_postgres_create_databases" "1" }}
           env:
             DB_PORT: '{{repl ConfigOption "external_postgres_port"}}'
+            DB_SSL_MODE: '{{repl ConfigOption "external_postgres_ssl_mode"}}'
+            PGSSLMODE: '{{repl ConfigOption "external_postgres_ssl_mode"}}'
             DB_NAME: '{{repl ConfigOption "external_postgres_runtime_api_database"}}'
         plugin-directory:
           databaseMigrations:
             createDatabases: repl{{ ConfigOptionEquals "external_postgres_create_databases" "1" }}
+          database:
+            sslMode: '{{repl ConfigOption "external_postgres_ssl_mode"}}'
     - when: '{{repl ConfigOptionEquals "github_auth_enabled" "1" }}'
       recursiveMerge: true
       values:
@@ -497,6 +508,7 @@ spec:
             createDatabaseUser: true
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'
             port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
+            sslMode: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
             superuserName: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
 
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
@@ -625,6 +637,8 @@ spec:
               value: "true"
             - name: KC_TRUSTSTORE_PATHS
               value: /etc/openhands/ca-bundle/ca-bundle.crt
+            - name: KC_DB_URL_PROPERTIES
+              value: 'sslmode={{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
             # Proxy env vars
             - name: HTTP_PROXY
               value: '{{repl ConfigOption "http_proxy"}}'


### PR DESCRIPTION
## Summary
- Add a KOTS `external_postgres_ssl_mode` select field with `prefer`, `require`, and `disable`.
- Thread the SSL mode into OpenHands, Keycloak, LiteLLM, runtime-api, plugin-directory, automation, integrations-hub, DB init/wait containers, and external Postgres support-bundle checks.
- Bump affected child chart versions and the parent OpenHands chart version.
- Update chart image tags to the merged SSL-mode builds: OpenHands `sha-d765b0b`, runtime-api `sha-573b515`, automation `sha-eac5478`.

## Validation
- `make clean charts`
- `helm template oh-main build/openhands-0.7.40.tgz ... externalDatabase.sslMode=require ...`
- `helm template oh-main build/openhands-0.7.40.tgz ... keycloak.enabled=true ... sslMode=require ...`
- `helm template oh-main build/openhands-0.7.40.tgz ... automation/plugin-directory/integrations-hub enabled with their database.sslMode=require overrides ...`
- `helm lint build/openhands-0.7.40.tgz`
- `helm lint charts/runtime-api charts/automation charts/plugin-directory charts/integrations-hub`
- `git diff --check`
- Successfully validated `sslmode=require` on a real Replicated OHE instance using an external Postgres endpoint on port `5433`; app login and a test conversation passed.

## Notes
- Direct Helm installs configure database settings per subchart. The Replicated OHE config maps `external_postgres_ssl_mode` into the enabled services automatically.
- `charts/openhands/Chart.lock` was not regenerated against final OCI child chart versions because `runtime-api 0.3.8`, `automation 0.1.12`, `plugin-directory 0.1.2`, and `integrations-hub 0.1.1` are not published as final OCI versions until this PR merges. `make clean charts` validated packaging via local sibling chart dependencies.