### PR TITLE
Add KOTS option to hide personal workspaces for the default org

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: sha-d765b0b
-version: 0.7.44
+version: 0.7.45
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/troubleshoot/_default-org.tpl
+++ b/charts/openhands/templates/troubleshoot/_default-org.tpl
@@ -1,0 +1,90 @@
+{{/*
+Default-organization rename guard.
+
+The KOTS default-org bootstrap identifies the organization BY NAME: changing
+the "Organization Name" config after an org was bootstrapped creates a second
+organization rather than renaming the first. These preflight pieces warn when
+the configured name matches no existing org while team orgs already exist —
+the signature of an accidental rename. Gated on the default-org feature being
+enabled (values.env.OPENHANDS_DEFAULT_ORG_ENABLED).
+
+The check mirrors the app's own DB wiring from _env.yaml (bundled vs external
+postgres, password from postgresql.auth.existingSecret) and reuses the
+waitForDb postgres-client image, which KOTS already overrides to the
+Replicated proxy. Personal workspaces (org id == user id) are excluded from
+the "team orgs exist" test. Any psql failure (fresh install, DB not yet
+provisioned) downgrades to DEFAULT_ORG_CHECK_SKIPPED, which passes.
+*/}}
+
+{{- define "troubleshoot.defaultOrg.enabled" -}}
+{{- if eq (toString (.Values.env).OPENHANDS_DEFAULT_ORG_ENABLED) "true" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "troubleshoot.collectors.defaultOrg" -}}
+- runPod:
+    collectorName: default-org-name-check
+    name: default-org-name-check
+    namespace: {{ .Release.Namespace }}
+    timeout: 90s
+    podSpec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: default-org-name-check
+          image: {{ .Values.keycloak.waitForDb.image | quote }}
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: "{{ .Release.Name }}-postgresql"
+            - name: DB_PORT
+              value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
+            - name: DB_USER
+              value: "{{ .Values.postgresql.auth.username }}"
+            - name: DB_NAME
+              value: "{{ .Values.postgresql.auth.database }}"
+            {{- else }}
+            - name: DB_HOST
+              value: "{{ .Values.externalDatabase.host }}"
+            - name: DB_PORT
+              value: "{{ .Values.externalDatabase.port | default 5432 }}"
+            - name: DB_USER
+              value: "{{ .Values.externalDatabase.username | default "postgres" }}"
+            - name: DB_NAME
+              value: "{{ .Values.externalDatabase.database | default "openhands" }}"
+            {{- end }}
+            - name: PGSSLMODE
+              value: "{{ if not .Values.postgresql.enabled }}{{ .Values.externalDatabase.sslMode | default "prefer" }}{{ else }}prefer{{ end }}"
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: password
+            - name: DEFAULT_ORG_NAME
+              value: {{ (.Values.env).OPENHANDS_DEFAULT_ORG_NAME | default "" | quote }}
+          command: ['sh', '-c']
+          args:
+            - |
+              PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -t -A \
+                -v name="$DEFAULT_ORG_NAME" \
+                -c "SELECT CASE WHEN EXISTS (SELECT 1 FROM org WHERE name = :'name') THEN 'DEFAULT_ORG_OK' WHEN EXISTS (SELECT 1 FROM org o LEFT JOIN \"user\" u ON u.id = o.id WHERE u.id IS NULL) THEN 'DEFAULT_ORG_RENAME_RISK' ELSE 'DEFAULT_ORG_FRESH' END" \
+                2>/dev/null || echo 'DEFAULT_ORG_CHECK_SKIPPED'
+{{- end -}}
+
+{{- define "troubleshoot.analyzers.defaultOrg" -}}
+- textAnalyze:
+    checkName: Default Organization Name
+    fileName: default-org-name-check/default-org-name-check.log
+    regex: 'DEFAULT_ORG_RENAME_RISK'
+    outcomes:
+      - warn:
+          when: "true"
+          message: "No organization matches the configured Default Organization name, but team organizations already exist. Deploying will create a NEW organization with this name on the next owner sign-in; existing organizations and their data remain, and auto-added members are moved to the new organization on their next sign-in. If you meant to rename an existing organization, rename it in the app instead (organization settings) and set this field to match."
+      - pass:
+          when: "false"
+          message: "The Default Organization name is consistent with existing organizations."
+{{- end -}}

