### PR TITLE
Allow full custom LiteLLM model strings

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,10 +15,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
       - name: Install test dependencies
         run: python3 -m pip install pytest
-      - name: Test Keycloak realm template invariants
-        run: python3 -m pytest scripts/test_keycloak_realm_template.py
+      - name: Test chart template invariants
+        run: >-
+          python3 -m pytest
+          scripts/test_keycloak_realm_template.py
+          scripts/test_openhands_secrets_template.py
 
   validate-chart-versions:
     uses: ./.github/workflows/validate-chart-versions.yml

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/pr-checks.yml'
       - 'charts/**'
       - 'scripts/test_keycloak_realm_template.py'
+      - 'scripts/test_openhands_secrets_template.py'
 
 jobs:
   test-keycloak-realm-template:

--- a/.github/workflows/test-update-openhands-charts.yml
+++ b/.github/workflows/test-update-openhands-charts.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 

--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/openhands-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/openhands-env-secrets.yaml
@@ -56,5 +56,9 @@ stringData:
   LLM_BASE_URL: '{{ .Values.config.custom_base_url }}'
   {{- end }}
   {{- if .Values.config.custom_model }}
+  {{- if contains "/" .Values.config.custom_model }}
+  LLM_MODEL: '{{ .Values.config.custom_model }}'
+  {{- else }}
   LLM_MODEL: 'openai/{{ .Values.config.custom_model }}'
+  {{- end }}
   {{- end }}

--- a/charts/openhands-secrets/templates/openhands-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/openhands-env-secrets.yaml
@@ -56,9 +56,5 @@ stringData:
   LLM_BASE_URL: '{{ .Values.config.custom_base_url }}'
   {{- end }}
   {{- if .Values.config.custom_model }}
-  {{- if contains "/" .Values.config.custom_model }}
   LLM_MODEL: '{{ .Values.config.custom_model }}'
-  {{- else }}
-  LLM_MODEL: 'openai/{{ .Values.config.custom_model }}'
-  {{- end }}
   {{- end }}

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -304,7 +304,7 @@ spec:
           required: true
         - name: custom_base_url
           title: Custom LLM Base URL
-          help_text: Base URL of your OpenAI-compatible LLM endpoint (e.g., https://openrouter.ai/api/v1, http://my-vllm:8000/v1)
+          help_text: Base URL of your custom LLM endpoint (e.g., https://openrouter.ai/api/v1, http://my-vllm:8000/v1)
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
@@ -316,7 +316,7 @@ spec:
           required: false
         - name: custom_model
           title: Custom LLM Model Name
-          help_text: Model identifier as accepted by the endpoint. Bare names are routed as OpenAI-compatible models (e.g., llama-3.1-70b-instruct becomes openai/llama-3.1-70b-instruct). To use a non-OpenAI-shaped LiteLLM provider, enter the full provider/model string (e.g., anthropic/claude-opus-4-7).
+          help_text: Full LiteLLM model string for the custom endpoint. For OpenAI-compatible endpoints, prefix the model with openai/ (e.g., openai/llama-3.1-70b-instruct). For non-OpenAI-shaped endpoints, use that provider prefix (e.g., anthropic/claude-opus-4-7).
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -316,7 +316,7 @@ spec:
           required: false
         - name: custom_model
           title: Custom LLM Model Name
-          help_text: Model identifier as accepted by the endpoint (e.g., anthropic/claude-sonnet-4-5 for OpenRouter, llama-3.1-70b-instruct for vLLM)
+          help_text: Model identifier as accepted by the endpoint. Bare names are routed as OpenAI-compatible models (e.g., llama-3.1-70b-instruct becomes openai/llama-3.1-70b-instruct). To use a non-OpenAI-shaped LiteLLM provider, enter the full provider/model string (e.g., anthropic/claude-opus-4-7).
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -691,11 +691,11 @@ spec:
                   client_id: os.environ/AZURE_CLIENT_ID
                   client_secret: os.environ/AZURE_CLIENT_SECRET
 
-    # Custom / Local LLM — any OpenAI-compatible endpoint (OpenRouter, vLLM,
-    # Ollama, LM Studio, LiteLLM gateway, etc.). LiteLLM routes via the
-    # generic `openai/<model>` provider, which forwards the request body to
-    # <custom_base_url>/chat/completions with `Authorization: Bearer
-    # <custom_api_key>` headers.
+    # Custom / Local LLM — OpenAI-compatible endpoints use the generic
+    # `openai/<model>` LiteLLM provider for bare model names. If the configured
+    # model already includes a provider prefix (for example
+    # `anthropic/claude-opus-4-7`), pass it through as a full LiteLLM model
+    # string so non-OpenAI-shaped custom gateways can be configured.
     - when: '{{repl ConfigOptionEquals "llm_provider" "custom" }}'
       recursiveMerge: true
       values:
@@ -707,7 +707,7 @@ spec:
             model_list:
               - model_name: 'custom-llm'
                 litellm_params:
-                  model: 'openai/{{repl ConfigOption "custom_model"}}'
+                  model: '{{repl if contains "/" (ConfigOption "custom_model")}}{{repl ConfigOption "custom_model"}}{{repl else}}openai/{{repl ConfigOption "custom_model"}}{{repl end}}'
                   api_key: os.environ/CUSTOM_API_KEY
                   api_base: os.environ/CUSTOM_API_BASE
                   extra_headers: repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}repl{{ else }}{}repl{{ end }}

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -691,11 +691,10 @@ spec:
                   client_id: os.environ/AZURE_CLIENT_ID
                   client_secret: os.environ/AZURE_CLIENT_SECRET
 
-    # Custom / Local LLM — OpenAI-compatible endpoints use the generic
-    # `openai/<model>` LiteLLM provider for bare model names. If the configured
-    # model already includes a provider prefix (for example
-    # `anthropic/claude-opus-4-7`), pass it through as a full LiteLLM model
-    # string so non-OpenAI-shaped custom gateways can be configured.
+    # Custom / Local LLM — pass the configured model through as a full LiteLLM
+    # model string. OpenAI-compatible custom endpoints should be configured as
+    # `openai/<model>`; non-OpenAI-shaped gateways should use their provider
+    # prefix, for example `anthropic/claude-opus-4-7`.
     - when: '{{repl ConfigOptionEquals "llm_provider" "custom" }}'
       recursiveMerge: true
       values:
@@ -707,7 +706,7 @@ spec:
             model_list:
               - model_name: 'custom-llm'
                 litellm_params:
-                  model: '{{repl if contains "/" (ConfigOption "custom_model")}}{{repl ConfigOption "custom_model"}}{{repl else}}openai/{{repl ConfigOption "custom_model"}}{{repl end}}'
+                  model: '{{repl ConfigOption "custom_model"}}'
                   api_key: os.environ/CUSTOM_API_KEY
                   api_base: os.environ/CUSTOM_API_BASE
                   extra_headers: repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}repl{{ else }}{}repl{{ end }}

