### PR TITLE
refactor: improve update_openhands_charts test quality (granularity + fixture reuse)

### DIFF
--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -36,11 +36,14 @@ Usage Example
 
 import base64
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
 from ruamel.yaml import YAML
+
+import update_openhands_charts
 
 # =============================================================================
 # Fixture baseline constants
@@ -841,3 +844,27 @@ def mock_github_ref(monkeypatch):
         return mock_github, mock_github.get_repo.return_value
 
     return _mock_github
+
+
+@pytest.fixture
+def openhands_workflow_mocks(monkeypatch):
+    """Patch the four inner functions called by update_openhands_workflow.
+
+    Returns a namespace exposing each MagicMock by name (`.values`,
+    `.replicated`, `.replicated_config`, `.chart`) so each workflow-contract
+    test asserts on the calls it focuses on without depending on a positional
+    return shape. The values mock reports has_changes=True so the chart-bump
+    path is exercised; the others return a no-change UpdateResult and exist to
+    prevent writes to the real files.
+    """
+    mocks = SimpleNamespace(
+        values=MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True)),
+        replicated=MagicMock(return_value=update_openhands_charts.UpdateResult()),
+        replicated_config=MagicMock(return_value=update_openhands_charts.UpdateResult()),
+        chart=MagicMock(return_value=update_openhands_charts.UpdateResult()),
+    )
+    monkeypatch.setattr("update_openhands_charts.update_openhands_values", mocks.values)
+    monkeypatch.setattr("update_openhands_charts.update_replicated_openhands_values", mocks.replicated)
+    monkeypatch.setattr("update_openhands_charts.update_replicated_config", mocks.replicated_config)
+    monkeypatch.setattr("update_openhands_charts.update_openhands_chart", mocks.chart)
+    return mocks

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -2447,25 +2447,6 @@ class TestUpdateOpenhandsWorkflow:
     has_changes propagates from values into the chart's bump decision.
     """
 
-    @pytest.fixture
-    def patched_inner_calls(self, monkeypatch):
-        """Mock all four inner update functions.
-
-        Return only the values/chart mocks asserted by this workflow-contract
-        test class. The replicated mocks are intentionally not returned here;
-        they are patched only to prevent writes to the real replicated files and
-        have dedicated assertions in the focused replicated workflow test classes.
-        """
-        mock_values = MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True))
-        mock_replicated = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        mock_replicated_config = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        mock_chart = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        monkeypatch.setattr("update_openhands_charts.update_openhands_values", mock_values)
-        monkeypatch.setattr("update_openhands_charts.update_replicated_openhands_values", mock_replicated)
-        monkeypatch.setattr("update_openhands_charts.update_replicated_config", mock_replicated_config)
-        monkeypatch.setattr("update_openhands_charts.update_openhands_chart", mock_chart)
-        return mock_values, mock_chart
-
     def test_chart_call_receives_has_changes_true_when_values_changed(self, monkeypatch):
         """When values has changes, the chart is invoked with has_changes=True so version bumps."""
         monkeypatch.setattr(
@@ -2520,10 +2501,8 @@ class TestUpdateOpenhandsWorkflow:
 
         assert mock_chart.call_args.kwargs["has_changes"] is False
 
-    def test_values_call_receives_openhands_version(self, patched_inner_calls):
+    def test_values_call_receives_openhands_version(self, openhands_workflow_mocks):
         """openhands_version is passed positionally to update_openhands_values as the 2nd argument."""
-        mock_values, _ = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-9.9.9",
@@ -2532,12 +2511,10 @@ class TestUpdateOpenhandsWorkflow:
             dry_run=False,
         )
 
-        assert mock_values.call_args.args[1] == "cloud-9.9.9"
+        assert openhands_workflow_mocks.values.call_args.args[1] == "cloud-9.9.9"
 
-    def test_values_call_receives_runtime_image_tag(self, patched_inner_calls):
+    def test_values_call_receives_runtime_image_tag(self, openhands_workflow_mocks):
         """runtime_image_tag is passed positionally to update_openhands_values as the 3rd argument."""
-        mock_values, _ = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2546,12 +2523,10 @@ class TestUpdateOpenhandsWorkflow:
             dry_run=False,
         )
 
-        assert mock_values.call_args.args[2] == "image-tag-v9"
+        assert openhands_workflow_mocks.values.call_args.args[2] == "image-tag-v9"
 
-    def test_chart_call_receives_openhands_version(self, patched_inner_calls):
+    def test_chart_call_receives_openhands_version(self, openhands_workflow_mocks):
         """openhands_version is passed positionally to update_openhands_chart as the 2nd argument."""
-        _, mock_chart = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-9.9.9",
@@ -2560,12 +2535,10 @@ class TestUpdateOpenhandsWorkflow:
             dry_run=False,
         )
 
-        assert mock_chart.call_args.args[1] == "cloud-9.9.9"
+        assert openhands_workflow_mocks.chart.call_args.args[1] == "cloud-9.9.9"
 
-    def test_chart_call_receives_runtime_api_version(self, patched_inner_calls):
+    def test_chart_call_receives_runtime_api_version(self, openhands_workflow_mocks):
         """runtime_api_version is passed positionally to update_openhands_chart as the 3rd argument."""
-        _, mock_chart = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2574,13 +2547,11 @@ class TestUpdateOpenhandsWorkflow:
             dry_run=False,
         )
 
-        assert mock_chart.call_args.args[2] == "0.9.99"
+        assert openhands_workflow_mocks.chart.call_args.args[2] == "0.9.99"
 
     @pytest.mark.parametrize("dry_run", [True, False])
-    def test_dry_run_is_propagated_to_both_inner_calls(self, patched_inner_calls, dry_run):
+    def test_dry_run_is_propagated_to_both_inner_calls(self, openhands_workflow_mocks, dry_run):
         """The dry_run flag is forwarded to both update_openhands_values and update_openhands_chart."""
-        mock_values, mock_chart = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2589,8 +2560,8 @@ class TestUpdateOpenhandsWorkflow:
             dry_run=dry_run,
         )
 
-        assert mock_values.call_args.kwargs["dry_run"] is dry_run
-        assert mock_chart.call_args.kwargs["dry_run"] is dry_run
+        assert openhands_workflow_mocks.values.call_args.kwargs["dry_run"] is dry_run
+        assert openhands_workflow_mocks.chart.call_args.kwargs["dry_run"] is dry_run
 
 
 class TestUpdateOpenhandsWorkflowReplicated:
@@ -2601,23 +2572,8 @@ class TestUpdateOpenhandsWorkflowReplicated:
     The workflow must update that file too, or Replicated installs ship a stale tag.
     """
 