--- a/charts/openhands/templates/troubleshoot/preflights.yaml
+++ b/charts/openhands/templates/troubleshoot/preflights.yaml
@@ -1,5 +1,6 @@
 {{- define "troubleshoot.preflights" -}}
 {{- $tls := include "troubleshoot.tlsHostname.vars" . | fromYaml -}}
+{{- $defaultOrg := include "troubleshoot.defaultOrg.enabled" . -}}
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
@@ -10,9 +11,15 @@ spec:
     {{- if $tls.cert }}
     {{- include "troubleshoot.collectors.tlsHostname" . | nindent 4 }}
     {{- end }}
+    {{- if $defaultOrg }}
+    {{- include "troubleshoot.collectors.defaultOrg" . | nindent 4 }}
+    {{- end }}
   analyzers:
     {{- include "troubleshoot.analyzers.shared" . | nindent 4 }}
     {{- if $tls.cert }}
     {{- include "troubleshoot.analyzers.tlsHostname" . | nindent 4 }}
+    {{- end }}
+    {{- if $defaultOrg }}
+    {{- include "troubleshoot.analyzers.defaultOrg" . | nindent 4 }}
     {{- end }}
 {{- end -}}

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -451,7 +451,7 @@ spec:
           default: "0"
         - name: default_openhands_org_name
           title: Organization Name
-          help_text: 'Enter the name of the default organization. It is created after a configured owner signs in. Note: renaming an org here will create a new org; the previous org and its data remain.'
+          help_text: 'Enter the name of the default organization. It is created after a configured owner signs in. Note: renaming an org here, after already bootstrapping, will create a new org; the previous org and its data remain. To rename an existing org, use its organization settings in the app.'
           type: text
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
           required: true

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -463,7 +463,7 @@ spec:
           required: true
         - name: default_openhands_org_auto_add_users
           title: Automatically Add Signed-In Users
-          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, users land in the default organization automatically; existing users are moved into it on their next sign-in (they can switch workspaces afterwards in the app).
+          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, users land in the default organization automatically; existing users are moved into it on their next sign-in.
           type: bool
           default: "1"
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -451,7 +451,7 @@ spec:
           default: "0"
         - name: default_openhands_org_name
           title: Organization Name
-          help_text: 'Enter the name of the default organization. New organizations are created after a configured owner signs in. Note: renaming creates a new organization with the new name; the previous organization and its data remain, and members are moved into the new organization on their next sign-in.'
+          help_text: 'Enter the name of the default organization. It is created after a configured owner signs in. Note: renaming an org here will create a new org; the previous org and its data remain.'
           type: text
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
           required: true

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -451,7 +451,7 @@ spec:
           default: "0"
         - name: default_openhands_org_name
           title: Organization Name
-          help_text: Enter the name of the default organization. New organizations are created after a configured owner signs in.
+          help_text: 'Enter the name of the default organization. New organizations are created after a configured owner signs in. Note: renaming creates a new organization with the new name; the previous organization and its data remain, and members are moved into the new organization on their next sign-in.'
           type: text
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
           required: true
@@ -463,10 +463,16 @@ spec:
           required: true
         - name: default_openhands_org_auto_add_users
           title: Automatically Add Signed-In Users
-          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, new users land in the default organization automatically; existing users can switch to the default organization via the UI.
+          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, users land in the default organization automatically; existing users are moved into it on their next sign-in (they can switch workspaces afterwards in the app).
           type: bool
           default: "1"
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
+        - name: default_openhands_org_hide_personal_workspaces
+          title: Hide Personal Workspaces
+          help_text: 'Make the default organization the only workspace users see. Users'' existing personal-workspace conversations, secrets, API keys, and automations are hidden — not deleted — and equivalents can be recreated in the organization; disabling this option restores them. Organization LLM settings and billing are managed by organization admins. Users who are not yet members of the default organization keep seeing their personal workspace until they are added.'
+          type: bool
+          default: "0"
+          when: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") }}'
 
     - name: bitbucket_data_center_authentication
       title: Bitbucket Data Center Authentication

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -469,7 +469,7 @@ spec:
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
         - name: default_openhands_org_hide_personal_workspaces
           title: Hide Personal Workspaces
