### PR TITLE
Explain invitation behavior in the org membership KOTS help text

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -451,13 +451,13 @@ spec:
           default: "0"
         - name: default_openhands_org_auto_add_users
           title: Automatically Add Signed-In Users
-          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, users land in the default organization automatically; existing users are moved into it on their next sign-in.
+          help_text: Add every authenticated OpenHands user to the default organization as a member. After sign in, users land in the default organization automatically; existing users are moved into it on their next sign-in. With this enabled, in-app invitations are only needed to grant a role such as admin up front. With this disabled, the organization is invitation-only and admins share invite links from the members page.
           type: bool
           default: "1"
           when: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
         - name: default_openhands_org_hide_personal_workspaces
           title: Hide Personal Workspaces
-          help_text: 'Make the default organization the only workspace users see. Existing personal workspace data (conversations, secrets, API keys, automations) is hidden, not deleted; disabling this option restores it.'
+          help_text: 'Make the default organization the only workspace users see. Existing personal workspace data (conversations, secrets, API keys, automations) is hidden, not deleted; disabling this option restores it. Requires automatic adding of signed-in users, so no one is left without a visible workspace; a user who belongs to no organization keeps their personal workspace either way.'
           type: bool
           default: "1"
           when: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") }}'


### PR DESCRIPTION
Follow-up to the org invite work (OpenHands #14758/#14759/#14786/#14790): the installer-facing help text now answers the question those PRs raised.

- **Automatically Add Signed-In Users**: states what invitations mean in each mode: with auto-add on, invitations only matter for pre-assigning a role (e.g. admin); with it off, the org is invitation-only and admins share invite links from the members page.
- **Hide Personal Workspaces**: explains *why* it requires auto-add (no one is left without a visible workspace) and documents the existing frontend safety valve (a user in no org keeps their personal workspace regardless).

Help-text only; no behavior, env, or template changes. `make lint` clean (the may-contain-secrets infos are pre-existing).