### PR TITLE
fix: pin enterprise-server to a #14773-inclusive sha for managed models

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-d6f88b0'
+      tag: 'sha-480c094'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## Problem

Any deploy/upgrade off OpenHands-Cloud `main` currently crashloops the `openhands`, `openhands-integrations`, and `openhands-mcp` pods with:

```
ModuleNotFoundError: No module named 'server.verified_models.litellm_proxy_model_router'
```

This is an **atomicity violation in the managed-models rollout, not a sandbox/feature bug:**

- #707 (`95240ff`) re-pointed `OH_LLM_MODEL_KIND` in `charts/openhands/templates/_env.yaml` to `server.verified_models.litellm_proxy_model_router.LiteLLMProxyModelServiceInjector`.
- That class was added by OpenHands app **#14773** (`a6bce82`, 2026-06-14).
- But the enterprise-server image pin in `replicated/openhands.yaml` was left at `sha-d6f88b0` (Release 1.38.0, 2026-06-10) — **4 days before the module existed**.
- The env parser does a hard `importlib.import_module(OH_LLM_MODEL_KIND)` with **no fallback**, so a SET-but-missing kind takes the whole app down at startup (the UNSET path would fall back to `DefaultLLMModelServiceInjector`, but the chart sets it unconditionally).

## Fix (forward-only)

Bump the enterprise-server pin to a `#14773`-inclusive build:

```diff
-      tag: 'sha-d6f88b0'
+      tag: 'sha-480c094'
```

`sha-480c094` = OpenHands `main` HEAD **#14803** (`480c0946c`), which includes `#14773` + `#14774` (the full managed-models stack). The enterprise-server image for this sha built successfully (Docker workflow on `main`).

## Why this is safe / sufficient

- The missing module is present at this sha (`enterprise/server/verified_models/litellm_proxy_model_router.py`).
- **No new env/secret is required for the pods to boot:** the injector/service have no failing `__init__`, module-level imports use safe defaults (`LITE_LLM_API_URL`/`LITE_LLM_API_KEY` already chart-provided), and request-time proxy discovery is fully `try/except`ed (degrades to an empty/catalogue model list, never raises). `STORE_MODEL_IN_DB` + the LiteLLM salt key are LiteLLM-subchart concerns for *persisting* dashboard-added models and are already configured.

## Notes

- The design (hardcoding `OH_*_KIND` class paths in `_env.yaml`) is the established OHE pattern and proxy-as-catalog is the intended OHE default, so nothing is reverted/gated here — this just completes the atomic chart+image bump that #707 missed.
- A normal OHE release will later normalize this pin to a `cloud-1.39.0` tag once OpenHands release-please **#14748** merges; this sha pin is the immediate unblock for `main`.
- Follow-up worth considering (separate PR): move the OHE default model-service kind into the enterprise *image* (via the `OPENHANDS_CONFIG_CLS` hook) so the chart never pins an app-internal class path and this class of skew can't recur.

