### PR TITLE
Bump Embedded Cluster to 2.13.5+k8s-1.33

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -3,7 +3,7 @@ kind: Config
 metadata:
   name: embedded-cluster-config
 spec:
-  version: "2.13.0+k8s-1.33"
+  version: "2.13.5+k8s-1.33"
   domains:
     proxyRegistryDomain: "images.r9.all-hands.dev"
     replicatedAppDomain: "updates.r9.all-hands.dev"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -8,7 +8,7 @@ spec:
   releaseName: openhands
   namespace: openhands
   weight: 10
-  helmUpgradeFlags: ["--wait", "--timeout", "600s", "--force-conflicts"]
+  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
   values:
     global:
       imageRegistry: 'images.r9.all-hands.dev'

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -8,7 +8,7 @@ spec:
   namespace: openhands
   releaseName: openhands-secrets
   weight: 1
-  helmUpgradeFlags: ["--wait", "--timeout", "600s", "--force-conflicts"]
+  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
   values:
     config:
       # Security secrets


### PR DESCRIPTION
## What

1. Bumps the Embedded Cluster version pin in `replicated/embedded-cluster.yaml` from `2.13.0+k8s-1.33` to `2.13.5+k8s-1.33`.
2. Removes the Helm-4-only `--force-conflicts` flag from the `openhands` and `openhands-secrets` HelmChart `helmUpgradeFlags` — **required** for deploys to work on EC ≥2.13.3 (see validation comment). These must ship together.

## Why

A customer needs to rotate the Admin Console TLS certificate. EC 2.13.2 introduced the supported one-liner for this:

```bash
sudo ./openhands admin-console update-tls --tls-cert <cert> --tls-key <key>
```

Without it, the options are the anonymous-upload Admin Console flow (Replicated docs flag it as a temporary security hole) or manually patching the `kotsadm-tls` secret via kubectl.

## Why 2.13.5 specifically

- Latest patch on the 2.13.x line — stays on Kubernetes 1.33 (1.33.6 → 1.33.8 node patch only), no k8s minor jump, no Helm 4 migration (that lands in EC 2.15.0).
- **Avoids 2.13.2 exactly**: 2.13.1/2.13.2 shipped Helm v4 with default server-side apply, which could fail application upgrades; 2.13.3 fixed it by pinning Helm v3.
- Small KOTS bump 1.129.1 → 1.129.4; no breaking changes.
- Fixes the `embedded-cluster-operator` CrashLoopBackOff seen on long-lived installs (operator pod limits removed — 2.13.2 release note; confirmed fixed on R02).
- Picks up Go 1.25.7 / crypto/tls CVE-2025-68121 fixes.

Release notes: https://docs.replicated.com/release-notes/rn-embedded-cluster

## Why the --force-conflicts removal is coupled

EC 2.13.3+ pins the KOTS-bundled Helm back to v3, which has no `--force-conflicts` flag — with it, every chart deploy on the upgraded cluster fails with `Error: unknown flag: --force-conflicts` (reproduced on R02). The flag was added in #648 for Helm-4 server-side-apply field-manager conflicts, which don't occur under Helm v3's client-side apply. Cluster upgrades always complete before the app deploys, so this release's charts always deploy under Helm v3.

## Rollout

Existing installs pick up the EC infrastructure upgrade automatically on their next admin-console app update. Expect a longer deploy than chart-only upgrades (k0s + kotsadm restart; ~15 min observed on m8i.2xlarge) and a brief API-server blip. **Known hang risk on single-node installs:** warm runtime/sandbox pod PDBs (`maxUnavailable: 0`) block the node drain — see validation comment.

## Validation

In-place 2.13.0 → 2.13.5 upgrade on R02 — PASS. Details in the PR comment; full report in `~/replicated-tests/alona-ec-2.13.5/2026-06-11/REPORT.md`. `update-tls` verified working post-upgrade.