### PR TITLE
fix: pin runtime-api image to include sandbox hostPath + KVM features

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -263,6 +263,7 @@ spec:
         enabled: false
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/runtime-api'
+        tag: 'sha-8919a43'
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       ingress:


### PR DESCRIPTION
## What

Pins the runtime-api image (in `replicated/openhands.yaml`) to `sha-8919a43` — the runtime-api `main` HEAD that includes both merged sandbox features:
- #593 `ADDITIONAL_HOST_PATHS` (hostPath sandbox volumes, OSS `SANDBOX_VOLUMES` parity)
- #594 `SANDBOX_KVM_ENABLED` (/dev/kvm passthrough, OSS `SANDBOX_KVM_ENABLED` parity)

## Why

OpenHands-Cloud#715 / #716 added the KOTS config + chart wiring for these features, but the chart still pinned the *old* runtime-api image (`sha-61fc535`), which doesn't contain the parsing code. So the config options rendered but did nothing. This bumps the pin so the features actually run. No chart-version change (the override lives in the KOTS HelmChart values, not a chart file).

Backward-compatible: the new runtime-api image is a no-op when the env vars are unset/default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