-    @pytest.fixture
-    def patched_inner_calls(self, monkeypatch):
-        """Mock all four inner update functions and return the first three MagicMocks."""
-        mock_values = MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True))
-        mock_replicated = MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True))
-        mock_replicated_config = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        mock_chart = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        monkeypatch.setattr("update_openhands_charts.update_openhands_values", mock_values)
-        monkeypatch.setattr("update_openhands_charts.update_replicated_openhands_values", mock_replicated)
-        monkeypatch.setattr("update_openhands_charts.update_replicated_config", mock_replicated_config)
-        monkeypatch.setattr("update_openhands_charts.update_openhands_chart", mock_chart)
-        return mock_values, mock_replicated, mock_chart
-
-    def test_replicated_updater_invoked_with_replicated_openhands_path(self, patched_inner_calls):
+    def test_replicated_updater_invoked_with_replicated_openhands_path(self, openhands_workflow_mocks):
         """The workflow points the replicated updater at replicated/openhands.yaml."""
-        _, mock_replicated, _ = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2626,12 +2582,10 @@ class TestUpdateOpenhandsWorkflowReplicated:
             dry_run=False,
         )
 
-        assert mock_replicated.call_args.args[0] == update_openhands_charts.REPLICATED_OPENHANDS_PATH
+        assert openhands_workflow_mocks.replicated.call_args.args[0] == update_openhands_charts.REPLICATED_OPENHANDS_PATH
 
