### PR TITLE
PLTF-2882: Render automation ingress whenever ingress and automation are enabled

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.47
+version: 0.7.48
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/ingress-automation.yaml
+++ b/charts/openhands/templates/ingress-automation.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.enabled .Values.ingress.enabled .Values.automation.enabled }}
+{{- if and .Values.ingress.enabled .Values.automation.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## What

Gate `charts/openhands/templates/ingress-automation.yaml` on `ingress.enabled` and `automation.enabled` only, instead of also requiring the top-level `enabled` flag.

## Why

The top-level `enabled` flag controls the OpenHands enterprise-server templates. The chart already supports component-only releases (top-level `enabled: false` with a single subchart enabled).

The automation component's ingress, however, lives in the parent chart, so it was impossible to deploy automation as its own automation-only release: with top-level `enabled: false` the `/api/automation`, `/api/automation/v1/events`, and `/automations` routes would not render at all.

With this change the ingress follows the automation component:

- app + automation enabled (current installs): renders exactly as before
- automation disabled: nothing renders, as before
- automation-only release (`enabled: false`, `automation.enabled: true`, `ingress.enabled: true`): the ingress now renders with the release

## Validation

`helm template` with an automation-only values file (top-level `enabled: false`, all subcharts disabled except automation, `ingress.enabled: true`) renders exactly:

- `Deployment/automation`, `Deployment/automation-events`
- `Service/automation`, `Service/automation-events`
- `ServiceAccount/automation-sa`
- `Ingress/openhands-automation-ingress` with the three automation paths

`helm template` with a standard values file (app enabled, `automation.enabled: false`) renders no automation resources and no automation ingress, unchanged from 0.7.47.