-          help_text: 'Make the default organization the only workspace users see. Users'' existing personal-workspace conversations, secrets, API keys, and automations are hidden — not deleted — and equivalents can be recreated in the organization; disabling this option restores them. Organization LLM settings and billing are managed by organization admins. Users who are not yet members of the default organization keep seeing their personal workspace until they are added.'
+          help_text: 'Make the default organization the only workspace users see. Existing personal workspace data (conversations, secrets, API keys, automations) is hidden, not deleted; disabling this option restores it.'
           type: bool
           default: "0"
           when: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") }}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -39,6 +39,13 @@ spec:
       OPENHANDS_DEFAULT_ORG_NAME: 'repl{{ ConfigOption "default_openhands_org_name" }}'
       OPENHANDS_DEFAULT_ORG_OWNER_EMAILS: 'repl{{ ConfigOption "default_openhands_org_owner_emails" }}'
       OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS: 'repl{{ ConfigOptionEquals "default_openhands_org_auto_add_users" "1" }}'
+      # Hiding personal workspaces needs both forms: the structured flag drives
+      # the web client (plain envs are ignored once any OH_WEB_CLIENT_FEATURE_FLAGS_*
+      # is set — see the ENABLE_JIRA_DC note above), and the plain env drives the
+      # server-side default-org bootstrap that moves users off personal workspaces
+      # on login.
+      OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES: 'repl{{ ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1" }}'
+      HIDE_PERSONAL_WORKSPACES: 'repl{{ ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1" }}'
 
     ingress:
       enabled: true


### PR DESCRIPTION
## Summary

Adds a **Hide Personal Workspaces** checkbox to the Default OpenHands Organization config group, making the bootstrapped default org the only workspace users see. Companion to OpenHands/OpenHands#14740 and OpenHands/OpenHands#14741 (requires an enterprise-server image containing both).

- Shown only when the default org **and** auto-add-users are both enabled (hiding personal workspaces without auto-membership would strand users without a workspace). Default off.
- Sets both env forms on the openhands deployment: structured `OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES` for the web client (plain envs are ignored once any structured flag is present — same gotcha as `ENABLE_JIRA_DC`, noted inline) and plain `HIDE_PERSONAL_WORKSPACES` for the server-side bootstrap that moves users off personal workspaces on login.
- Help text spells out the consequences: existing personal-workspace data is hidden, not deleted; unchecking restores it.
- Updates the auto-add-users help text (existing users are moved into the default org on next sign-in) and documents that renaming the default org after bootstrapping creates a new organization — renaming an existing org is done in the app.

## Default-org rename preflight

The bootstrap identifies the org **by name**, so editing the Organization Name after bootstrapping creates a second org. A new preflight (gated on the default-org feature being enabled) runs a `psql` check against the app DB at deploy time and **warns** when the configured name matches no existing org while team orgs already exist — the signature of an accidental rename. Details:

- Mirrors the app's DB wiring from `_env.yaml` (bundled vs external postgres, password from `postgresql.auth.existingSecret`), reuses the `waitForDb` postgres-client image that KOTS already proxies, and excludes personal workspaces (org id == user id) from the "team orgs exist" test.
- Org name is passed via `psql -v` variable binding (no SQL injection from the config value).
- Any psql failure (fresh install, DB not provisioned yet) downgrades to `DEFAULT_ORG_CHECK_SKIPPED`, which passes — first installs are never blocked.

## Testing

- `make lint` (replicated release lint) passes — only pre-existing info-level notices.
- `helm template` render checks: enabled+bundled DB (collector + analyzer render), enabled+external DB (host/port/user/db wired), feature disabled (nothing rendered).
- Validated live on a Replicated test instance (embedded cluster): deploy ran the preflight and it passed with "The Default Organization name is consistent with existing organizations" against a bootstrapped org.
- Chart.lock churn from lint/packaging reverted; no chart dependency changes intended.


## Validation — real Replicated install (R03, 2026-06-10)

Validated on embedded-cluster instance replicated-03 (channel `alona/org-only-mode-kots`, chart 0.7.44, KOTS sequences 20–26):

- KOTS checkbox/env wiring confirmed in the running pod: `HIDE_PERSONAL_WORKSPACES=true`, `OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES=true`, `OPENHANDS_DEFAULT_ORG_ENABLED=true`, `OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS=true`, `OPENHANDS_DEFAULT_ORG_NAME=AlonaCorp3`, owner emails set.
- Default-org rename preflight ran during the seq-26 deploy and passed ("Default Organization name is consistent with existing organizations").
- End-to-end app behavior on top of this config (owner bootstrap, member auto-add via GitLab signup, hidden personal workspaces, working conversations) validated against OpenHands PRs #14740/#14741.
