### PR TITLE
PLTF-2944: Release 1.38.0

### DIFF
--- a/charts/automation/Chart.yaml
+++ b/charts/automation/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: automation
 description: OpenHands Automations Service — scheduled and event-driven automation execution
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "0.1.0"
 dependencies:
   - name: postgresql

--- a/charts/automation/values.yaml
+++ b/charts/automation/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/automation
-  tag: sha-eac5478
+  tag: sha-a3ad2b7
 
 imagePullSecrets: []
 

--- a/charts/image-loader/Chart.yaml
+++ b/charts/image-loader/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: image-loader
 description: A Helm chart for loading images on nodes using a DaemonSet with configurable runtime class
-version: 0.1.7
+version: 0.1.8
 appVersion: "1.0.0"

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.23.1-python
+  tag: 1.26.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.26.0-python
+  tag: 1.28.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: sha-d765b0b
-version: 0.7.46
+appVersion: cloud-1.38.0
+version: 0.7.47
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,11 +38,11 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.8
+    version: 0.3.9
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.13
+    version: 0.1.14
     condition: automation.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: sha-d765b0b
+  tag: cloud-1.38.0
 
 ingress:
   enabled: false
@@ -237,7 +237,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.23.1-python
+    tag: 1.26.0-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -648,7 +648,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/agent-server:1.23.1-python"
+        image: "ghcr.io/openhands/agent-server:1.26.0-python"
         working_dir: "/workspace"
         environment:
           LOG_JSON: "1"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.38.0
+  tag: sha-d6f88b0
 
 ingress:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -237,7 +237,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.26.0-python
+    tag: 1.28.0-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -648,7 +648,7 @@ runtime-api:
     count: 1
     configs:
       - name: default
-        image: "ghcr.io/openhands/agent-server:1.26.0-python"
+        image: "ghcr.io/openhands/agent-server:1.28.0-python"
         working_dir: "/workspace"
         environment:
           LOG_JSON: "1"

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.8 # Change this to trigger a new helm chart version being published
+version: 0.3.9 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -10,7 +10,7 @@ databaseMigrations:
 
 image:
   repository: ghcr.io/openhands/runtime-api
-  tag: sha-573b515
+  tag: sha-61fc535
   pullPolicy: Always
 
 imagePullSecrets:
@@ -220,7 +220,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/agent-server:1.23.1-python"
+      image: "ghcr.io/openhands/agent-server:1.26.0-python"
       working_dir: "/workspace"
       environment:
         LOG_JSON: "1"

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -220,7 +220,7 @@ warmRuntimes:
   count: 0
   configs:
     - name: default
-      image: "ghcr.io/openhands/agent-server:1.26.0-python"
+      image: "ghcr.io/openhands/agent-server:1.28.0-python"
       working_dir: "/workspace"
       environment:
         LOG_JSON: "1"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -891,7 +891,7 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.26.0-python
+          help_text: Image tag, e.g. 1.28.0-python
           type: text
           default: "1.26.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -893,7 +893,7 @@ spec:
           title: Sandbox Image Tag
           help_text: Image tag, e.g. 1.28.0-python
           type: text
-          default: "1.26.0-python"
+          default: "1.28.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -891,9 +891,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.26.0-python
+          help_text: Image tag, e.g. 1.28.0-python
           type: text
-          default: "1.26.0-python"
+          default: "1.28.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -891,9 +891,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.23.1-python
+          help_text: Image tag, e.g. 1.26.0-python
           type: text
-          default: "1.23.1-python"
+          default: "1.26.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'cloud-1.38.0'
+      tag: 'sha-d6f88b0'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 
@@ -72,7 +72,7 @@ spec:
         # takes over — both for new sandboxes (via AGENT_SERVER_IMAGE_*
         # env on the openhands server) and for the warm pool below.
         repository: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server{{repl end}}'
-        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.26.0-python{{repl end}}'
+        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.28.0-python{{repl end}}'
 
     keycloak:
       enabled: true
@@ -281,7 +281,7 @@ spec:
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
-            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.26.0-python{{repl end}}'
+            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.28.0-python{{repl end}}'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -545,11 +545,11 @@ spec:
         runtime:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.26.0-python'
+            tag: '1.28.0-python'
           warmRuntimes:
             configs:
               - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.26.0-python'
+                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.28.0-python'
                 working_dir: "/workspace"
                 environment:
                   LOG_JSON: "1"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-774a36e'
+      tag: 'cloud-1.38.0'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 
@@ -72,7 +72,7 @@ spec:
         # takes over — both for new sandboxes (via AGENT_SERVER_IMAGE_*
         # env on the openhands server) and for the warm pool below.
         repository: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server{{repl end}}'
-        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.23.1-python{{repl end}}'
+        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.26.0-python{{repl end}}'
 
     keycloak:
       enabled: true
@@ -281,7 +281,7 @@ spec:
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configs:
           - name: default
-            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.23.1-python{{repl end}}'
+            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.26.0-python{{repl end}}'
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -545,11 +545,11 @@ spec:
         runtime:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.23.1-python'
+            tag: '1.26.0-python'
           warmRuntimes:
             configs:
               - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.23.1-python'
+                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.26.0-python'
                 working_dir: "/workspace"
                 environment:
                   LOG_JSON: "1"


### PR DESCRIPTION
Cuts OHE release 1.38.0 from OpenHands `cloud-1.38.0` via `update_openhands_charts.py` (deploy-config read from the deploy repo's 1.38.0 tag).

## Base (script-faithful 1.38.0)
- enterprise-server: `sha-d765b0b` → `cloud-1.38.0` (incl. the manual `replicated/openhands.yaml` tag bump the script doesn't do)
- agent-server refs: `1.23.1-python` → `1.26.0-python`
- runtime-api: `sha-573b515` → `sha-61fc535` (1.38.0 deploy pin; includes external PG port/SSL #570/#571 and workspace-preservation #575)
- automation: `sha-eac5478` → `sha-a3ad2b7` (1.38.0 deploy pin; includes external PG SSL #163)
- chart 0.7.47

## Applied overrides (commits after the base release)
- enterprise-server → `sha-d6f88b0` = OpenHands main tip: #14752 (first signed-in user owns default org), #14451 (preserve user LLM settings — Gemini caching app half), all org-only mode work, agent-server pin #14754
- agent-server → `1.28.0-python` (SDK v1.28.0, carries the Gemini cache_control fix agent-sdk#3586) — applied consistently across chart values, warm runtimes, image-loader, replicated KOTS refs, and config help text/default, matching the app image's internal pin
- runtime-api `sha-61fc535` / automation `sha-a3ad2b7` deliberately left at the 1.38.0 deploy pins (note: `sha-61fc535` predates runtime-api archive fixes #580/#582/#584)
