### PR TITLE
Add KOTS LiteLLM admin password

### DIFF
--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/litellm-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/litellm-env-secrets.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
+  {{- if .Values.config.litellm_admin_password }}
+  UI_PASSWORD: {{ .Values.config.litellm_admin_password | b64enc | quote }}
+  {{- end }}
   {{- if .Values.config.anthropic_api_key }}
   ANTHROPIC_API_KEY: {{ .Values.config.anthropic_api_key | b64enc | quote }}
   {{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -17,6 +17,7 @@ config:
   keycloak_admin_password: ""
   keycloak_client_secret: ""
   litellm_api_key: ""
+  litellm_admin_password: ""
   default_api_key: ""
   sandbox_api_key: ""
   

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -321,6 +321,16 @@ spec:
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
 
+    - name: litellm_admin_console
+      title: LiteLLM Admin Console
+      description: Configure credentials for the bundled LiteLLM Admin UI.
+      items:
+        - name: litellm_admin_password
+          title: LiteLLM Admin Password
+          help_text: Password for the LiteLLM Admin UI at the LLM Proxy hostname with /ui. The username is admin. Changing this password restarts LiteLLM.
+          type: password
+          required: true
+
     - name: security_secrets
       title: Security & Authentication
       description: Configure passwords and secrets for various services

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -327,7 +327,7 @@ spec:
       items:
         - name: litellm_admin_password
           title: LiteLLM Admin Password
-          help_text: Password for the LiteLLM Admin UI at the LLM Proxy hostname with /ui. The username is admin. Changing this password restarts LiteLLM.
+          help_text: Password for the LiteLLM Admin UI at the LLM Proxy hostname with /ui. The username is fixed as admin. Changing this password restarts LiteLLM.
           type: password
           required: true
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -163,6 +163,8 @@ spec:
         - name: '{{repl ImagePullSecretName }}'
       environmentSecrets:
         - litellm-env-secrets
+      podAnnotations:
+        checksum/litellm-credentials: 'repl{{ sha256sum (printf "%s|%s" (ConfigOption "litellm_api_key") (ConfigOption "litellm_admin_password")) }}'
       # caBundle wiring: mount the trust-manager Bundle ConfigMap and point
       # the Python SSL stack (httpx + requests) at the merged PEM. envVars
       # is a map (merges with proxy/vertex blocks), but volumes/volumeMounts
@@ -172,6 +174,7 @@ spec:
       envVars:
         SSL_CERT_FILE: /etc/openhands/ca-bundle/ca-bundle.crt
         REQUESTS_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
+        UI_USERNAME: admin
       volumes:
         - name: openhands-ca-bundle
           configMap:
@@ -339,7 +342,7 @@ spec:
     # Grouped in order: LLM provider keys; app/infra secrets (admin, postgres,
     # redis, jwt, keycloak, litellm, sandbox, plugin-directory, automation); then
     # auth/integration secrets (bitbucket DC, jira DC, github, gitlab, slack, laminar).
-    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "azure_devops_client_secret") (ConfigOption "jira_data_center_client_secret") (ConfigOption "jira_data_center_service_account_email") (ConfigOption "jira_data_center_service_account_pat") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key")) }}'
+    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "litellm_admin_password") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "azure_devops_client_secret") (ConfigOption "jira_data_center_client_secret") (ConfigOption "jira_data_center_service_account_email") (ConfigOption "jira_data_center_service_account_pat") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key")) }}'
     bitbucketDataCenter:
       enabled: repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}
       host: 'repl{{ ConfigOption "bitbucket_data_center_domain" }}'

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -18,6 +18,7 @@ spec:
       keycloak_admin_password: '{{repl ConfigOption "keycloak_admin_password"}}'
       keycloak_client_secret: '{{repl ConfigOption "keycloak_client_secret"}}'
       litellm_api_key: '{{repl ConfigOption "litellm_api_key"}}'
+      litellm_admin_password: '{{repl ConfigOption "litellm_admin_password"}}'
       default_api_key: '{{repl ConfigOption "default_api_key"}}'
       sandbox_api_key: '{{repl ConfigOption "default_api_key"}}'
 


### PR DESCRIPTION
## Summary

- Add a required KOTS `LiteLLM Admin Password` field under a new `LiteLLM Admin Console` config section.
- Keep the LiteLLM UI username fixed as `admin`.
- Render the configured password into `litellm-env-secrets` as `UI_PASSWORD`.
- Add a LiteLLM pod checksum annotation so changing the KOTS password restarts `openhands-litellm` and reloads the env var.

## Why

OHE customers can technically log into the bundled LiteLLM UI today by retrieving the hidden LiteLLM master key from Kubernetes, but that requires raw `kubectl` access. This gives admins a normal KOTS flow: set the LiteLLM admin password, deploy config, and log into `https://llm-proxy.<domain>/ui` as `admin`.

The field is required and has no generated default. On upgrade, admins must choose a password rather than receiving an unknowable random value.

## Validation

Successfully validated on an OHE replicated instance.

- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- `helm template openhands-secrets charts/openhands-secrets --namespace openhands --set config.litellm_admin_password=test-password`
- In-place validation on `instance-2`:
  - Published branch channel `alona/litellm-admin-login`.
  - Upgraded existing OHE install without reset.
  - Set `litellm_admin_password` through KOTS config.
  - Confirmed `litellm-env-secrets` contains `UI_PASSWORD`.
  - Confirmed running `openhands-litellm` pod has `UI_USERNAME=admin` and the configured `UI_PASSWORD`.
  - `POST /v2/login` with `admin` and configured password returned HTTP 200.
  - Same endpoint with wrong password returned HTTP 401.
  - `https://llm-proxy.replicated-02.aws.alona.platform-team.all-hands.dev/ui` resolves to HTTP 200 after redirect.
  
  
<img width="789" height="289" alt="Screenshot 2026-06-08 at 12 12 26 PM" src="https://github.com/user-attachments/assets/ea8684a3-52db-42e4-8754-5548e08bebbf" />

