### PR TITLE
Add KOTS default OpenHands organization config

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -430,6 +430,34 @@ spec:
           hidden: true
           value: '{{repl RandomString 32}}'
 
+    - name: default_openhands_organization
+      title: Default OpenHands Organization
+      description: 'Bootstrap a default OpenHands organization for this instance. Note: this config is additive and never deletes organizations, removes members, or demotes users; these actions can be done in the app.'
+      items:
+        - name: default_openhands_org_enabled
+          title: Enable Default OpenHands Organization
+          help_text: Turn on default OpenHands organization setup.
+          type: bool
+          default: "0"
+        - name: default_openhands_org_name
+          title: Organization Name
+          help_text: Enter the name of the default organization. New organizations are created after a configured owner signs in.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
+          required: true
+        - name: default_openhands_org_owner_emails
+          title: Owner Emails
+          help_text: 'Enter one or more owner email addresses, separated by commas (e.g., user1@example.com, user2@example.com). Note: removing an email from this field does not remove or demote existing owners; existing owners can be managed in the app.'
+          type: textarea
+          when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
+          required: true
+        - name: default_openhands_org_auto_add_users
+          title: Automatically Add Signed-In Users
+          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, new users land in the default organization automatically; existing users can switch to the default organization via the UI.
+          type: bool
+          default: "1"
+          when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
+
     - name: bitbucket_data_center_authentication
       title: Bitbucket Data Center Authentication
       description: Configure Bitbucket Data Center OAuth for user authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -35,6 +35,10 @@ spec:
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA_DC: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       OH_AGENT_SERVER_ENV: '{"SSL_CERT_FILE": "/etc/openhands/ca-bundle/ca-bundle.crt", "REQUESTS_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "GIT_SSL_CAINFO": "/etc/openhands/ca-bundle/ca-bundle.crt", "CURL_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "NODE_EXTRA_CA_CERTS": "/etc/openhands/ca-bundle/ca-bundle.crt"}'
+      OPENHANDS_DEFAULT_ORG_ENABLED: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
+      OPENHANDS_DEFAULT_ORG_NAME: 'repl{{ ConfigOption "default_openhands_org_name" }}'
+      OPENHANDS_DEFAULT_ORG_OWNER_EMAILS: 'repl{{ ConfigOption "default_openhands_org_owner_emails" }}'
+      OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS: 'repl{{ ConfigOptionEquals "default_openhands_org_auto_add_users" "1" }}'
 
     ingress:
       enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-d765b0b'
+      tag: 'sha-774a36e'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## Summary

Adds KOTS Admin Console configuration for bootstrapping a default OpenHands organization in OHE Replicated installs.

- Adds a `Default OpenHands Organization` config section.
- Supports enabling the default org bootstrap, setting the org name, configuring owner emails, and toggling automatic member addition.
- Passes the configured values through to the OpenHands deployment as environment variables.
- Updates the Replicated enterprise-server image tag to `sha-774a36e`, which includes the merged backend support.
- Uses creation-oriented copy while keeping destructive membership/org changes managed in the app.

## Companion PR

Backend support merged in OpenHands/OpenHands#14713 (`774a36ef7f7211c1cda99eea59a01d0b2b04d63d`).

## Validation

- `yq '.' replicated/config.yaml >/dev/null`
- `yq '.' replicated/openhands.yaml >/dev/null`
- `docker manifest inspect ghcr.io/openhands/enterprise-server:sha-774a36e >/dev/null`
- `make lint`
- Created and promoted Replicated release `0.7.41-default-org-20260608021245` as release sequence `931`
- Deployed to R01 as KOTS sequence `12`
- Verified R01 app and KOTS admin both returned HTTP 200
- Successfully validated the default organization flow on R01 with the companion backend changes: default org creation, owner/member behavior, and healthy app/admin endpoints.

## Notes

`make lint` emits the existing informational `may-contain-secrets` warnings in `build/openhands.yaml`.