-    def test_replicated_updater_receives_runtime_image_tag(self, patched_inner_calls):
+    def test_replicated_updater_receives_runtime_image_tag(self, openhands_workflow_mocks):
         """runtime_image_tag is forwarded to the replicated updater."""
-        _, mock_replicated, _ = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2640,13 +2594,11 @@ class TestUpdateOpenhandsWorkflowReplicated:
             dry_run=False,
         )
 
-        assert mock_replicated.call_args.args[1] == "9.9.9-python"
+        assert openhands_workflow_mocks.replicated.call_args.args[1] == "9.9.9-python"
 
     @pytest.mark.parametrize("dry_run", [True, False])
-    def test_replicated_updater_receives_dry_run(self, patched_inner_calls, dry_run):
+    def test_replicated_updater_receives_dry_run(self, openhands_workflow_mocks, dry_run):
         """The dry_run flag is forwarded to the replicated updater."""
-        _, mock_replicated, _ = patched_inner_calls
-
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
             openhands_version="cloud-1.0.0",
@@ -2655,7 +2607,7 @@ class TestUpdateOpenhandsWorkflowReplicated:
             dry_run=dry_run,
         )
 
-        assert mock_replicated.call_args.kwargs["dry_run"] is dry_run
+        assert openhands_workflow_mocks.replicated.call_args.kwargs["dry_run"] is dry_run
 
 
 class TestUpdateOpenhandsWorkflowReplicatedConfig:
@@ -2666,26 +2618,7 @@ class TestUpdateOpenhandsWorkflowReplicatedConfig:
     must update that file too, or Replicated admins see a stale default tag.
     """
 
-    @pytest.fixture
-    def patched_inner_calls(self, monkeypatch):
-        """Mock all four inner update functions; return the replicated-config MagicMock."""
-        monkeypatch.setattr(
-            "update_openhands_charts.update_openhands_values",
-            MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True)),
-        )
-        monkeypatch.setattr(
-            "update_openhands_charts.update_replicated_openhands_values",
-            MagicMock(return_value=update_openhands_charts.UpdateResult()),
-        )
-        mock_replicated_config = MagicMock(return_value=update_openhands_charts.UpdateResult())
-        monkeypatch.setattr("update_openhands_charts.update_replicated_config", mock_replicated_config)
-        monkeypatch.setattr(
-            "update_openhands_charts.update_openhands_chart",
-            MagicMock(return_value=update_openhands_charts.UpdateResult()),
-        )
-        return mock_replicated_config
-
-    def test_replicated_config_updater_invoked_with_replicated_config_path(self, patched_inner_calls):
+    def test_replicated_config_updater_invoked_with_replicated_config_path(self, openhands_workflow_mocks):
         """The workflow points the config updater at replicated/config.yaml."""
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
@@ -2695,9 +2628,9 @@ class TestUpdateOpenhandsWorkflowReplicatedConfig:
             dry_run=False,
         )
 
-        assert patched_inner_calls.call_args.args[0] == update_openhands_charts.REPLICATED_CONFIG_PATH
+        assert openhands_workflow_mocks.replicated_config.call_args.args[0] == update_openhands_charts.REPLICATED_CONFIG_PATH
 
-    def test_replicated_config_updater_receives_runtime_image_tag(self, patched_inner_calls):
+    def test_replicated_config_updater_receives_runtime_image_tag(self, openhands_workflow_mocks):
         """runtime_image_tag is forwarded to the config updater."""
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
@@ -2707,10 +2640,10 @@ class TestUpdateOpenhandsWorkflowReplicatedConfig:
             dry_run=False,
         )
 
-        assert patched_inner_calls.call_args.args[1] == "9.9.9-python"
+        assert openhands_workflow_mocks.replicated_config.call_args.args[1] == "9.9.9-python"
 
     @pytest.mark.parametrize("dry_run", [True, False])
-    def test_replicated_config_updater_receives_dry_run(self, patched_inner_calls, dry_run):
+    def test_replicated_config_updater_receives_dry_run(self, openhands_workflow_mocks, dry_run):
         """The dry_run flag is forwarded to the config updater."""
         update_openhands_workflow(
             DeployConfig(runtime_api_sha="abc"),
@@ -2720,7 +2653,7 @@ class TestUpdateOpenhandsWorkflowReplicatedConfig:
             dry_run=dry_run,
         )
 
-        assert patched_inner_calls.call_args.kwargs["dry_run"] is dry_run
+        assert openhands_workflow_mocks.replicated_config.call_args.kwargs["dry_run"] is dry_run
 
 
 class TestParseArgs:

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -1454,13 +1454,21 @@ class TestUpdateImageLoaderValues:
         return make_temp_yaml_file(sample_image_loader_values)
 
     def test_updates_agent_server_image_tag(self, temp_image_loader_values_file):
-        """Test that the agent-server image tag is updated."""
-        result = update_image_loader_values(
+        """Test that the agent-server image tag is written to the file."""
+        update_image_loader_values(
             temp_image_loader_values_file,
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
         assert_file_contains(temp_image_loader_values_file, f"tag: {NEW_RUNTIME_IMAGE_TAG}\n")
+
+    def test_reports_has_changes_when_tag_updated(self, temp_image_loader_values_file):
+        """Test that updating the tag reports has_changes is True."""
+        result = update_image_loader_values(
+            temp_image_loader_values_file,
+            runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
+        )
+
         assert result.has_changes is True
 
     def test_result_records_image_loader_change(self, temp_image_loader_values_file):
@@ -1950,12 +1958,19 @@ class TestUpdateAutomationValues:
         return make_temp_yaml_file(sample_automation_values)
 
     def test_updates_automation_image_tag(self, temp_automation_values_file):
-        """Test that automation image tag is updated from deploy-config SHA."""
+        """Test that automation image tag is written from the deploy-config SHA."""
+        sha = "1234567890abcdef1234567890abcdef12345678"
+
+        update_automation_values(temp_automation_values_file, automation_sha=sha)
+
+        assert_file_contains(temp_automation_values_file, "tag: sha-1234567\n")
+
+    def test_reports_has_changes_when_automation_tag_updated(self, temp_automation_values_file):
+        """Test that updating the automation tag reports has_changes is True."""
         sha = "1234567890abcdef1234567890abcdef12345678"
 
         result = update_automation_values(temp_automation_values_file, automation_sha=sha)
 
-        assert_file_contains(temp_automation_values_file, "tag: sha-1234567\n")
         assert result.has_changes is True
 
     def test_bare_short_automation_sha_matches_prefixed_chart_tag(self, temp_automation_values_file):
@@ -2296,20 +2311,24 @@ class TestUpdateRuntimeApiWorkflow:
 class TestUpdateAutomationWorkflow:
     """Tests for update_automation_workflow orchestration."""
 
-    def test_updates_values_bumps_chart_and_returns_new_chart_version(
+    @pytest.fixture
+    def automation_paths(
         self,
         monkeypatch,
         make_temp_yaml_file,
         sample_automation_values,
         sample_automation_chart,
     ):
-        """When values change, the automation chart version is bumped and returned."""
+        """Point the workflow at temporary copies of the automation chart files."""
         values_path = make_temp_yaml_file(sample_automation_values)
         chart_path = make_temp_yaml_file(sample_automation_chart)
         monkeypatch.setattr("update_openhands_charts.AUTOMATION_VALUES_PATH", values_path)
         monkeypatch.setattr("update_openhands_charts.AUTOMATION_CHART_PATH", chart_path)
+        return values_path, chart_path
 
-        new_version = update_automation_workflow(
+    def _run(self):
+        """Invoke the workflow with a changed automation SHA; return its result."""
+        return update_automation_workflow(
             DeployConfig(
                 runtime_api_sha="unused",
                 automation_sha="1234567890abcdef1234567890abcdef12345678",
@@ -2317,8 +2336,26 @@ class TestUpdateAutomationWorkflow:
             dry_run=False,
         )
 
+    def test_updates_values_file(self, automation_paths):
+        """When values change, the automation values.yaml receives the new tag."""
+        values_path, _ = automation_paths
+
+        self._run()
+
         assert_file_contains(values_path, "tag: sha-1234567\n")
+
+    def test_bumps_chart_version(self, automation_paths):
+        """When values change, the automation chart version is bumped in the file."""
+        _, chart_path = automation_paths
+
+        self._run()
+
         assert get_chart_value(chart_path, "version") == "0.1.2"
+
+    def test_returns_new_chart_version(self, automation_paths):
+        """When values change, the workflow returns the bumped chart version."""
+        new_version = self._run()
+
         assert new_version == "0.1.2"
 
 

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -617,8 +617,8 @@ def get_agent_server_image():
         called_headers = mock_get.call_args[1]["headers"]
         assert called_headers["Authorization"] == "Bearer my-secret-token"
 
-    def test_returns_none_and_prints_error_on_http_failure(self, monkeypatch, capsys):
-        """Test graceful handling when the GitHub API request fails."""
+    def test_returns_none_on_http_failure(self, monkeypatch):
+        """Returns None (rather than raising) when the GitHub API request fails."""
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = Exception("HTTP 404: Not Found")
         monkeypatch.setattr(
@@ -629,12 +629,24 @@ def get_agent_server_image():
         result = get_runtime_image_tag_from_sandbox_spec("token", "owner/repo", ref="cloud-1.26.1")
 
         assert result is None
+
+    def test_prints_error_on_http_failure(self, monkeypatch, capsys):
+        """Prints a diagnostic message when the GitHub API request fails."""
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = Exception("HTTP 404: Not Found")
+        monkeypatch.setattr(
+            "update_openhands_charts.requests.get",
+            Mock(return_value=mock_response)
+        )
+
+        get_runtime_image_tag_from_sandbox_spec("token", "owner/repo", ref="cloud-1.26.1")
+
         assert "Error fetching sandbox spec" in capsys.readouterr().out
 
-    def test_returns_none_and_prints_error_when_image_constant_missing(
-        self, monkeypatch, make_workflow_response, capsys
+    def test_returns_none_when_image_constant_missing(
+        self, monkeypatch, make_workflow_response
     ):
-        """Test graceful handling when AGENT_SERVER_IMAGE constant is absent."""
+        """Returns None when the AGENT_SERVER_IMAGE constant is absent."""
         response = make_workflow_response("# No image constant here\n")
         monkeypatch.setattr(
             "update_openhands_charts.requests.get",
@@ -644,6 +656,19 @@ def get_agent_server_image():
         result = get_runtime_image_tag_from_sandbox_spec("token", "owner/repo", ref="cloud-1.26.1")
 
         assert result is None
+
+    def test_prints_error_naming_missing_constant(
+        self, monkeypatch, make_workflow_response, capsys
+    ):
+        """Prints an error naming AGENT_SERVER_IMAGE when the constant is absent."""
+        response = make_workflow_response("# No image constant here\n")
+        monkeypatch.setattr(
+            "update_openhands_charts.requests.get",
+            Mock(return_value=response)
+        )
+
+        get_runtime_image_tag_from_sandbox_spec("token", "owner/repo", ref="cloud-1.26.1")
+
         out = capsys.readouterr().out
         assert "Error fetching sandbox spec" in out
         assert "AGENT_SERVER_IMAGE" in out
@@ -786,7 +811,7 @@ env:
     # The printed error message enables operators to diagnose issues from logs.
     # =========================================================================
 
-    @pytest.mark.parametrize("error_name,setup_mock", [
+    _error_scenarios = pytest.mark.parametrize("error_name,setup_mock", [
         # =====================================================================
         # Network-level errors (transient, typically retryable)
         # Recovery: Caller should retry with exponential backoff or skip update
@@ -876,16 +901,12 @@ env:
             lambda: make_invalid_yaml_response("env:\n\t\tinvalid_indent: true"),
         ),
     ])
-    def test_returns_none_and_prints_error(self, error_name, setup_mock, monkeypatch, capsys):
-        """Test that error scenarios return None and print an error message.
+    @_error_scenarios
+    def test_returns_none_on_error(self, error_name, setup_mock, monkeypatch):
+        """Every error path returns None (not raising), enabling graceful degradation.
 
-        All error paths in get_deploy_config should:
-        1. Return None (not raise an exception) - enables graceful degradation
-        2. Print an error message containing "Error fetching deploy config" - enables debugging
-
-        This fail-safe design ensures CI/CD pipelines can continue even when
-        deploy config is temporarily unavailable, while providing clear diagnostic
-        output for operators to investigate and resolve the underlying issue.
+        This fail-safe design lets CI/CD pipelines continue even when the deploy
+        config is temporarily unavailable.
         """
         mock_get = setup_mock()
         monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
