### PR TITLE
[DO NOT MERGE] Stable chart-fix-1: cherry-pick #691 onto openhands/0.7.37

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/pr-checks.yml'
       - 'charts/**'
       - 'scripts/test_keycloak_realm_template.py'
+      - 'scripts/test_openhands_secrets_template.py'
 
 jobs:
   test-keycloak-realm-template:
@@ -15,10 +16,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
       - name: Install test dependencies
         run: python3 -m pip install pytest
-      - name: Test Keycloak realm template invariants
-        run: python3 -m pytest scripts/test_keycloak_realm_template.py
+      - name: Test chart template invariants
+        run: >-
+          python3 -m pytest
+          scripts/test_keycloak_realm_template.py
+          scripts/test_openhands_secrets_template.py
 
   validate-chart-versions:
     uses: ./.github/workflows/validate-chart-versions.yml

--- a/.github/workflows/test-update-openhands-charts.yml
+++ b/.github/workflows/test-update-openhands-charts.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 

--- a/charts/openhands-secrets/Chart.yaml
+++ b/charts/openhands-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openhands-secrets
 description: A Helm chart for OpenHands secrets
 type: application
-version: 0.1.21
+version: 0.1.21-fix1
 appVersion: "1.0"

--- a/charts/openhands-secrets/templates/openhands-env-secrets.yaml
+++ b/charts/openhands-secrets/templates/openhands-env-secrets.yaml
@@ -56,5 +56,5 @@ stringData:
   LLM_BASE_URL: '{{ .Values.config.custom_base_url }}'
   {{- end }}
   {{- if .Values.config.custom_model }}
-  LLM_MODEL: 'openai/{{ .Values.config.custom_model }}'
+  LLM_MODEL: '{{ .Values.config.custom_model }}'
   {{- end }}

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.37.2
-version: 0.7.37
+version: 0.7.37-fix1
 maintainers:
   - name: rbren
   - name: xingyao

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -285,7 +285,7 @@ spec:
           required: true
         - name: custom_base_url
           title: Custom LLM Base URL
