### PR TITLE
Gate hide-personal-workspaces envs on the same conditions as the checkbox

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -41,9 +41,12 @@ spec:
       # the web client (plain envs are ignored once any OH_WEB_CLIENT_FEATURE_FLAGS_*
       # is set — see the ENABLE_JIRA_DC note above), and the plain env drives the
       # server-side default-org bootstrap that moves users off personal workspaces
-      # on login.
-      OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES: 'repl{{ ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1" }}'
-      HIDE_PERSONAL_WORKSPACES: 'repl{{ ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1" }}'
+      # on login. Both repeat the checkbox's `when` gating (default org enabled +
+      # auto-add on) because KOTS keeps a hidden item's stored value: unchecking
+      # auto-add or disabling the default org must also switch hiding off, or users
+      # would lose their personal workspace with no auto-membership to land in.
+      OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") (ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1") }}'
+      HIDE_PERSONAL_WORKSPACES: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") (ConfigOptionEquals "default_openhands_org_hide_personal_workspaces" "1") }}'
 
     ingress:
       enabled: true


### PR DESCRIPTION
## Summary

The **Hide Personal Workspaces** checkbox is shown only when the default org and auto-add-users are both enabled (`when` gating), encoding the invariant: never hide personal workspaces unless auto-membership guarantees users an org to land in.

KOTS `when` only controls **visibility** — a hidden item's stored value persists. So this sequence produced a bad end state:

1. Admin enables default org + auto-add + hide → works as designed.
2. Admin later unchecks auto-add (or disables the default org) → the Hide checkbox disappears from the config UI, but its stored value is still `"1"`.
3. The env templates rendered from that stored value alone → `HIDE_PERSONAL_WORKSPACES=true` kept being set: personal workspaces hidden, no auto-membership for new users, and the setting causing it invisible to the admin.

## Fix

The two env templates (`OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_PERSONAL_WORKSPACES` for the web client, `HIDE_PERSONAL_WORKSPACES` for the server-side bootstrap) now repeat the checkbox's `when` conditions — `and` of org-enabled, auto-add, and the checkbox itself — so the rendered value can never disagree with the visible config state. Unchecking auto-add or disabling the org feature now switches hiding off automatically.

## Testing

- `make lint` (replicated release lint) passes — only pre-existing info-level notices.
- Chart.lock churn from the lint build reverted; no chart changes.

## Empirical verification (replicated-03, 2026-06-11)

Confirmed both failure paths live on a real embedded-cluster install (config-change deploy, then restored):

- Set `default_openhands_org_enabled="0"` and **deleted** the stored value of `default_openhands_org_auto_add_users` (default `"1"`, hidden by its `when` once the feature is off). Rendered deployment env came back `OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS='true'` — **KOTS falls back to an item's default even when the item is hidden and has no stored value.** On the current config spec, where `default_openhands_org_hide_personal_workspaces` defaults to `"1"`, this means a never-touched install renders `HIDE_PERSONAL_WORKSPACES=true` with the org feature completely disabled.
- In the same deploy, `HIDE_PERSONAL_WORKSPACES='true'` rendered while `OPENHANDS_DEFAULT_ORG_ENABLED='false'` — the hidden checkbox's persisted `"1"` driving the env (the turn-on → turn-off path).

The `and`-gating in this PR makes both impossible: the envs can't render true while the org feature or auto-add is off, regardless of stored values or defaults.
