### PR TITLE
ROUGH DRAFT: Support multi-model LLM config in KOTS

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -143,10 +143,24 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "anthropic" }}'
           required: true
+        - name: anthropic_models
+          title: Anthropic Models
+          help_text: Enter one or more Anthropic model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "claude-sonnet-4-5-20250929, claude-opus-4-7"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "anthropic" }}'
+          required: true
         - name: openai_api_key
           title: OpenAI API Key
           help_text: Your OpenAI API key for GPT models
           type: password
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "openai" }}'
+          required: true
+        - name: openai_models
+          title: OpenAI Models
+          help_text: Enter one or more OpenAI model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "gpt-5.2"
           when: 'repl{{ ConfigOptionEquals "llm_provider" "openai" }}'
           required: true
         - name: google_api_type
@@ -164,6 +178,13 @@ spec:
           title: Google Gemini API Key
           help_text: Your Google AI Studio API key for Gemini models
           type: password
+          when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
+          required: true
+        - name: google_gemini_models
+          title: Google Gemini Models
+          help_text: Enter one or more Gemini API model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "gemini-2.5-flash"
           when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
           required: true
         - name: google_vertex_project_id
@@ -185,16 +206,37 @@ spec:
           type: file
           when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "vertex") }}'
           required: true
+        - name: google_vertex_models
+          title: Google Vertex AI Models
+          help_text: Enter one or more Vertex AI model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "gemini-2.5-flash"
+          when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "vertex") }}'
+          required: true
         - name: deepseek_api_key
           title: DeepSeek API Key
           help_text: Your DeepSeek API key
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "deepseek" }}'
           required: true
+        - name: deepseek_models
+          title: DeepSeek Models
+          help_text: Enter one or more DeepSeek model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "deepseek-chat"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "deepseek" }}'
+          required: true
         - name: mistral_api_key
           title: Mistral API Key
           help_text: Your Mistral AI API key
           type: password
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "mistral" }}'
+          required: true
+        - name: mistral_models
+          title: Mistral Models
+          help_text: Enter one or more Mistral model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "mistral-large-latest"
           when: 'repl{{ ConfigOptionEquals "llm_provider" "mistral" }}'
           required: true
         - name: azure_auth_method
@@ -247,9 +289,9 @@ spec:
           when: 'repl{{ ConfigOptionEquals "llm_provider" "azure" }}'
           required: true
         - name: azure_deployment_name
-          title: Azure OpenAI Deployment Name
-          help_text: The name of your Azure OpenAI model deployment (set when you deployed the model in Azure)
-          type: text
+          title: Azure OpenAI Deployments
+          help_text: Enter one or more Azure OpenAI deployment names, separated by commas or new lines. These are deployment names from Azure AI Foundry / Azure OpenAI, not the underlying model names. The first entry is used as the default. Optionally use display-name=deployment-name for shorter names in the OpenHands dropdown.
+          type: textarea
           when: 'repl{{ ConfigOptionEquals "llm_provider" "azure" }}'
           required: true
         - name: groq_api_key
@@ -258,10 +300,23 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "groq" }}'
           required: true
+        - name: groq_models
+          title: Groq Models
+          help_text: Enter one or more Groq model IDs to make available in OpenHands, separated by commas or new lines. The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
+          default: "llama-3.3-70b-versatile"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "groq" }}'
+          required: true
         - name: openrouter_api_key
           title: OpenRouter API Key
           help_text: Your OpenRouter API key
           type: password
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "openrouter" }}'
+          required: true
+        - name: openrouter_models
+          title: OpenRouter Models
+          help_text: Enter one or more OpenRouter model IDs to make available in OpenHands, separated by commas or new lines (for example, anthropic/claude-sonnet-4.5). The first entry is used as the default. Optionally use display-name=model-id for shorter names in the OpenHands dropdown.
+          type: textarea
           when: 'repl{{ ConfigOptionEquals "llm_provider" "openrouter" }}'
           required: true
         - name: aws_auth_method
@@ -296,9 +351,9 @@ spec:
           when: 'repl{{ ConfigOptionEquals "llm_provider" "bedrock" }}'
           required: true
         - name: bedrock_model_id
