### PR TITLE
Make LiteLLM admin password optional with a generated default

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -327,9 +327,9 @@ spec:
       items:
         - name: litellm_admin_password
           title: LiteLLM Admin Password
-          help_text: Password for the LiteLLM Admin UI at the LLM Proxy hostname with /ui. The username is fixed as admin. Changing this password restarts LiteLLM.
+          help_text: Password for the LiteLLM Admin UI at the LLM Proxy hostname with /ui. The username is fixed as admin. A random password is generated at install; to use the LiteLLM Admin UI, set your own password here and deploy. Changing this password restarts LiteLLM.
           type: password
-          required: true
+          value: '{{repl RandomString 32}}'
 
     - name: security_secrets
       title: Security & Authentication


### PR DESCRIPTION
Follow-up to #690. The `litellm_admin_password` KOTS field was `required` with no default, which hard-blocks every upgrade from pre-0.7.44 until the admin invents a password — even on installs that never use the LiteLLM UI (hit on the R03 0.7.34→0.7.44 upgrade, and KOTS `required` is not satisfied by a `default`).

## Change
- Drop `required: true`; generate an initial value with `value: '{{repl RandomString 32}}'` — the same once-generated-then-sticky pattern the other bundled secrets (jwt_secret, redis_password, keycloak_admin_password) already use.
- Field stays **visible** (not `hidden`) so the no-kubectl flow from #690 is unchanged: an admin who wants the LiteLLM dashboard sets their own password in the KOTS config and deploys — the existing pod checksum annotation restarts `openhands-litellm` and the new password takes effect.

## Behavior
- Fresh installs / upgrades: no prompt, random password generated and stored in ConfigValues.
- Worst case if never touched: the LiteLLM UI stays inaccessible to the admin — identical to the pre-#690 status quo; reset-and-deploy is always available.
- `UI_PASSWORD` in `litellm-env-secrets` is now never empty (verified via `helm template` render), so no chart changes needed.

No chart content changes — replicated/config.yaml only.