### PR TITLE
APP-2260: omit LMNR_HTTP_PORT env when httpPort is unset

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: sha-d765b0b
-version: 0.7.41
+version: 0.7.42
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -411,8 +411,10 @@
 {{- end }}
 - name: LMNR_FORCE_HTTP
   value: {{ if and .Values.laminar.enabled .Values.laminar.forceHttp }}{{ .Values.laminar.forceHttp | quote }}{{ else }}""{{ end }}
+{{- if and .Values.laminar.enabled .Values.laminar.httpPort }}
 - name: LMNR_HTTP_PORT
-  value: {{ if and .Values.laminar.enabled .Values.laminar.httpPort }}{{ .Values.laminar.httpPort | quote }}{{ else }}""{{ end }}
+  value: {{ .Values.laminar.httpPort | quote }}
+{{- end }}
 - name: DB_PASS
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Problem

In `charts/openhands/templates/_env.yaml`, the `LMNR_HTTP_PORT` entry guarded only its **value**, not the whole env entry:

```yaml
- name: LMNR_HTTP_PORT
  value: {{ if and .Values.laminar.enabled .Values.laminar.httpPort }}{{ .Values.laminar.httpPort | quote }}{{ else }}""{{ end }}
```

`laminar.httpPort` defaults to `null` (per the chart values comment, null means "use the SDK default of 443"). But because only the value was conditional, the key was **always rendered**, producing `LMNR_HTTP_PORT=""` whenever `httpPort` was unset.

An empty-valued env key is not the same as an unset one — it is a real key in the container environment. The agent server propagates this key into runtime sandbox creation requests, so the request's env key set no longer matches the warm runtime pool (which has no such key). Warm-runtime matching then fails and every conversation cold-starts.

## Fix

Wrap the entire entry in the conditional so the key is **omitted** when `httpPort` is not set, mirroring the existing `LMNR_BASE_URL` block just above it:

```yaml
{{- if and .Values.laminar.enabled .Values.laminar.httpPort }}
- name: LMNR_HTTP_PORT
  value: {{ .Values.laminar.httpPort | quote }}
{{- end }}
```

## Behavior

- `httpPort: null` (default) → key omitted → request env matches the warm pool again; SDK falls back to its default port (443).
- `httpPort: 8000` (self-hosted) → `LMNR_HTTP_PORT=8000` emitted, unchanged from before.

Patch `version` bumped `0.7.41` → `0.7.42`.

## Testing

Template change is a standard `{{- if }}…{{- end }}` guard identical to the adjacent `LMNR_BASE_URL` block; a full `helm template` render requires `helm dependency build` for the subcharts.