### PR TITLE
Expose Keycloak SSO session lifetimes as KOTS config options

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: sha-d765b0b
-version: 0.7.43
+version: 0.7.44
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -96,6 +96,17 @@ data:
     export GITLAB_HOST=${GITLAB_HOST:-"gitlab.com"}
     export AZURE_DEVOPS_TENANT_ID=${AZURE_DEVOPS_TENANT_ID:-"common"}
     envsubst '$WEB_HOST,$AUTH_WEB_HOST,$KEYCLOAK_REALM_NAME,$KEYCLOAK_CLIENT_ID,$KEYCLOAK_CLIENT_SECRET,$GITHUB_APP_CLIENT_ID,$GITHUB_APP_CLIENT_SECRET,$GITLAB_APP_CLIENT_ID,$GITLAB_APP_CLIENT_SECRET,$GITLAB_HOST,$BITBUCKET_APP_CLIENT_ID,$BITBUCKET_APP_CLIENT_SECRET,$GITHUB_BASE_URL,$KEYCLOAK_SMTP_PASSWORD,$BITBUCKET_DATA_CENTER_HOST,$BITBUCKET_DATA_CENTER_CLIENT_ID,$BITBUCKET_DATA_CENTER_CLIENT_SECRET,$AZURE_DEVOPS_TENANT_ID,$AZURE_DEVOPS_CLIENT_ID,$AZURE_DEVOPS_CLIENT_SECRET'< /realm-template/allhands-realm-github-provider.json.tmpl > /tmp/allhands-realm-github-provider.json
+    # Apply realm SSO session lifetimes (seconds) on top of the rendered realm
+    # JSON. These are numeric realm-level fields, so they are set with jq (the
+    # template must stay valid JSON) and flow through both the create path and
+    # the realm-settings update path below, meaning changes take effect on a
+    # live install at the next restart.
+    SSO_SESSION_IDLE_TIMEOUT={{ .Values.keycloak.ssoSessionIdleTimeout | default 1800 | int }}
+    SSO_SESSION_MAX_LIFESPAN={{ .Values.keycloak.ssoSessionMaxLifespan | default 36000 | int }}
+    jq --argjson idle "$SSO_SESSION_IDLE_TIMEOUT" --argjson max "$SSO_SESSION_MAX_LIFESPAN" \
+      '.ssoSessionIdleTimeout = $idle | .ssoSessionMaxLifespan = $max' \
+      /tmp/allhands-realm-github-provider.json > /tmp/allhands-realm-with-sessions.json
+    mv /tmp/allhands-realm-with-sessions.json /tmp/allhands-realm-github-provider.json
     REALM_JSON=/tmp/allhands-realm-github-provider.json
 
     if [ "$ERROR_MESSAGE" = "Realm not found." ]; then

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -306,6 +306,15 @@ keycloak:
   # keycloak-admin and keycloak-realm secrets) at that external server, and set
   # this to true.
   provisionRealm: false
+  # Parent-chart realm settings (not consumed by the Keycloak subchart),
+  # applied by the keycloak-config init container on create and on every
+  # update, so changes take effect on a live install.
+  # SSO session lifetimes for the OpenHands realm, in seconds. Idle timeout is
+  # how long a login session survives inactivity; max lifespan caps the total
+  # session duration before the user is sent back through the identity
+  # provider (e.g. Bitbucket Data Center) to log in again.
+  ssoSessionIdleTimeout: 1800
+  ssoSessionMaxLifespan: 36000
   url: "http://keycloak"
   fullnameOverride: keycloak
   replicaCount: 1

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1054,3 +1054,25 @@ spec:
             regex:
               pattern: '(?s)^\s*(\{\s*\}|\{\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*(,\s*"(?:[^"\\]|\\.)+"\s*:\s*"(?:[^"\\]|\\.)+"\s*)*\})?\s*$'
               message: Must be blank or a JSON object with string values, such as {"Header-Name":"value"}
+        - name: keycloak_sso_session_idle_timeout
+          title: Login Session Idle Timeout (seconds)
+          help_text: >-
+            How long a login session stays valid without activity before the user must sign in again. Default is 1800 (30 minutes).
+          type: text
+          default: "1800"
+          required: true
+          validation:
+            regex:
+              pattern: '^[1-9][0-9]*$'
+              message: Must be a positive number of seconds
+        - name: keycloak_sso_session_max_lifespan
+          title: Login Session Max Duration (seconds)
+          help_text: >-
+            Maximum total lifetime of a login session before the user must sign in again, regardless of activity. Default is 36000 (10 hours). Each forced re-login also re-authorizes the configured identity provider (for example, Bitbucket Data Center records a new authorized-application grant), so raising this reduces how often that happens.
+          type: text
+          default: "36000"
+          required: true
+          validation:
+            regex:
+              pattern: '^[1-9][0-9]*$'
+              message: Must be a positive number of seconds

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -72,6 +72,8 @@ spec:
     keycloak:
       enabled: true
       url: 'http://keycloak'