@@ -893,6 +914,19 @@ env:
         result = get_deploy_config("fake-token", "owner/repo")
 
         assert result is None, f"Expected None for {error_name}, got {result}"
+
+    @_error_scenarios
+    def test_prints_error_on_error(self, error_name, setup_mock, monkeypatch, capsys):
+        """Every error path prints a message containing "Error fetching deploy config".
+
+        Clear diagnostic output lets operators investigate and resolve the
+        underlying issue.
+        """
+        mock_get = setup_mock()
+        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
+
+        get_deploy_config("fake-token", "owner/repo")
+
         captured = capsys.readouterr()
         assert "Error fetching deploy config" in captured.out, (
             f"Expected error message for {error_name}, got: {captured.out}"


### PR DESCRIPTION
## Summary

Test-quality refactor of `scripts/update_openhands_charts` driven by a Dave Farley test-design audit (starting Farley Score 8.8/10). All changes are behavior-preserving — no assertions were weakened or removed; the test count grew only from splitting multi-behavior tests.

The audit found no correctness or reliability issues (every network/file boundary is mocked, `tmp_path` throughout). The two addressable weaknesses were Granularity (tests asserting more than one behavior) and Maintainability (a fixture duplicated across three classes).

## Changes

**1. Split combined return-value + stdout tests into single-assertion tests**
Error-path tests in `TestGetRuntimeImageTagFromSandboxSpec` and `TestGetDeployConfig` asserted both the `None` return value and the printed diagnostic in one body. Each is now one test per observable behavior. The parametrized `get_deploy_config` error cases share an `_error_scenarios` decorator so the case list is not duplicated.

**2. Split file-content + `has_changes` assertions**
The image-loader and automation tag updaters each had a test asserting both the written file content and `result.has_changes`. These are now one test per behavior. The automation workflow integration test, which asserted values-file content, chart-version bump, and return value together, is split via a new `automation_paths` fixture mirroring the existing image-loader workflow class.

**3. Extract a shared `openhands_workflow_mocks` fixture**
The three `TestUpdateOpenhandsWorkflow*` classes each defined a near-identical `patched_inner_calls` fixture patching the same four inner functions, differing only in which mocks they returned as a positional tuple. They now share one `conftest.py` fixture that exposes every mock by name (`.values`, `.replicated`, `.replicated_config`, `.chart`), removing the positional-tuple coupling.

## Verification

Full suite before and after, run with `uv run --with pytest --with PyGithub --with ruamel.yaml --with requests python -m pytest test_update_openhands_charts.py`:

| | Result |
|---|---|
| Before | 252 passed |
| After | 274 passed |

The +22 cases come entirely from splitting multi-assertion tests. Net line change: 143 insertions, 112 deletions across the test file and conftest.

_This PR was drafted by an AI agent on behalf of the user._
