### PR TITLE
Fix automation database grants

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/templates/deployment.yaml
+++ b/charts/automation/templates/deployment.yaml
@@ -57,16 +57,37 @@ spec:
           - |
             echo "Waiting for PostgreSQL at $DB_HOST to be available..."
             for i in $(seq 1 60); do
-              if psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d postgres -c "SELECT 1;" > /dev/null 2>&1; then
+              if psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d postgres -c "SELECT 1;" > /dev/null 2>&1; then
                 echo "PostgreSQL is up!"
 
                 echo "Creating the database $DB_NAME if it doesn't exist..."
-                psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1 || \
-                psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d postgres -c "CREATE DATABASE $DB_NAME;"
+                psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d postgres \
+                  --set=ON_ERROR_STOP=1 \
+                  --set=db_name="$DB_NAME" <<'SQL'
+            SELECT format('CREATE DATABASE %I', :'db_name')
+            WHERE NOT EXISTS (
+              SELECT 1 FROM pg_database WHERE datname = :'db_name'
+            )
+            \gexec
+            SQL
 
-                echo "Creating the user $DB_USER if it doesn't exist..."
-                psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d $DB_NAME -tc "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'" | grep -q 1 || \
-                (psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d $DB_NAME -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER; GRANT USAGE ON SCHEMA public TO $DB_USER; GRANT CREATE ON SCHEMA public TO $DB_USER; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $DB_USER;")
+                echo "Creating the user $DB_USER if it doesn't exist and applying grants..."
+                psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d "$DB_NAME" \
+                  --set=ON_ERROR_STOP=1 \
+                  --set=db_name="$DB_NAME" \
+                  --set=db_user="$DB_USER" \
+                  --set=db_password="$DB_PASSWORD" <<'SQL'
+            SELECT format('CREATE USER %I WITH PASSWORD %L', :'db_user', :'db_password')
+            WHERE NOT EXISTS (
+              SELECT 1 FROM pg_roles WHERE rolname = :'db_user'
+            )
+            \gexec
+
+            GRANT ALL PRIVILEGES ON DATABASE :"db_name" TO :"db_user";
+            GRANT USAGE ON SCHEMA public TO :"db_user";
+            GRANT CREATE ON SCHEMA public TO :"db_user";
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO :"db_user";
+            SQL
 
                 exit 0
               fi

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: sha-d765b0b
-version: 0.7.40
+version: 0.7.41
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,7 +42,7 @@ dependencies:
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.12
+    version: 0.1.13
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts


### PR DESCRIPTION
## Summary
- Make the automation chart's external Postgres bootstrap grant database and public schema privileges on every deploy.
- Keep database and role creation idempotent while repairing existing roles that are missing `USAGE` or `CREATE` on the `public` schema.
- Use psql identifier/literal quoting for the create/grant SQL, matching the safer pattern already used by integrations-hub.

## Why
If `automation_user` already existed, the chart skipped the entire create-user branch, including the grants needed for Alembic migrations. That could leave the automation migration init container failing until an operator manually ran `GRANT USAGE, CREATE ON SCHEMA public TO automation_user;`.

## Validation
- `helm dependency build charts/automation`
- `helm template automation charts/automation --set database.createDatabaseUser=true --set database.host=db.example.com --set database.port=5433 --set database.sslMode=require >/tmp/automation-chart-render.yaml`
- `helm lint charts/automation`