+      ssoSessionIdleTimeout: 'repl{{ ConfigOption "keycloak_sso_session_idle_timeout" }}'
+      ssoSessionMaxLifespan: 'repl{{ ConfigOption "keycloak_sso_session_max_lifespan" }}'
       resourcesPreset: none
       resources:
         requests:

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -98,6 +98,68 @@ def test_keycloak_api_call_extraction_is_not_tied_to_yaml_indent() -> None:
     assert "errorMessage" in keycloak_api_call_body(script_template)
 
 
+def sso_session_jq_filter(script_template: str) -> str:
+    match = re.search(
+        r"jq --argjson idle \"\$SSO_SESSION_IDLE_TIMEOUT\" "
+        r"--argjson max \"\$SSO_SESSION_MAX_LIFESPAN\" \\\n"
+        r"\s*'([^']+)'",
+        script_template,
+    )
+    assert match, (
+        "Could not find the SSO session lifetime jq override in "
+        "keycloak-config-script.yaml"
+    )
+    return match.group(1)
+
+
+def test_keycloak_config_script_applies_sso_session_lifetimes() -> None:
+    """The config script must apply keycloak.ssoSession* values to the realm JSON.
+
+    The realm template itself must stay valid JSON, so the numeric session
+    lifetimes are applied with jq after envsubst rather than templated in.
+    """
+    script_template = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+
+    assert ".Values.keycloak.ssoSessionIdleTimeout" in script_template
+    assert ".Values.keycloak.ssoSessionMaxLifespan" in script_template
+
+    jq_filter = sso_session_jq_filter(script_template)
+    assert ".ssoSessionIdleTimeout = $idle" in jq_filter
+    assert ".ssoSessionMaxLifespan = $max" in jq_filter
+
+
+def test_sso_session_jq_filter_rewrites_realm_lifetimes() -> None:
+    """Run the script's actual jq filter against the realm template."""
+    import shutil
+    import subprocess
+
+    if shutil.which("jq") is None:
+        pytest.skip("jq not available")
+
+    script_template = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    jq_filter = sso_session_jq_filter(script_template)
+
+    result = subprocess.run(
+        [
+            "jq",
+            "--argjson",
+            "idle",
+            "28800",
+            "--argjson",
+            "max",
+            "2592000",
+            jq_filter,
+            str(REALM_TEMPLATE),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    realm = json.loads(result.stdout)
+    assert realm["ssoSessionIdleTimeout"] == 28800
+    assert realm["ssoSessionMaxLifespan"] == 2592000
+
+
 def test_keycloak_error_guard_catches_missing_error_message() -> None:
     script_template = """\
     keycloak_api_call() {


### PR DESCRIPTION
## Summary

- Add KOTS options `keycloak_sso_session_idle_timeout` (default 1800) and `keycloak_sso_session_max_lifespan` (default 36000) under Advanced Options, with numeric validation.
- Wire them through new parent-chart values `keycloak.ssoSessionIdleTimeout` / `keycloak.ssoSessionMaxLifespan`.
- Apply them to the rendered realm JSON with `jq` in the keycloak-config init container (the realm template must stay valid JSON). They flow through both the realm-create and realm-update paths, so changing the KOTS value updates a live install on the next deploy.

## Why

The allhands realm hardcodes a 30-minute idle timeout and 10-hour max session lifespan. Every Keycloak session expiry forces a fresh brokered IdP login, and for OAuth2 providers like Bitbucket Data Center each re-login records a new authorized-application grant on the user's Bitbucket account. Bitbucket DC has no token-revocation API (UI-only), so a Replicated customer accumulated 20 duplicate "Openhands Enterprise" entries. Session length is the only lever we control. Defaults are unchanged.

## Testing

- `scripts/test_keycloak_realm_template.py`: new tests assert the config script applies both values and run the script's actual jq filter against the realm template (8/8 pass).
- Helm-rendered the config script with defaults, overrides, and KOTS-style string values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)