### PR TITLE
Optional /dev/kvm passthrough for sandboxes (SANDBOX_KVM_ENABLED)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.51
+version: 0.7.52
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.9
+    version: 0.3.10
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.9 # Change this to trigger a new helm chart version being published
+version: 0.3.10 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/kvm-device-plugin.yaml
+++ b/charts/runtime-api/templates/kvm-device-plugin.yaml
@@ -1,0 +1,74 @@
+{{- if eq (toString .Values.kvm.enabled) "true" }}
+# smarter-device-manager advertises /dev/kvm as an extended resource so sandbox
+# pods can request it and run hardware-accelerated QEMU without being privileged.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "runtime-api.fullname" . }}-kvm-device-plugin
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
+data:
+  conf.yaml: |
+    - devicematch: ^kvm$
+      nummaxdevices: {{ .Values.kvm.maxDevices }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "runtime-api.fullname" . }}-kvm-device-plugin
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "runtime-api.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kvm-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "runtime-api.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kvm-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      {{- with .Values.kvm.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kvm.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kvm-device-plugin
+          image: "{{ .Values.kvm.image.repository }}:{{ .Values.kvm.image.tag }}"
+          imagePullPolicy: {{ .Values.kvm.image.pullPolicy }}
+          # smarter-device-manager needs to read host devices and register with
+          # the kubelet, so it runs privileged (the device plugin only, not sandboxes).
+          securityContext:
+            privileged: true
+          resources:
+            {{- toYaml .Values.kvm.resources | nindent 12 }}
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev-dir
+              mountPath: /dev
+            - name: config
+              mountPath: /root/config
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: config
+          configMap:
+            name: {{ include "runtime-api.fullname" . }}-kvm-device-plugin
+{{- end }}

--- a/charts/runtime-api/templates/kvm-device-plugin.yaml
+++ b/charts/runtime-api/templates/kvm-device-plugin.yaml
@@ -40,6 +40,20 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.kvm.relaxDevicePermissions }}
+      initContainers:
+        # Device plugin advertises /dev/kvm, but its 0660 root:kvm perms block the
+        # non-root sandbox UID; relax to 0666 so unprivileged sandboxes can open it.
+        - name: chmod-kvm
+          image: "{{ .Values.kvm.initImage.repository }}:{{ .Values.kvm.initImage.tag }}"
+          imagePullPolicy: {{ .Values.kvm.initImage.pullPolicy }}
+          securityContext:
+            privileged: true
+          command: ["sh", "-c", "if [ -e /dev/kvm ]; then chmod 0666 /dev/kvm; fi"]
+          volumeMounts:
+            - name: dev-dir
+              mountPath: /dev
+      {{- end }}
       containers:
         - name: kvm-device-plugin
           image: "{{ .Values.kvm.image.repository }}:{{ .Values.kvm.image.tag }}"

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -107,6 +107,30 @@ nodeSelector: {}
 
 securityContext: {}
 
+# KVM device plugin (OSS SANDBOX_KVM_ENABLED parity). When enabled, runs a
+# smarter-device-manager DaemonSet that advertises /dev/kvm as an extended
+# resource (kvm.resourceName) so sandbox pods can use hardware-accelerated QEMU
+# WITHOUT being privileged. The node must expose /dev/kvm (bare-metal or a
+# nested-virt-capable VM). The plugin DaemonSet itself runs privileged, like
+# other device plugins; the sandbox pods do not.
+kvm:
+  enabled: false
+  resourceName: smarter-devices/kvm
+  maxDevices: 20
+  image:
+    repository: ghcr.io/smarter-project/smarter-device-manager
+    tag: v1.20.11
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
+  nodeSelector: {}
+  tolerations: []
+
 tolerations: []
 
 affinity: {}

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -121,6 +121,15 @@ kvm:
     repository: ghcr.io/smarter-project/smarter-device-manager
     tag: v1.20.11
     pullPolicy: IfNotPresent
+  # The device plugin advertises /dev/kvm but the node's default 0660 root:kvm
+  # perms still block the non-root sandbox UID from opening it. An init container
+  # relaxes /dev/kvm to 0666 so unprivileged sandboxes can use it. Disable only if
+  # you grant access another way (e.g. a node udev rule or supplementalGroups).
+  relaxDevicePermissions: true
+  initImage:
+    repository: busybox
+    tag: "1.36"
+    pullPolicy: IfNotPresent
   resources:
     limits:
       cpu: 100m

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -938,6 +938,17 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
+        - name: sandbox_kvm_enabled
+          title: Enable /dev/kvm passthrough (QEMU/KVM)
+          help_text: >-
+            Pass /dev/kvm into sandboxes so they can run hardware-accelerated QEMU/KVM
+            (the OSS SANDBOX_KVM_ENABLED equivalent). Deploys a small device-plugin
+            DaemonSet and requests the device on each sandbox WITHOUT making sandboxes
+            privileged. The cluster node(s) MUST expose /dev/kvm — i.e. bare metal or a
+            nested-virtualization-capable VM (on Azure, a Dv3+/Ev3+/v4/v5 size, not
+            B-series; on AWS, a .metal instance). Verify with `ls -l /dev/kvm` on the node.
+          type: bool
+          default: "0"
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
           help_text: Use this if you bundle a custom agent-server image.

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -938,17 +938,6 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
-        - name: sandbox_kvm_enabled
-          title: Enable /dev/kvm passthrough (QEMU/KVM)
-          help_text: >-
-            Pass /dev/kvm into sandboxes so they can run hardware-accelerated QEMU/KVM
-            (the OSS SANDBOX_KVM_ENABLED equivalent). Deploys a small device-plugin
-            DaemonSet and requests the device on each sandbox WITHOUT making sandboxes
-            privileged. The cluster node(s) MUST expose /dev/kvm — i.e. bare metal or a
-            nested-virtualization-capable VM (on Azure, a Dv3+/Ev3+/v4/v5 size, not
-            B-series; on AWS, a .metal instance). Verify with `ls -l /dev/kvm` on the node.
-          type: bool
-          default: "0"
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
           help_text: Use this if you bundle a custom agent-server image.
