### PR TITLE
feat: pin OH_DEPLOYMENT_MODE=self_hosted on OHE deployments

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.48
+version: 0.7.49
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -541,6 +541,9 @@
 {{- end }}
 - name: OH_APP_MODE
   value: "saas"
+# OHE is always self-hosted; pin it so deployment_mode isn't host-inferred.
+- name: OH_DEPLOYMENT_MODE
+  value: "self_hosted"
 - name: OH_APP_CONVERSATION_INFO_KIND
   value: server.utils.saas_app_conversation_info_injector.SaasAppConversationInfoServiceInjector
 - name: OH_LLM_MODEL_KIND


### PR DESCRIPTION
## What

An OHE install is always self-hosted. Set **`OH_DEPLOYMENT_MODE=self_hosted`** statically on the OpenHands deployments so `deployment_mode` is deterministic rather than inferred from the hostname — the host heuristic mislabels self-hosted installs under `*.all-hands.dev` (e.g. our test VMs) as `cloud`.

Added to the `openhands.env.defaults` macro next to `OH_APP_MODE`, so it propagates to `openhands`, `openhands-integrations`, and `openhands-mcp` via the shared `openhands.env` helper. No KOTS config field — there's no scenario where an OHE install isn't self-hosted.

Companion to OpenHands/OpenHands#14794, which honors the flag (explicit `OH_DEPLOYMENT_MODE` precedence in both deployment-mode resolvers) and gates the cloud-only "Need an OpenHands Account?" CTA on it.

## Test

`helm template charts/openhands` renders cleanly; `OH_DEPLOYMENT_MODE=self_hosted` appears alongside `OH_APP_MODE` on all three deployments.