### PR TITLE
Release 1.39.0

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/automation
-  tag: sha-eac5478
+  tag: sha-a3fef09
 
 imagePullSecrets: []
 

--- a/charts/image-loader/Chart.yaml
+++ b/charts/image-loader/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: image-loader
 description: A Helm chart for loading images on nodes using a DaemonSet with configurable runtime class
-version: 0.1.7
+version: 0.1.8
 appVersion: "1.0.0"

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.23.1-python
+  tag: 1.27.1-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: sha-d765b0b
-version: 0.7.45
+appVersion: cloud-1.39.0
+version: 0.7.46
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,11 +38,11 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.8
+    version: 0.3.9
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.13
+    version: 0.1.14
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: sha-d765b0b
+  tag: cloud-1.39.0
 
 ingress:
   enabled: false
@@ -237,7 +237,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.23.1-python
+    tag: 1.27.1-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -648,7 +648,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/agent-server:1.23.1-python"
+        image: "ghcr.io/openhands/agent-server:1.27.1-python"
         working_dir: "/workspace"
         environment:
           LOG_JSON: "1"

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.8 # Change this to trigger a new helm chart version being published
+version: 0.3.9 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-573b515
+  tag: sha-ecc78de
   pullPolicy: Always
 
 imagePullSecrets:
@@ -220,7 +220,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/agent-server:1.23.1-python"
+      image: "ghcr.io/openhands/agent-server:1.27.1-python"
       working_dir: "/workspace"
       environment:
         LOG_JSON: "1"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -903,9 +903,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.23.1-python
+          help_text: Image tag, e.g. 1.27.1-python
           type: text
-          default: "1.23.1-python"
+          default: "1.27.1-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-774a36e'
+      tag: 'cloud-1.39.0'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -74,7 +74,7 @@ spec:
         # takes over — both for new sandboxes (via AGENT_SERVER_IMAGE_*
         # env on the openhands server) and for the warm pool below.
         repository: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server{{repl end}}'
-        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.23.1-python{{repl end}}'
+        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.27.1-python{{repl end}}'
 
     keycloak:
       enabled: true
@@ -283,7 +283,7 @@ spec:
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
-            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.23.1-python{{repl end}}'
+            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.27.1-python{{repl end}}'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -547,11 +547,11 @@ spec:
         runtime:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.23.1-python'
+            tag: '1.27.1-python'
           warmRuntimes:
             configs:
               - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.23.1-python'
+                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.27.1-python'
                 working_dir: "/workspace"
                 environment:
                   LOG_JSON: "1"


### PR DESCRIPTION
Cuts OHE release 1.39.0 from OpenHands `cloud-1.39.0` via `update_openhands_charts.py`.

## Image updates
- enterprise-server: `sha-d765b0b` → `cloud-1.39.0`
- agent-server (runtime/warm/image-loader/KOTS refs): `1.23.1-python` → `1.27.1-python`
- runtime-api: `sha-573b515` → `sha-ecc78de` (latest main)
- automation: `sha-eac5478` → `sha-a3fef09` (latest main)

## Included since 1.37.2
- **runtime-api PLTF-2927 conversation-archiving incident fixes**: preserve workspaces on transient K8s/pod//server_info failures (#575/#580/#582), escalate zombie runtimes to Paused (#584), logging fixes (#573/#574)
- **OHE default org / org-only mode**: bootstrap (#14713), org LLM profiles (#14715), move existing users on first auto-add (#14740), hide personal workspaces (#14741), automation default-org fallback (#14745), KOTS config (Cloud #689/#698)
- **Bitbucket DC user resolution**: userinfo lookup fix (#14711), whoami avatar fix (#14734)
- **External Postgres**: SSL mode (#14695, Cloud #687, runtime-api #571, automation #163), custom ports (Cloud #683, runtime-api #570)
- **Keycloak SSO session lifetimes** as KOTS options (Cloud #694)
- **Automation database grants fix** (Cloud #688)
- **Gemini prompt caching**: preserve user LLM settings (#14451) + agent-server 1.27.1 carrying agent-sdk #3586 (no explicit cache_control for Gemini)
- **Custom LLM provider**: full LiteLLM model strings (Cloud #691), static extra headers (Cloud #669), LiteLLM admin password (Cloud #690)
- Keycloak realm provisioning decoupling (Cloud #693), TLS preflights (Cloud #681/#682), org-owned GitHub App creation (Cloud #685)

Note: the script's deploy-config lookup expects a `1.39.0` tag on OpenHands/deploy which only exists once SaaS ships that version; this run read the same values from the deploy repo's main (verified identical: `RUNTIME_API_SHA=ecc78deb`, `AUTOMATION_SHA=a3fef092`). Script itself unchanged.