### PR TITLE
Expose sandbox host-path mounts in KOTS (ADDITIONAL_HOST_PATHS)

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -938,16 +938,6 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
-        - name: sandbox_additional_host_paths
-          title: Additional Host Path Mounts
-          help_text: >-
-            Mount node host paths into every sandbox (the OSS SANDBOX_VOLUMES equivalent).
-            Comma-separated host_path:container_path[:mode] entries; mode is ro or rw
-            (default rw), e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist
-            on the node — for NFS, pre-mount the export at that path on every node. On
-            multi-node clusters the path must exist on all nodes. Leave blank to disable.
-          type: textarea
-          default: ""
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
           help_text: Use this if you bundle a custom agent-server image.
@@ -995,6 +985,16 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: false
+        - name: sandbox_additional_host_paths
+          title: Additional Host Path Mounts
+          help_text: >-
+            Mount node host paths into every sandbox (the OSS SANDBOX_VOLUMES equivalent).
+            Comma-separated host_path:container_path[:mode] entries; mode is ro or rw
+            (default rw), e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist
+            on the node — for NFS, pre-mount the export at that path on every node. On
+            multi-node clusters the path must exist on all nodes. Leave blank to disable.
+          type: textarea
+          default: ""
 
     - name: proxy_configuration
       title: Proxy Configuration

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -988,11 +988,11 @@ spec:
         - name: sandbox_additional_host_paths
           title: Additional Host Path Mounts
           help_text: >-
-            Mount node host paths into every sandbox. Comma-separated
-            host_path:container_path[:mode] entries; mode is ro or rw (default rw),
-            e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist on the
-            node. For NFS, pre-mount the export at that path on every node. On
-            multi-node clusters the path must exist on all nodes. Leave blank to disable.
+            Mount node host paths into every sandbox, one per line as
+            host_path:container_path[:mode] (mode ro or rw, default rw), e.g.
+            /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist on the node.
+            For NFS, pre-mount the export at that path on every node. On multi-node
+            clusters the path must exist on all nodes.
           type: textarea
           default: ""
 

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -938,6 +938,16 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
+        - name: sandbox_additional_host_paths
+          title: Additional Host Path Mounts
+          help_text: >-
+            Mount node host paths into every sandbox (the OSS SANDBOX_VOLUMES equivalent).
+            Comma-separated host_path:container_path[:mode] entries; mode is ro or rw
+            (default rw), e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist
+            on the node — for NFS, pre-mount the export at that path on every node. On
+            multi-node clusters the path must exist on all nodes. Leave blank to disable.
+          type: textarea
+          default: ""
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
           help_text: Use this if you bundle a custom agent-server image.

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -988,10 +988,10 @@ spec:
         - name: sandbox_additional_host_paths
           title: Additional Host Path Mounts
           help_text: >-
-            Mount node host paths into every sandbox (the OSS SANDBOX_VOLUMES equivalent).
-            Comma-separated host_path:container_path[:mode] entries; mode is ro or rw
-            (default rw), e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist
-            on the node — for NFS, pre-mount the export at that path on every node. On
+            Mount node host paths into every sandbox. Comma-separated
+            host_path:container_path[:mode] entries; mode is ro or rw (default rw),
+            e.g. /mnt/nfs-artifacts:/nfs:ro. The host_path must already exist on the
+            node. For NFS, pre-mount the export at that path on every node. On
             multi-node clusters the path must exist on all nodes. Leave blank to disable.
           type: textarea
           default: ""

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -308,6 +308,7 @@ spec:
         CPU_LIMIT: 'repl{{ ConfigOption "sandbox_cpu_limit" }}'
         LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
         ADDITIONAL_CONFIGMAPS: "openhands-ca-bundle:/etc/openhands/ca-bundle"
+        ADDITIONAL_HOST_PATHS: 'repl{{ ConfigOption "sandbox_additional_host_paths" }}'
       warmRuntimes:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}


### PR DESCRIPTION
## What

Adds an **Additional Host Path Mounts** option to the sandbox configuration so admins can mount node host paths into every sandbox — the OSS `SANDBOX_VOLUMES` equivalent for OHE.

- `replicated/config.yaml`: new `sandbox_additional_host_paths` config option (textarea, blank by default).
- `replicated/openhands.yaml`: passes it to the runtime-api chart as `ADDITIONAL_HOST_PATHS`.

No chart-template change needed — `charts/runtime-api/templates/_env.yaml` already ranges `.Values.env`.

## Why

An enterprise customer migrating from OSS Docker OpenHands shares 100GB+ build artifacts into sandboxes via an NFS export mounted on the host, and prefers hostPath over PVC. This surfaces that capability in the admin console.

## How it works

The admin enters `host_path:container_path[:mode]` entries (comma- or newline-separated; `mode` ro/rw, default rw), e.g. `/mnt/nfs-artifacts:/nfs:ro`. The host path must already exist on the node — for NFS, pre-mount the export there (on every node for multi-node clusters). Blank = disabled (no-op).

## Companion PR

Requires the runtime-api change that reads the env var and builds the hostPath volumes: OpenHands/runtime-api#593.

## Testing

- `config.yaml` + `openhands.yaml` parse cleanly; the new option renders as `type: textarea`.
- `helm template charts/runtime-api` confirms `ADDITIONAL_HOST_PATHS` reaches both the runtime-api deployment and the warm-runtime pods.

## ✅ Proven live on a real OHE embedded-cluster install (R03)

With this env wiring delivering the value, a **real sandbox pod** mounted a node host path and read a host-written sentinel file through a read-only `/nfs` mount (write correctly denied). See OpenHands/runtime-api#593 for the full end-to-end trace. Internal report: `~/replicated-tests/sandbox-hostpath-volumes/2026-06-14/REPORT.md`.
