### PR TITLE
Drop chart OH_*_KIND env now baked into the enterprise image (#14811)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.52
+version: 0.7.53
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -544,10 +544,8 @@
 # OHE is always self-hosted; pin it so deployment_mode isn't host-inferred.
 - name: OH_DEPLOYMENT_MODE
   value: "self_hosted"
-- name: OH_APP_CONVERSATION_INFO_KIND
-  value: server.utils.saas_app_conversation_info_injector.SaasAppConversationInfoServiceInjector
-- name: OH_LLM_MODEL_KIND
-  value: server.verified_models.litellm_proxy_model_router.LiteLLMProxyModelServiceInjector
+# OH_APP_CONVERSATION_INFO_KIND / OH_LLM_MODEL_KIND are baked into the enterprise
+# image (OpenHands#14811), so the chart no longer sets them — keeps the two in sync.
 - name: CONVERSATION_MANAGER_CLASS
   value: server.saas_nested_conversation_manager.SaasNestedConversationManager
 {{- if (index .Values "plugin-directory").enabled }}

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-480c094'
+      tag: 'sha-48cc27a'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## What

- Bumps the enterprise-server image pin in `replicated/openhands.yaml` from `sha-480c094` → **`sha-48cc27a`** (= OpenHands/OpenHands#14811, current `main` HEAD).
- Removes `OH_APP_CONVERSATION_INFO_KIND` and `OH_LLM_MODEL_KIND` from `charts/openhands/templates/_env.yaml`.
- Bumps the `openhands` chart `0.7.52` → `0.7.53` (chart file changed).

## Why

OpenHands#14811 bakes those two injector-kind defaults into the enterprise image's Dockerfile (`ENV OH_LLM_MODEL_KIND=…`, `ENV OH_APP_CONVERSATION_INFO_KIND=…`). With an image that carries them, the chart no longer needs to set them — and shouldn't, so the two can never skew (the failure mode behind #717's crashloop, where the chart referenced an injector class the pinned image didn't have).

The chart values were **byte-for-byte identical** to the image's `ENV` defaults, so this is a **no-op at runtime** — the same value just comes from the image instead of the chart.

## Ordering / safety

The image bump and the line removal are in the **same commit** on purpose: `sha-480c094` predates #14811 and has no baked-in defaults, so dropping the lines against the old image would leave the injector kinds unset. Pinning the #14811 image first (here, atomically) keeps every rendered state correct. The `sha-48cc27a` image build is already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
