### PR TITLE
PLTF-2957: Bump enterprise-server image to version that has SDK 1.28.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.53
+version: 0.7.54
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: sha-d6f88b0
+  tag: sha-d511918
 
 ingress:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -140,7 +140,7 @@ gitlabWebhookInstallation:
 
 image:
   repository: ghcr.io/openhands/enterprise-server
-  tag: sha-d511918
+  tag: sha-f941ba5
 
 ingress:
   enabled: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-48cc27a'
+      tag: 'sha-d511918'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -17,7 +17,7 @@ spec:
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
-      tag: 'sha-d511918'
+      tag: 'sha-f941ba5'
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 


### PR DESCRIPTION
## What

Bump the `enterprise-server` image tag to a working version of openhands that has SDK 1.28.0 to address context issues from a LiteLLM upgrade

## Notes

Validated on a Replicated Embedded Cluster install (embedded Postgres): enterprise-server `sha-f941ba5` (SDK 1.28.0) deploys cleanly and an end-to-end smoke test (GitLab SSO → new conversation → agent response) passed.

_This PR was drafted by an AI agent on behalf of the user._