-          title: Bedrock Model ID
-          help_text: Bedrock model ID or cross-region inference profile ID. Cross-region profiles (prefix `us.`) work in any US region; standard model IDs are region-specific. Most current Claude models on Bedrock are inference-profile only (e.g., `us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
-          type: text
+          title: Bedrock Models
+          help_text: Enter one or more Bedrock model IDs or inference profile IDs, separated by commas or new lines. The first entry is used as the default. For long IDs, use display-name=model-id (for example, sonnet=us.anthropic.claude-sonnet-4-5-20250929-v1:0).
+          type: textarea
           default: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
           when: 'repl{{ ConfigOptionEquals "llm_provider" "bedrock" }}'
           required: true
@@ -315,9 +370,9 @@ spec:
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: false
         - name: custom_model
-          title: Custom LLM Model Name
-          help_text: Full LiteLLM model string for the custom endpoint. For OpenAI-compatible endpoints, prefix the model with openai/ (e.g., openai/llama-3.1-70b-instruct). For non-OpenAI-shaped endpoints, use that provider prefix (e.g., anthropic/claude-opus-4-7).
-          type: text
+          title: Custom LLM Model Names
+          help_text: Enter one or more full LiteLLM model strings accepted by your endpoint, separated by commas or new lines. The first entry is used as the default. For OpenAI-compatible endpoints, prefix each model with openai/ (for example, openai/llama-3.1-70b-instruct). For shorter names in the OpenHands dropdown, use display-name=model-string.
+          type: textarea
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,12 +17,12 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-774a36e'
+      tag: 'sha-56e9936'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 
     env:
-      LITELLM_DEFAULT_MODEL: 'litellm_proxy/claude-sonnet-4-5-20250929'
+      OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "anthropic_models" | replace "\r" "," | replace "\n" "," }}'
       REQUIRE_PAYMENT: 0
       ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_BILLING: false
@@ -201,21 +201,10 @@ spec:
           OR_SITE_URL: "https://docs.all-hands.dev"
         general_settings:
           forward_client_headers_to_llm_api: repl{{ ConfigOptionEquals "litellm_forward_client_headers" "1" }}
-        model_list:
-          # Keep this alias available through the proxy for
-          # openhands/claude-opus-4-7 (retained for backward compatibility
-          # with existing OpenHands installations that route this model
-          # through the proxy). LiteLLM 1.84.1 is the stable release
-          # containing the thinking translation fix from
-          # https://github.com/BerriAI/litellm/pull/27074.
-          - model_name: "claude-opus-4-7"
-            litellm_params:
-              model: "anthropic/claude-opus-4-7"
-              api_key: os.environ/ANTHROPIC_API_KEY
-          - model_name: "claude-sonnet-4-5-20250929"
-            litellm_params:
-              model: "anthropic/claude-sonnet-4-5-20250929"
-              api_key: os.environ/ANTHROPIC_API_KEY
+        model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "anthropic_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "anthropic/%s" $model) "api_key" "os.environ/ANTHROPIC_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+          # Entries accept either `model-id` or `display-name=model-id`.
+          # The display name becomes the LiteLLM route shown in OpenHands as
+          # `openhands/<display-name>`.
 
     runtime-api:
       enabled: true
@@ -659,37 +648,71 @@ spec:
             HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
             NO_PROXY: '{{repl $computedNoProxy}}'
             SSL_VERIFY: '{{repl if ConfigOptionEquals "ssl_verify" "1"}}True{{repl else}}False{{repl end}}'
+    - when: '{{repl ConfigOptionEquals "llm_provider" "openai" }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "openai_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "openai_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "openai/%s" $model) "api_key" "os.environ/OPENAI_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    - when: '{{repl and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "google_gemini_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "google_gemini_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "gemini/%s" $model) "api_key" "os.environ/GOOGLE_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    - when: '{{repl ConfigOptionEquals "llm_provider" "deepseek" }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "deepseek_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "deepseek_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "deepseek/%s" $model) "api_key" "os.environ/DEEPSEEK_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    - when: '{{repl ConfigOptionEquals "llm_provider" "mistral" }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "mistral_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "mistral_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "mistral/%s" $model) "api_key" "os.environ/MISTRAL_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    - when: '{{repl ConfigOptionEquals "llm_provider" "groq" }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "groq_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "groq_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "groq/%s" $model) "api_key" "os.environ/GROQ_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    - when: '{{repl ConfigOptionEquals "llm_provider" "openrouter" }}'
+      recursiveMerge: true
+      values:
+        env:
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "openrouter_models" | replace "\r" "," | replace "\n" "," }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "openrouter_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "openrouter/%s" $model) "api_key" "os.environ/OPENROUTER_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
     - when: '{{repl and (ConfigOptionEquals "llm_provider" "azure") (ConfigOptionEquals "azure_auth_method" "api_key") }}'
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/azure-{{repl ConfigOption "azure_deployment_name"}}'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "azure_deployment_name" | replace "\r" "," | replace "\n" "," }}'
           OH_AGENT_SERVER_ENV: '{{repl printf "{\"AZURE_API_KEY\": \"%s\", \"AZURE_API_BASE\": \"%s\", \"AZURE_API_VERSION\": \"%s\"}" (ConfigOption "azure_api_key") (ConfigOption "azure_endpoint") (ConfigOption "azure_api_version") }}'
         litellm-helm:
           proxy_config:
-            model_list:
-              - model_name: 'azure-{{repl ConfigOption "azure_deployment_name"}}'
-                litellm_params:
-                  model: 'azure/{{repl ConfigOption "azure_deployment_name"}}'
-                  api_key: os.environ/AZURE_API_KEY
-                  api_base: os.environ/AZURE_API_BASE
-                  api_version: os.environ/AZURE_API_VERSION
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "azure_deployment_name" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "azure/%s" $model) "api_key" "os.environ/AZURE_API_KEY" "api_base" "os.environ/AZURE_API_BASE" "api_version" "os.environ/AZURE_API_VERSION")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
     - when: '{{repl and (ConfigOptionEquals "llm_provider" "azure") (ConfigOptionEquals "azure_auth_method" "service_principal") }}'
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/azure-{{repl ConfigOption "azure_deployment_name"}}'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "azure_deployment_name" | replace "\r" "," | replace "\n" "," }}'
         litellm-helm:
           proxy_config:
-            model_list:
-              - model_name: 'azure-{{repl ConfigOption "azure_deployment_name"}}'
-                litellm_params:
-                  model: 'azure/{{repl ConfigOption "azure_deployment_name"}}'
-                  api_base: os.environ/AZURE_API_BASE
-                  api_version: os.environ/AZURE_API_VERSION
-                  tenant_id: os.environ/AZURE_TENANT_ID
-                  client_id: os.environ/AZURE_CLIENT_ID
-                  client_secret: os.environ/AZURE_CLIENT_SECRET
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "azure_deployment_name" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "azure/%s" $model) "api_base" "os.environ/AZURE_API_BASE" "api_version" "os.environ/AZURE_API_VERSION" "tenant_id" "os.environ/AZURE_TENANT_ID" "client_id" "os.environ/AZURE_CLIENT_ID" "client_secret" "os.environ/AZURE_CLIENT_SECRET")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
 
     # Custom / Local LLM — pass the configured model through as a full LiteLLM
     # model string. OpenAI-compatible custom endpoints should be configured as
@@ -699,23 +722,17 @@ spec:
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/custom-llm'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "custom_model" | replace "\r" "," | replace "\n" "," }}'
           OH_AGENT_SERVER_ENV: '{{repl printf "{\"CUSTOM_API_KEY\": \"%s\", \"CUSTOM_API_BASE\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOption "custom_api_key") (ConfigOption "custom_base_url") }}'
         litellm-helm:
           proxy_config:
-            model_list:
-              - model_name: 'custom-llm'
-                litellm_params:
-                  model: '{{repl ConfigOption "custom_model"}}'
-                  api_key: os.environ/CUSTOM_API_KEY
-                  api_base: os.environ/CUSTOM_API_BASE
-                  extra_headers: repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}repl{{ else }}{}repl{{ end }}
+            model_list: repl{{ $headers := dict }}repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ $headers = ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson }}repl{{ end }}repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "custom_model" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" $model "api_key" "os.environ/CUSTOM_API_KEY" "api_base" "os.environ/CUSTOM_API_BASE" "extra_headers" $headers)) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
 
-    - when: '{{repl ConfigOptionEquals "google_api_type" "vertex" }}'
+    - when: '{{repl and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "vertex") }}'
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/gemini-2.5-flash'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "google_vertex_models" | replace "\r" "," | replace "\n" "," }}'
           OH_AGENT_SERVER_ENV: '{{repl printf "{\"VERTEXAI_CREDENTIALS\": %s, \"VERTEXAI_PROJECT\": \"%s\", \"VERTEXAI_LOCATION\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOptionData "google_vertex_credentials" | toJson) (ConfigOption "google_vertex_project_id") (ConfigOption "google_vertex_location") }}'
         litellm-helm:
           # volumes / volumeMounts are arrays — recursiveMerge replaces them,
@@ -742,12 +759,7 @@ spec:
           envVars:
             GOOGLE_APPLICATION_CREDENTIALS: "/etc/gcloud/vertex_credentials.json"
           proxy_config:
-            model_list:
-              - model_name: "gemini-2.5-flash"
-                litellm_params:
-                  model: "vertex_ai/gemini-2.5-flash"
-                  vertex_project: os.environ/VERTEXAI_PROJECT
-                  vertex_location: os.environ/VERTEXAI_LOCATION
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "google_vertex_models" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "vertex_ai/%s" $model) "vertex_project" "os.environ/VERTEXAI_PROJECT" "vertex_location" "os.environ/VERTEXAI_LOCATION")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
           vertexAI:
             enabled: true
             project: '{{repl ConfigOption "google_vertex_project_id"}}'
@@ -760,17 +772,11 @@ spec:
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/bedrock'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "bedrock_model_id" | replace "\r" "," | replace "\n" "," }}'
           OH_AGENT_SERVER_ENV: '{{repl printf "{\"AWS_ACCESS_KEY_ID\": \"%s\", \"AWS_SECRET_ACCESS_KEY\": \"%s\", \"AWS_REGION_NAME\": \"%s\"}" (ConfigOption "aws_access_key_id") (ConfigOption "aws_secret_access_key") (ConfigOption "aws_region_name") }}'
         litellm-helm:
           proxy_config:
-            model_list:
-              - model_name: 'bedrock'
-                litellm_params:
-                  model: 'bedrock/{{repl ConfigOption "bedrock_model_id"}}'
-                  aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
-                  aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-                  aws_region_name: os.environ/AWS_REGION_NAME
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "bedrock_model_id" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "bedrock/%s" $model) "aws_access_key_id" "os.environ/AWS_ACCESS_KEY_ID" "aws_secret_access_key" "os.environ/AWS_SECRET_ACCESS_KEY" "aws_region_name" "os.environ/AWS_REGION_NAME")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
     # AWS Bedrock — instance profile / IRSA. Omit AWS_ACCESS_KEY_ID/SECRET so
     # boto3 falls back to its default credential chain (IMDS on EC2, web
     # identity token on EKS). Region still injected explicitly.
@@ -778,14 +784,10 @@ spec:
       recursiveMerge: true
       values:
         env:
-          LITELLM_DEFAULT_MODEL: 'litellm_proxy/bedrock'
+          OPENHANDS_MANAGED_LITELLM_MODELS: 'repl{{ ConfigOption "bedrock_model_id" | replace "\r" "," | replace "\n" "," }}'
         litellm-helm:
           proxy_config:
-            model_list:
-              - model_name: 'bedrock'
-                litellm_params:
-                  model: 'bedrock/{{repl ConfigOption "bedrock_model_id"}}'
-                  aws_region_name: os.environ/AWS_REGION_NAME
+            model_list: repl{{ $models := list }}repl{{ range $raw := splitList "," (ConfigOption "bedrock_model_id" | replace "\r" "," | replace "\n" ",") }}repl{{ $entry := trim $raw }}repl{{ if $entry }}repl{{ $parts := splitList "=" $entry }}repl{{ $alias := trim (first $parts) }}repl{{ $model := trim (last $parts) }}repl{{ if and $alias $model }}repl{{ $models = append $models (dict "model_name" $alias "litellm_params" (dict "model" (printf "bedrock/%s" $model) "aws_region_name" "os.environ/AWS_REGION_NAME")) }}repl{{ end }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
     # Path-based sandbox routing: route every runtime at <base>/{id} through a
     # shared Gateway instead of per-sandbox Ingresses at {id}.<base>. Traefik's
     # kubernetesGateway provider (enabled in embedded-cluster.yaml) installs


### PR DESCRIPTION
Draft checkpoint for the OHE managed multi-model work.

Cloud stack layer 1/2. Companion app PR: OpenHands/OpenHands#14736.

This layer introduces KOTS textarea model fields and renders multiple bundled LiteLLM routes so OHE can expose more than one admin-configured model.

Important WIP notes before marking ready:
- Add/verify upgrade compatibility aliases for existing Azure/Bedrock/custom route names (`azure-*`, `bedrock`, `custom-llm`).
- Remove validation-only enterprise-server image pin from the final product diff or update it intentionally as part of the normal release process.
- Decide whether display-name alias syntax should remain removed or be deferred to docs/future model registry work.
- Re-run `make release`/render validation after alias compatibility is implemented.