-          help_text: Base URL of your OpenAI-compatible LLM endpoint (e.g., https://openrouter.ai/api/v1, http://my-vllm:8000/v1)
+          help_text: Base URL of your custom LLM endpoint (e.g., https://openrouter.ai/api/v1, http://my-vllm:8000/v1)
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true
@@ -297,7 +297,7 @@ spec:
           required: false
         - name: custom_model
           title: Custom LLM Model Name
-          help_text: Model identifier as accepted by the endpoint (e.g., anthropic/claude-sonnet-4-5 for OpenRouter, llama-3.1-70b-instruct for vLLM)
+          help_text: Full LiteLLM model string for the custom endpoint. For OpenAI-compatible endpoints, prefix the model with openai/ (e.g., openai/llama-3.1-70b-instruct). For non-OpenAI-shaped endpoints, use that provider prefix (e.g., anthropic/claude-opus-4-7).
           type: text
           when: 'repl{{ ConfigOptionEquals "llm_provider" "custom" }}'
           required: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -663,11 +663,10 @@ spec:
                   client_id: os.environ/AZURE_CLIENT_ID
                   client_secret: os.environ/AZURE_CLIENT_SECRET
 
-    # Custom / Local LLM — any OpenAI-compatible endpoint (OpenRouter, vLLM,
-    # Ollama, LM Studio, LiteLLM gateway, etc.). LiteLLM routes via the
-    # generic `openai/<model>` provider, which forwards the request body to
-    # <custom_base_url>/chat/completions with `Authorization: Bearer
-    # <custom_api_key>` headers.
+    # Custom / Local LLM — pass the configured model through as a full LiteLLM
+    # model string. OpenAI-compatible custom endpoints should be configured as
+    # `openai/<model>`; non-OpenAI-shaped gateways should use their provider
+    # prefix, for example `anthropic/claude-opus-4-7`.
     - when: '{{repl ConfigOptionEquals "llm_provider" "custom" }}'
       recursiveMerge: true
       values:
@@ -679,7 +678,7 @@ spec:
             model_list:
               - model_name: 'custom-llm'
                 litellm_params:
-                  model: 'openai/{{repl ConfigOption "custom_model"}}'
+                  model: '{{repl ConfigOption "custom_model"}}'
                   api_key: os.environ/CUSTOM_API_KEY
                   api_base: os.environ/CUSTOM_API_BASE
                   extra_headers: repl{{ if ConfigOptionEquals "custom_llm_extra_headers_enabled" "1" }}repl{{ ConfigOption "custom_llm_extra_headers" | trim | default "{}" | mustFromJson | mustToJson }}repl{{ else }}{}repl{{ end }}

--- a/scripts/test_openhands_secrets_template.py
+++ b/scripts/test_openhands_secrets_template.py
@@ -1,0 +1,57 @@
+"""Tests for OpenHands secrets chart rendering."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENHANDS_SECRETS_CHART = REPO_ROOT / "charts" / "openhands-secrets"
+OPENHANDS_ENV_SECRETS_TEMPLATE = "templates/openhands-env-secrets.yaml"
+
+
+def render_openhands_env_secrets(custom_model: str) -> str:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "openhands-secrets",
+            str(OPENHANDS_SECRETS_CHART),
+            "--show-only",
+            OPENHANDS_ENV_SECRETS_TEMPLATE,
+            "--set",
+            "config.llm_provider=custom",
+            "--set-string",
+            f"config.custom_model={custom_model}",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def rendered_llm_model(custom_model: str) -> str:
+    manifest = render_openhands_env_secrets(custom_model)
+    match = re.search(r"(?m)^\s+LLM_MODEL:\s+'([^']+)'$", manifest)
+    assert match, f"Rendered LLM_MODEL not found in manifest:\n{manifest}"
+    return match.group(1)
+
+
+@pytest.mark.parametrize(
+    ("custom_model", "expected_llm_model"),
+    [
+        ("openai/llama-3.1-70b-instruct", "openai/llama-3.1-70b-instruct"),
+        ("anthropic/claude-opus-4-7", "anthropic/claude-opus-4-7"),
+        ("bare-model-name", "bare-model-name"),
+    ],
+)
+def test_custom_llm_model_renders_as_configured(
+    custom_model: str, expected_llm_model: str
+) -> None:
+    assert rendered_llm_model(custom_model) == expected_llm_model


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This PR exists for review only. The release branch is
> published independently — merging this PR back into a long-lived branch is
> not the workflow. See "How this gets released" below.

## What this is

A cherry-pick-only **chart-fix-1** release built on top of the current
Replicated **Stable** channel (`openhands/0.7.37`, which ships SaaS
`cloud-1.37.2`).

| | |
|---|---|
| **Release branch** | `rel/openhands-1.37.2.chart-fix-1` |
| **Base (review)** | `stable/openhands-0.7.37` (long-lived snapshot of the tag `openhands/0.7.37`) |
| **Stable today** | `openhands/0.7.37` → Replicated release notes title "OpenHands v1.37.2" |
| **Server image (unchanged)** | `ghcr.io/openhands/enterprise-server:cloud-1.37.2` |
| **Chart versions** | `openhands` `0.7.37` → `0.7.37-fix1`; `openhands-secrets` `0.1.21` → `0.1.21-fix1` |

## Why pick this base for review (`stable/openhands-0.7.37`)

Using the `stable/openhands-0.7.37` baseline branch (which points at the same
commit as the `openhands/0.7.37` tag) makes the PR diff show **only the two
commits in this fix release**, not the dozens of unrelated changes that have
landed on `main` since Stable was cut. That's the diff customers will actually
receive when they upgrade from current Stable to this fix.

If you'd like to also see how far behind `main` this branch is, run locally:

```
git fetch origin
git log --oneline openhands/0.7.37..origin/main  # what's NOT in this fix
```

## Cherry-picks included

1. **#691 — Allow full custom LiteLLM model strings** (`5e1e969`,
   cherry-picked from `d542fdc`)
   - Stops the chart from hard-prepending `openai/` to `custom_model`. Users
     now supply the full LiteLLM provider-prefixed string (e.g.
     `openai/llama-3.1-70b-instruct`, `anthropic/claude-opus-4-7`).
   - Updates Replicated config help text and adds a `helm template`
     regression test.
2. **`chore(charts): bump openhands to 0.7.37-fix1`** (`674d00d`) — re-labels
   the umbrella Replicated release as a fix on top of Stable. Pairs with
   the `openhands-secrets@0.1.21-fix1` bump from the cherry-pick.

## ⚠️ Customer-visible breaking change

Customers using a **custom LLM endpoint** on Stable `0.7.37` will need to
update their `custom_model` Replicated config value when upgrading to this
fix:

- **Before (Stable 0.7.37):** entering `llama-3.1-70b-instruct` was silently
  rewritten to `openai/llama-3.1-70b-instruct`.
- **After (this fix):** the chart passes the value through verbatim. Anyone
  who today enters a bare model name must now supply the provider prefix
  themselves (e.g. `openai/llama-3.1-70b-instruct`).

This needs to be called out in the chart-fix-1 Replicated release notes.

## How this gets released (not by merging this PR)

This branch is the source of truth for the chart-fix-1 release. To actually
publish:

1. CI on this branch needs to fire `publish-helm-charts.yml`,
   `tag-chart-versions.yml`, and `release-replicated.yml` — all of which
   currently trigger **only on `main`**. Options:
   - extend their `on.push.branches:` lists to include `rel/**`, **or**
   - use `workflow_dispatch` to run each manually from this branch.
2. The Replicated channel for this release will be derived from the branch
   name by the Makefile (`CHANNEL := $(shell git branch --show-current)`),
   so it will appear as `rel/openhands-1.37.2.chart-fix-1` in the vendor
   portal. Promotion to `Stable` happens from there.

## Open questions

- [ ] Do we want to also wire `rel/**` into the publish workflows as part of
  this fix release, or use `workflow_dispatch` this time and plumb the
  workflows in a separate follow-up?
- [ ] Branch name encodes `1.37.2` (matching the SaaS release shipped in
  Stable 0.7.37, per the Replicated release notes title). The pre-existing
  Replicated channel `av/release-1-37-1` also at chart 0.7.37 is a misnomer
  — leftover from when the cut was initially aimed at 1.37.1. Keeping `1.37.2`
  in the branch name unless there's an internal reason to align with the
  channel name.

---

_This PR description and the underlying cherry-pick were prepared by an AI
agent (OpenHands) on behalf of the requester._


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1804c689-8530-47d7-8353-65f7c3ff3d68)