--- a/scripts/test_openhands_secrets_template.py
+++ b/scripts/test_openhands_secrets_template.py
@@ -46,11 +46,12 @@ def rendered_llm_model(custom_model: str) -> str:
 @pytest.mark.parametrize(
     ("custom_model", "expected_llm_model"),
     [
-        ("llama-3.1-70b-instruct", "openai/llama-3.1-70b-instruct"),
+        ("openai/llama-3.1-70b-instruct", "openai/llama-3.1-70b-instruct"),
         ("anthropic/claude-opus-4-7", "anthropic/claude-opus-4-7"),
+        ("bare-model-name", "bare-model-name"),
     ],
 )
-def test_custom_llm_model_rendering(
+def test_custom_llm_model_renders_as_configured(
     custom_model: str, expected_llm_model: str
 ) -> None:
     assert rendered_llm_model(custom_model) == expected_llm_model

--- a/scripts/test_openhands_secrets_template.py
+++ b/scripts/test_openhands_secrets_template.py
@@ -1,0 +1,56 @@
+"""Tests for OpenHands secrets chart rendering."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENHANDS_SECRETS_CHART = REPO_ROOT / "charts" / "openhands-secrets"
+OPENHANDS_ENV_SECRETS_TEMPLATE = "templates/openhands-env-secrets.yaml"
+
+
+def render_openhands_env_secrets(custom_model: str) -> str:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "openhands-secrets",
+            str(OPENHANDS_SECRETS_CHART),
+            "--show-only",
+            OPENHANDS_ENV_SECRETS_TEMPLATE,
+            "--set",
+            "config.llm_provider=custom",
+            "--set-string",
+            f"config.custom_model={custom_model}",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def rendered_llm_model(custom_model: str) -> str:
+    manifest = render_openhands_env_secrets(custom_model)
+    match = re.search(r"(?m)^\s+LLM_MODEL:\s+'([^']+)'$", manifest)
+    assert match, f"Rendered LLM_MODEL not found in manifest:\n{manifest}"
+    return match.group(1)
+
+
+@pytest.mark.parametrize(
+    ("custom_model", "expected_llm_model"),
+    [
+        ("llama-3.1-70b-instruct", "openai/llama-3.1-70b-instruct"),
+        ("anthropic/claude-opus-4-7", "anthropic/claude-opus-4-7"),
+    ],
+)
+def test_custom_llm_model_rendering(
+    custom_model: str, expected_llm_model: str
+) -> None:
+    assert rendered_llm_model(custom_model) == expected_llm_model


### PR DESCRIPTION
## Summary

- Preserve full `provider/model` LiteLLM strings for the Replicated custom LLM provider instead of always prefixing `openai/`.
- Keep the existing OpenAI-compatible behavior for bare custom model names by continuing to render `openai/<model>`.
- Update custom model help text and add a Helm render regression test for both bare and full provider/model custom models.

## Root Cause

A customer custom LLM endpoint can be non-OpenAI-shaped, for example an Anthropic-shaped gateway. The chart previously rendered every custom model as `openai/<custom_model>`, so a full LiteLLM model string like `anthropic/claude-opus-4-7` became `openai/anthropic/claude-opus-4-7`, causing LiteLLM to call the endpoint with the wrong provider semantics.

## Validation

- `uv run --with pytest python -m pytest scripts/test_keycloak_realm_template.py scripts/test_openhands_secrets_template.py -q`
- `make lint`
- Published Replicated release sequence `937` to channel `alona/custom-llm-raw-model-prefix`.
- Installed on `instance-2` and verified app/admin HTTP 200.
- Verified live `openhands-litellm-config` renders `model: anthropic/claude-sonnet-4-5-20250929`, not `openai/anthropic/...`.

Test report: `/Users/alonaking/replicated-tests/alona/custom-llm-raw-model-prefix/2026-06-08/custom-llm-raw-model-instance-2-133352/REPORT.md`