@@ -996,6 +985,14 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: false
+        - name: sandbox_kvm_enabled
+          title: Enable /dev/kvm passthrough (QEMU/KVM)
+          help_text: >-
+            Pass /dev/kvm into sandboxes so they can run hardware-accelerated QEMU/KVM
+            (the OSS SANDBOX_KVM_ENABLED equivalent). The cluster node(s) MUST expose
+            /dev/kvm. Verify with `ls -l /dev/kvm` on the node.
+          type: bool
+          default: "0"
 
     - name: proxy_configuration
       title: Proxy Configuration

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -308,6 +308,14 @@ spec:
         CPU_LIMIT: 'repl{{ ConfigOption "sandbox_cpu_limit" }}'
         LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
         ADDITIONAL_CONFIGMAPS: "openhands-ca-bundle:/etc/openhands/ca-bundle"
+        SANDBOX_KVM_ENABLED: 'repl{{ ConfigOptionEquals "sandbox_kvm_enabled" "1" }}'
+        KVM_DEVICE_RESOURCE: "smarter-devices/kvm"
+      kvm:
+        enabled: repl{{ ConfigOptionEquals "sandbox_kvm_enabled" "1" }}
+        resourceName: smarter-devices/kvm
+        image:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/smarter-project/smarter-device-manager'
+          tag: v1.20.11
       warmRuntimes:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -316,6 +316,9 @@ spec:
         image:
           repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/smarter-project/smarter-device-manager'
           tag: v1.20.11
+        initImage:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/busybox'
+          tag: "1.36"
       warmRuntimes:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}


### PR DESCRIPTION
## What

Adds an opt-in **/dev/kvm passthrough** option so sandboxes can run hardware-accelerated QEMU/KVM (the OSS `SANDBOX_KVM_ENABLED` equivalent) — **without** making sandbox pods privileged.

- `replicated/config.yaml`: new `sandbox_kvm_enabled` bool (default `0`).
- `replicated/openhands.yaml`: sets `SANDBOX_KVM_ENABLED` + `KVM_DEVICE_RESOURCE=smarter-devices/kvm` on runtime-api, and enables the device-plugin DaemonSet, both gated on the toggle.
- `charts/runtime-api`: a `smarter-device-manager` DaemonSet (+ config ConfigMap) advertising `/dev/kvm` as `smarter-devices/kvm`, plus a `chmod-kvm` init container (see validation). Rendered only when the toggle is on.

## Security posture

Route B (device plugin), not privileged sandboxes. The **device-plugin DaemonSet** runs privileged — like NVIDIA's GPU plugin, it needs host `/dev` + the kubelet device-plugin socket — but the **sandbox pods stay unprivileged** and only receive the single `/dev/kvm` device. Default off → zero impact on existing installs until an admin enables it.

## Requirements

The cluster node(s) must expose a real `/dev/kvm`: bare metal, or a nested-virt-capable VM (Azure Dv3+/Ev3+/v4/v5 — not B-series; AWS `.metal`). `ls -l /dev/kvm` on the node is the definitive check. Keep `RUNTIME_CLASS` empty or `sysbox-runc` (runtime-api rejects gvisor).

## Companion PR

App side that requests the device: OpenHands/runtime-api#594. The two must land together — enabling the toggle without the device plugin would make sandboxes unschedulable.

## Testing

- YAML parses; toggle renders as `type: bool`; `helm template` shows the DaemonSet + ConfigMap render **only** when enabled (0 objects when off).

## ✅ Proven live on real KVM hardware (AWS c5.metal)

Deployed the **actual chart-rendered** device-plugin DaemonSet on a single-node k8s on an AWS **bare-metal** node:
- the node advertised `smarter-devices/kvm`;
- an unprivileged UID-10001 pod requesting it opened `/dev/kvm` read-write and ran KVM-accelerated QEMU (SeaBIOS boot, no KVM-access error).

**Why the `chmod-kvm` init container exists:** the live test showed the device plugin exposes `/dev/kvm` into the sandbox, but its default `0660 root:kvm` perms blocked the non-root sandbox UID from opening it ("OPEN DENIED"). The init container relaxes `/dev/kvm` to `0666` (toggle `kvm.relaxDevicePermissions`, default true); after it, the unprivileged sandbox UID opened the device and QEMU accelerated. Re-verified with the real chart manifest (reset perms to 0660 first; the chart's own init container re-applied 0666). Internal report: `~/replicated-tests/sandbox-kvm/2026-06-14/REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
