### PR TITLE
ci: auto-open PRs bumping chart image tags on component releases

### DIFF
--- a/.github/workflows/bump-image-tag.yml
+++ b/.github/workflows/bump-image-tag.yml
@@ -229,11 +229,6 @@ jobs:
             Opened by the `bump-image-tag` reusable workflow after a release in the
             `${{ inputs.component }}` repository.
 
-            > [!NOTE]
-            > This PR updates **only** the image tag. It does not bump the chart
-            > `version` in `Chart.yaml`, so **Validate Chart Versions** will fail
-            > until the chart version is bumped as part of merging. This is by design.
-
       - name: Summary
         if: ${{ steps.cpr.outputs.pull-request-number != '' }}
         env:

--- a/.github/workflows/bump-image-tag.yml
+++ b/.github/workflows/bump-image-tag.yml
@@ -73,60 +73,6 @@ on:
         description: 'URL of the created/updated PR (empty if no change was needed).'
         value: ${{ jobs.bump.outputs.pull-request-url }}
 
-  # ===== TEMP: testing scaffold — remove before merge (see bottom of file) =====
-  # Lets the workflow be run manually from the Actions tab. These inputs mirror
-  # the workflow_call inputs above; the `inputs` context serves both triggers.
-  workflow_dispatch:
-    inputs:
-      component:
-        description: 'Component name (e.g. runtime-api).'
-        required: true
-        type: string
-      chart_file:
-        description: 'YAML file to edit (e.g. charts/runtime-api/values.yaml).'
-        required: true
-        type: string
-      tag:
-        description: 'New image tag to set (e.g. sha-61fc535).'
-        required: true
-        type: string
-      image_tag_path:
-        description: 'yq-style path to the image tag scalar.'
-        required: false
-        default: '.image.tag'
-        type: string
-      base_branch:
-        description: 'Branch to open the PR against.'
-        required: false
-        default: 'main'
-        type: string
-      chart_repo:
-        description: 'Chart repo to update, owner/name.'
-        required: false
-        default: 'OpenHands/OpenHands-Cloud'
-        type: string
-      pr_branch:
-        description: 'Head branch for the PR (blank = bump-image-tag/<component>).'
-        required: false
-        default: ''
-        type: string
-      pr_labels:
-        description: 'Comma- or newline-separated PR labels.'
-        required: false
-        default: 'automated,image-bump'
-        type: string
-      draft:
-        description: 'Open the PR as a draft.'
-        required: false
-        default: false
-        type: boolean
-  # Pushing this branch produces one run, which registers the workflow so the
-  # "Run workflow" (workflow_dispatch) button appears for it.
-  push:
-    branches:
-      - jl/bump-image-tag-workflow
-  # ===== END TEMP =====
-
 # One in-flight bump per component+repo, so two near-simultaneous releases can't
 # clobber each other's branch. Don't cancel: a running bump should finish.
 concurrency:
@@ -134,19 +80,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ===== TEMP: testing scaffold — remove before merge =====
-  # The registration push runs this no-op so the workflow gets a run and shows up
-  # in the Actions UI; the real `bump` job is skipped on push.
-  register:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Registered. Actions ▸ Bump chart image tag ▸ Run workflow (pick this branch) to test."
-  # ===== END TEMP =====
-
   bump:
-    # TEMP (remove before merge): skip the real bump on the registration push.
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # We act on the chart repo exclusively via the App token minted below, never

--- a/.github/workflows/bump-image-tag.yml
+++ b/.github/workflows/bump-image-tag.yml
@@ -1,0 +1,243 @@
+name: Bump chart image tag
+
+# Reusable workflow. A component repo (runtime-api, automation, ...) calls this
+# from its own release workflow to open a PR in the chart repo that points a
+# chart's image tag at the newly released image.
+#
+# It updates ONLY the tag scalar — it deliberately does not bump the chart
+# `version` in Chart.yaml or change anything else. (As a result the
+# "Validate Chart Versions" check will fail on the PR until a maintainer bumps
+# the chart version while merging; this is intentional.)
+#
+# See docs/automated-image-tag-bumps.md for caller setup and the auth model.
+
+on:
+  workflow_call:
+    inputs:
+      component:
+        description: 'Component name; used in the branch, PR title, and commit message (e.g. "runtime-api").'
+        required: true
+        type: string
+      chart_file:
+        description: 'YAML file to edit, relative to the chart repo root (e.g. charts/runtime-api/values.yaml).'
+        required: true
+        type: string
+      tag:
+        description: 'New image tag to set (e.g. sha-61fc535).'
+        required: true
+        type: string
+      image_tag_path:
+        description: 'yq-style path to the image tag scalar within chart_file.'
+        required: false
+        default: '.image.tag'
+        type: string
+      base_branch:
+        description: 'Branch to open the PR against.'
+        required: false
+        default: 'main'
+        type: string
+      chart_repo:
+        description: 'Chart repository to update, in owner/name form.'
+        required: false
+        default: 'OpenHands/OpenHands-Cloud'
+        type: string
+      pr_branch:
+        description: 'Head branch for the PR. The default rolls a single open PR per component, advancing it to the latest tag. Include the tag to get one PR per release.'
+        required: false
+        default: ''
+        type: string
+      pr_labels:
+        description: 'Comma- or newline-separated labels to add to the PR.'
+        required: false
+        default: |
+          automated
+          image-bump
+        type: string
+      draft:
+        description: 'Open the PR as a draft.'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      RELEASE_APP_ID:
+        description: 'App ID of the shared release GitHub App (the same one OpenHands/release-actions uses). The App must be installed on chart_repo with Contents + Pull requests read/write. Pass it via `secrets: inherit`.'
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: 'Private key (PEM) for that App. Pass it via `secrets: inherit`.'
+        required: true
+    outputs:
+      pull-request-number:
+        description: 'Number of the created/updated PR (empty if no change was needed).'
+        value: ${{ jobs.bump.outputs.pull-request-number }}
+      pull-request-url:
+        description: 'URL of the created/updated PR (empty if no change was needed).'
+        value: ${{ jobs.bump.outputs.pull-request-url }}
+
+  # ===== TEMP: testing scaffold — remove before merge (see bottom of file) =====
+  # Lets the workflow be run manually from the Actions tab. These inputs mirror
+  # the workflow_call inputs above; the `inputs` context serves both triggers.
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component name (e.g. runtime-api).'
+        required: true
+        type: string
+      chart_file:
+        description: 'YAML file to edit (e.g. charts/runtime-api/values.yaml).'
+        required: true
+        type: string
+      tag:
+        description: 'New image tag to set (e.g. sha-61fc535).'
+        required: true
+        type: string
+      image_tag_path:
+        description: 'yq-style path to the image tag scalar.'
+        required: false
+        default: '.image.tag'
+        type: string
+      base_branch:
+        description: 'Branch to open the PR against.'
+        required: false
+        default: 'main'
+        type: string
+      chart_repo:
+        description: 'Chart repo to update, owner/name.'
+        required: false
+        default: 'OpenHands/OpenHands-Cloud'
+        type: string
+      pr_branch:
+        description: 'Head branch for the PR (blank = bump-image-tag/<component>).'
+        required: false
+        default: ''
+        type: string
+      pr_labels:
+        description: 'Comma- or newline-separated PR labels.'
+        required: false
+        default: 'automated,image-bump'
+        type: string
+      draft:
+        description: 'Open the PR as a draft.'
+        required: false
+        default: false
+        type: boolean
+  # Pushing this branch produces one run, which registers the workflow so the
+  # "Run workflow" (workflow_dispatch) button appears for it.
+  push:
+    branches:
+      - jl/bump-image-tag-workflow
+  # ===== END TEMP =====
+
+# One in-flight bump per component+repo, so two near-simultaneous releases can't
+# clobber each other's branch. Don't cancel: a running bump should finish.
+concurrency:
+  group: bump-image-tag-${{ inputs.chart_repo }}-${{ inputs.component }}
+  cancel-in-progress: false
+
+jobs:
+  # ===== TEMP: testing scaffold — remove before merge =====
+  # The registration push runs this no-op so the workflow gets a run and shows up
+  # in the Actions UI; the real `bump` job is skipped on push.
+  register:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Registered. Actions ▸ Bump chart image tag ▸ Run workflow (pick this branch) to test."
+  # ===== END TEMP =====
+
+  bump:
+    # TEMP (remove before merge): skip the real bump on the registration push.
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # We act on the chart repo exclusively via the App token minted below, never
+    # via the caller's GITHUB_TOKEN, so it needs no permissions.
+    permissions: {}
+    outputs:
+      pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      pull-request-url: ${{ steps.cpr.outputs.pull-request-url }}
+
+    steps:
+      - name: Parse chart repo
+        id: repo
+        env:
+          CHART_REPO: ${{ inputs.chart_repo }}
+        run: |
+          echo "owner=${CHART_REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${CHART_REPO#*/}" >> "$GITHUB_OUTPUT"
+
+      # Mint a short-lived token for the shared release App, the same App
+      # OpenHands/release-actions uses. Unlike that repo (which operates on the
+      # repo it runs in), we run in the COMPONENT repo but write to the chart
+      # repo, so we scope the token to chart_repo via owner/repositories. This
+      # requires the App to be installed on chart_repo. There is deliberately no
+      # GITHUB_TOKEN fallback: a PR opened by GITHUB_TOKEN would not trigger the
+      # chart repo's required checks.
+      - name: Mint GitHub App token (scoped to the chart repo)
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ steps.repo.outputs.owner }}
+          repositories: ${{ steps.repo.outputs.name }}
+
+      - name: Checkout chart repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.chart_repo }}
+          ref: ${{ inputs.base_branch }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Bump image tag
+        env:
+          CHART_FILE: ${{ inputs.chart_file }}
+          IMAGE_TAG_PATH: ${{ inputs.image_tag_path }}
+          NEW_TAG: ${{ inputs.tag }}
+        run: |
+          uv run scripts/bump_image_tag/bump_image_tag.py \
+            --file "$CHART_FILE" \
+            --path "$IMAGE_TAG_PATH" \
+            --tag "$NEW_TAG"
+
+      - name: Create or update pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # Commit only the file we edited — never anything else the runner touched.
+          add-paths: ${{ inputs.chart_file }}
+          base: ${{ inputs.base_branch }}
+          branch: ${{ inputs.pr_branch != '' && inputs.pr_branch || format('bump-image-tag/{0}', inputs.component) }}
+          delete-branch: true
+          commit-message: 'chore(${{ inputs.component }}): bump image tag to ${{ inputs.tag }}'
+          title: 'chore(${{ inputs.component }}): bump image tag to ${{ inputs.tag }}'
+          labels: ${{ inputs.pr_labels }}
+          draft: ${{ inputs.draft }}
+          body: |
+            Automated image tag bump for **${{ inputs.component }}**.
+
+            |        |                              |
+            | ------ | ---------------------------- |
+            | File   | `${{ inputs.chart_file }}`     |
+            | Path   | `${{ inputs.image_tag_path }}` |
+            | New tag | `${{ inputs.tag }}`           |
+
+            Opened by the `bump-image-tag` reusable workflow after a release in the
+            `${{ inputs.component }}` repository.
+
+            > [!NOTE]
+            > This PR updates **only** the image tag. It does not bump the chart
+            > `version` in `Chart.yaml`, so **Validate Chart Versions** will fail
+            > until the chart version is bumped as part of merging. This is by design.
+
+      - name: Summary
+        if: ${{ steps.cpr.outputs.pull-request-number != '' }}
+        env:
+          URL: ${{ steps.cpr.outputs.pull-request-url }}
+          OP: ${{ steps.cpr.outputs.pull-request-operation }}
+        run: |
+          echo "PR ${OP}: ${URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/automated-image-tag-bumps.md
+++ b/docs/automated-image-tag-bumps.md
@@ -21,7 +21,7 @@ bump the chart `version` in `Chart.yaml` and does nothing else.
 Because of that, the **Validate Chart Versions** check (`enforce_version_bump:
 true`) will **fail** on these PRs: a chart file changed without a version bump.
 This is intentional — a maintainer bumps the chart version while reviewing/merging
-the bump. The PR body states this so reviewers aren't surprised.
+the bump.
 
 The edit is path-aware and minimal by design. `runtime-api/values.yaml` has three
 `tag:` keys (`image.tag`, `kvm.image.tag`, `kvm.initImage.tag`); the script edits

--- a/docs/automated-image-tag-bumps.md
+++ b/docs/automated-image-tag-bumps.md
@@ -1,0 +1,146 @@
+# Automated chart image-tag bumps
+
+When a component (e.g. `runtime-api`, `automation`) cuts a release, it can open a
+PR in this repo that points the component's chart `image.tag` at the freshly
+built image — without anyone editing `values.yaml` by hand.
+
+This is implemented as a **reusable workflow** that component repos call from
+their own release workflow:
+
+- Workflow: [`.github/workflows/bump-image-tag.yml`](../.github/workflows/bump-image-tag.yml)
+- Edit script: [`scripts/bump_image_tag/bump_image_tag.py`](../scripts/bump_image_tag/bump_image_tag.py)
+
+The caller passes just three things: which **file** to edit, the **path** to the
+tag inside it, and the new **tag**.
+
+## What it changes (and what it deliberately doesn't)
+
+The PR changes **only the image tag scalar** — a single line. It does **not**
+bump the chart `version` in `Chart.yaml` and does nothing else.
+
+Because of that, the **Validate Chart Versions** check (`enforce_version_bump:
+true`) will **fail** on these PRs: a chart file changed without a version bump.
+This is intentional — a maintainer bumps the chart version while reviewing/merging
+the bump. The PR body states this so reviewers aren't surprised.
+
+The edit is path-aware and minimal by design. `runtime-api/values.yaml` has three
+`tag:` keys (`image.tag`, `kvm.image.tag`, `kvm.initImage.tag`); the script edits
+exactly the one you name and leaves quoting, comments, and blank lines untouched.
+(`yq -i` strips blank lines; a full `ruamel` re-dump rewrites unrelated scalars
+like `dryRun: False` → `false`; a blanket `sed` hits the wrong `tag:`. The script
+avoids all three.)
+
+## Authentication
+
+This reuses the **same GitHub App** as
+[`OpenHands/release-actions`](https://github.com/OpenHands/release-actions) — the
+org secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`**. The component
+repo already has these in scope for its release-please workflow, so the caller just
+forwards them with `secrets: inherit`.
+
+The workflow mints a short-lived installation token from the App. There is **no
+`GITHUB_TOKEN` fallback** (matching release-actions): a PR opened with the default
+token wouldn't trigger this repo's required checks.
+
+> **Prerequisite to confirm.** release-actions uses the App on the repo it runs in.
+> Here the workflow runs in the *component* repo but writes to *this* repo, so it
+> scopes the token to `OpenHands/OpenHands-Cloud` via `owner`/`repositories`. That
+> requires the **same App to be installed on `OpenHands/OpenHands-Cloud`** with
+> **Contents: Read and write** and **Pull requests: Read and write**. If it's
+> installed org-wide, you're set; otherwise add this repo to its installation.
+
+## Caller setup (in the component repo)
+
+A reusable-workflow caller job can't run steps, so if you need to compute the tag
+(e.g. a short-SHA tag like `sha-61fc535`), do it in a small upstream job and pass
+the result.
+
+```yaml
+# .github/workflows/release.yml (in the runtime-api repo, for example)
+name: Release
+on:
+  push:
+    branches: [main]      # or: release: { types: [published] }
+
+jobs:
+  # ... your existing build-and-push-image job ...
+
+  prepare-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.t.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      # Must match the tag you pushed the image with.
+      - id: t
+        run: echo "tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+  bump-chart:
+    needs: prepare-tag
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    # Forwards RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY to the reusable workflow.
+    secrets: inherit
+    with:
+      component: runtime-api
+      chart_file: charts/runtime-api/values.yaml
+      image_tag_path: .image.tag          # optional — this is the default
+      tag: ${{ needs.prepare-tag.outputs.tag }}
+```
+
+A ready-to-copy version is in
+[`docs/examples/component-release-bump.yml`](examples/component-release-bump.yml).
+
+### The `automation` component
+
+```yaml
+  bump-chart:
+    needs: prepare-tag
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    secrets: inherit
+    with:
+      component: automation
+      chart_file: charts/automation/values.yaml
+      tag: ${{ needs.prepare-tag.outputs.tag }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `component` | yes | — | Used in the branch, PR title, and commit message. |
+| `chart_file` | yes | — | YAML file to edit, relative to the chart repo root. |
+| `tag` | yes | — | New image tag to set. Must match the tag you pushed. |
+| `image_tag_path` | no | `.image.tag` | yq-style path to the tag scalar. Supports nested keys and list indices, e.g. `.warmRuntimes.configs[0].image`. |
+| `base_branch` | no | `main` | Branch to open the PR against. |
+| `chart_repo` | no | `OpenHands/OpenHands-Cloud` | Repo to update, `owner/name`. |
+| `pr_branch` | no | `bump-image-tag/<component>` | Head branch. The default rolls a single open PR per component, advancing it to the latest tag. Set something tag-specific (e.g. `bump-image-tag/runtime-api/${{ needs.prepare-tag.outputs.tag }}`) to get one PR per release. |
+| `pr_labels` | no | `automated`, `image-bump` | Labels to add to the PR. |
+| `draft` | no | `false` | Open the PR as a draft. |
+
+Secrets (both required, forwarded via `secrets: inherit`): `RELEASE_APP_ID` and
+`RELEASE_APP_PRIVATE_KEY` — the shared release GitHub App. See
+[Authentication](#authentication).
+
+Outputs: `pull-request-number`, `pull-request-url` (empty when the tag was already
+current and no PR was needed).
+
+## Behavior notes
+
+- **Idempotent:** if the tag already matches, the script makes no change and no PR
+  is opened.
+- **One rolling PR per component (default):** a second release before the first PR
+  merges updates the same PR to the newer tag. After a PR merges and its branch is
+  deleted, the next release opens a fresh PR.
+- **Concurrency:** runs are serialized per `component` + `chart_repo` so two
+  near-simultaneous releases can't clobber each other's branch.
+
+## Testing the edit script locally
+
+```bash
+# Dry run against a real chart file (prints old -> new, writes nothing):
+uv run scripts/bump_image_tag/bump_image_tag.py \
+  --file charts/runtime-api/values.yaml --path .image.tag --tag sha-1234567 --dry-run
+
+# Unit tests:
+uv run scripts/bump_image_tag/test_bump_image_tag.py
+```

--- a/docs/examples/component-release-bump.yml
+++ b/docs/examples/component-release-bump.yml
@@ -1,0 +1,47 @@
+# EXAMPLE — copy this into a COMPONENT repo (e.g. runtime-api, automation) at
+# .github/workflows/release.yml and adapt it. It is NOT a workflow for this repo
+# (files under docs/ are never executed by GitHub Actions).
+#
+# It calls the reusable bump-image-tag workflow in OpenHands/OpenHands-Cloud to
+# open a PR that points the component's chart image.tag at the just-released image.
+#
+# Auth: reuses the shared release GitHub App (RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY,
+# the same secrets OpenHands/release-actions uses), forwarded via `secrets: inherit`.
+# That App must be installed on OpenHands/OpenHands-Cloud with Contents + Pull
+# requests read/write. See docs/automated-image-tag-bumps.md.
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+  # or, if you release via GitHub Releases:
+  # release:
+  #   types: [published]
+
+jobs:
+  # Your existing job(s) that build and push the image go here. Whatever tag you
+  # push the image with is the tag you must pass to the bump workflow below.
+
+  prepare-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.t.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: t
+        # Match however your image is tagged. Examples:
+        #   short-SHA tag:   echo "tag=sha-$(git rev-parse --short HEAD)"
+        #   release tag:     echo "tag=${{ github.event.release.tag_name }}"
+        run: echo "tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+  bump-chart:
+    needs: prepare-tag
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    # Forwards RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY to the reusable workflow.
+    secrets: inherit
+    with:
+      component: runtime-api
+      chart_file: charts/runtime-api/values.yaml
+      image_tag_path: .image.tag          # optional — this is the default
+      tag: ${{ needs.prepare-tag.outputs.tag }}

--- a/scripts/bump_image_tag/bump_image_tag.py
+++ b/scripts/bump_image_tag/bump_image_tag.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["ruamel.yaml"]
+# ///
+"""Set a single scalar (an image tag) in a YAML file, changing only that line.
+
+This is the edit half of the ``bump-image-tag`` reusable workflow. Component
+repos (runtime-api, automation, ...) call the workflow when they cut a release;
+the workflow runs this script to point a chart's ``image.tag`` at the freshly
+built image, then opens a PR.
+
+Why not ``yq -i`` or a ruamel round-trip dump?
+
+  * ``yq -i`` (mikefarah v4) strips every blank line from values.yaml, producing
+    an enormous, unreviewable diff.
+  * A full ruamel ``load`` -> ``dump`` round-trip normalises unrelated scalars
+    (e.g. ``dryRun: False`` -> ``dryRun: false``), touching lines we never meant
+    to change.
+  * A blanket ``sed 's/tag: .*/.../'`` is path-blind: runtime-api/values.yaml has
+    three ``tag:`` keys (image, kvm.image, kvm.initImage) and only one should move.
+
+So we use ruamel purely to *locate* the target scalar (its line/column and current
+value), then splice exactly that one value in the raw text. Indentation, quoting
+style, trailing comments, blank lines, and every other byte are preserved, and the
+PR diff is a single line. After writing, we re-parse and assert the path now holds
+the new value, so a bad splice fails loudly instead of committing broken YAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+# A path segment is either a bare mapping key (foo) or a list index ([0]).
+_SEGMENT_RE = re.compile(r"\[(\d+)\]|([^.\[\]]+)")
+
+
+class BumpError(Exception):
+    """A user-facing failure: bad path, missing key, unsupported scalar, etc."""
+
+
+def parse_path(path: str) -> list[str | int]:
+    """Turn a yq-style path into a list of mapping keys and list indices.
+
+    Accepts a leading dot (yq style) or not: ".image.tag" and "image.tag" are
+    equivalent. List indices use bracket notation, e.g. "warmRuntimes.configs[0].image".
+    """
+    raw = path.strip()
+    if raw.startswith("."):
+        raw = raw[1:]
+    if not raw:
+        raise BumpError("Path is empty")
+
+    segments: list[str | int] = []
+    pos = 0
+    while pos < len(raw):
+        if raw[pos] == ".":
+            pos += 1
+            continue
+        match = _SEGMENT_RE.match(raw, pos)
+        if not match or match.start() != pos:
+            raise BumpError(f"Could not parse path near {raw[pos:]!r} in {path!r}")
+        index, key = match.groups()
+        segments.append(int(index) if index is not None else key)
+        pos = match.end()
+
+    if not segments:
+        raise BumpError(f"Path {path!r} resolved to no segments")
+    return segments
+
+
+def locate(data, segments: list[str | int]):
+    """Walk ``segments`` and return (parent_container, final_key, current_value)."""
+    parent = None
+    key: str | int | None = None
+    current = data
+    traversed: list[str | int] = []
+
+    for segment in segments:
+        parent = current
+        key = segment
+        try:
+            current = parent[segment]
+        except (KeyError, IndexError):
+            shown = _render_path(traversed)
+            raise BumpError(
+                f"Path not found: no {segment!r} under {shown or '<root>'}"
+            ) from None
+        except TypeError:
+            shown = _render_path(traversed)
+            raise BumpError(
+                f"Path not navigable: {shown or '<root>'} is a scalar, "
+                f"cannot descend into {segment!r}"
+            ) from None
+        traversed.append(segment)
+
+    return parent, key, current
+
+
+def _render_path(segments: list[str | int]) -> str:
+    out = ""
+    for segment in segments:
+        out += f"[{segment}]" if isinstance(segment, int) else f".{segment}"
+    return out
+
+
+def _value_position(parent, key: str | int) -> tuple[int, int]:
+    """Return the (line, column) where the value for ``key`` begins.
+
+    ruamel stores this in the container's ``.lc.data`` line-column map: mapping
+    entries as [key_line, key_col, value_line, value_col]; sequence items as
+    [item_line, item_col].
+    """
+    lc = getattr(parent, "lc", None)
+    if lc is None or getattr(lc, "data", None) is None or key not in lc.data:
+        raise BumpError(
+            "Could not determine source position for the target value "
+            "(the YAML structure may be more complex than this tool supports)"
+        )
+    info = lc.data[key]
+    if isinstance(key, int):
+        return info[0], info[1]
+    return info[2], info[3]
+
+
+def set_scalar(text: str, segments: list[str | int], new_value: str) -> tuple[str, str | None]:
+    """Return (new_text, old_value). ``old_value`` is None when already current.
+
+    Only the single line holding the target scalar is rewritten; every other byte
+    of ``text`` is preserved exactly.
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    data = yaml.load(text)
+    if data is None:
+        raise BumpError("File is empty or not a YAML document")
+
+    parent, key, current = locate(data, segments)
+
+    if isinstance(current, (dict, list)):
+        raise BumpError(
+            f"Target {_render_path(segments)} is a "
+            f"{'mapping' if isinstance(current, dict) else 'sequence'}, not a scalar"
+        )
+
+    old_value = "" if current is None else str(current)
+    if old_value == new_value:
+        return text, None
+
+    line_no, col = _value_position(parent, key)
+    lines = text.splitlines(keepends=True)
+    if line_no >= len(lines):
+        raise BumpError("Computed line number is out of range for the file")
+    line = lines[line_no]
+
+    # Figure out the exact span of the existing scalar on this line.
+    quote = line[col] if col < len(line) else ""
+    if quote in ('"', "'"):
+        old_token = f"{quote}{old_value}{quote}"
+        new_token = f"{quote}{new_value}{quote}"
+    elif quote in ("|", ">"):
+        raise BumpError("Target uses a block scalar (| or >), which is unsupported")
+    else:
+        old_token = old_value
+        new_token = new_value
+
+    if not line[col:].startswith(old_token):
+        raise BumpError(
+            "Internal consistency check failed: the value at the computed "
+            f"position is not {old_token!r} (line was: {line.rstrip(chr(10))!r})"
+        )
+
+    lines[line_no] = line[:col] + new_token + line[col + len(old_token):]
+    new_text = "".join(lines)
+
+    # Re-parse and confirm the path now holds exactly the new string. This catches
+    # a mis-splice, and also a tag that YAML would coerce to a non-string (e.g. a
+    # purely numeric tag written unquoted) instead of silently writing bad YAML.
+    verify = YAML()
+    verify.preserve_quotes = True
+    _, _, round_tripped = locate(verify.load(new_text), segments)
+    if not isinstance(round_tripped, str) or round_tripped != new_value:
+        raise BumpError(
+            f"Post-edit verification failed: path now holds {round_tripped!r} "
+            f"(type {type(round_tripped).__name__}), expected the string {new_value!r}. "
+            "If the tag is purely numeric it may need to be quoted in the values file."
+        )
+
+    return new_text, old_value
+
+
+def run(file: Path, path: str, tag: str, dry_run: bool) -> bool:
+    """Apply the edit. Returns True when a change was written (or would be)."""
+    if not file.is_file():
+        raise BumpError(f"File not found: {file}")
+
+    segments = parse_path(path)
+    original = file.read_text()
+    new_text, old_value = set_scalar(original, segments, tag)
+
+    pretty_path = _render_path(segments)
+    if old_value is None:
+        print(f"{file}:{pretty_path} already {tag!r}; nothing to do.")
+        return False
+
+    if dry_run:
+        print(f"[dry-run] {file}:{pretty_path} {old_value!r} -> {tag!r}")
+        return True
+
+    file.write_text(new_text)
+    print(f"Updated {file}:{pretty_path} {old_value!r} -> {tag!r}")
+    return True
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--file", required=True, type=Path,
+                        help="Path to the YAML file to edit (e.g. charts/runtime-api/values.yaml)")
+    parser.add_argument("--path", required=True,
+                        help="yq-style path to the scalar (e.g. .image.tag)")
+    parser.add_argument("--tag", required=True,
+                        help="New tag value to set")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would change without writing")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        run(args.file, args.path, args.tag, args.dry_run)
+    except BumpError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bump_image_tag/test_bump_image_tag.py
+++ b/scripts/bump_image_tag/test_bump_image_tag.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["ruamel.yaml", "pytest"]
+# ///
+"""Unit tests for bump_image_tag.py."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the script directly, mirroring the sibling update_openhands_charts tests.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import bump_image_tag
+from bump_image_tag import BumpError, parse_path, run, set_scalar
+
+# A fixture document that exercises the things that make naive editors fail:
+# blank lines, comments (standalone + trailing), several `tag:` keys at different
+# depths, quoted and unquoted scalars, and a list of mappings.
+SAMPLE = """\
+# top comment
+image:
+  repository: ghcr.io/openhands/runtime-api
+  tag: sha-old0000
+  pullPolicy: Always
+
+kvm:
+  image:
+    repository: ghcr.io/smarter-project/smarter-device-manager
+    tag: v1.20.11
+  initImage:
+    tag: "1.36"  # trailing comment stays
+
+flag: False
+
+warmRuntimes:
+  configs:
+    - name: default
+      image: "ghcr.io/openhands/agent-server:1.28.0-python"
+"""
+
+
+def _lines(text):
+    return text.splitlines()
+
+
+def test_parse_path_variants():
+    assert parse_path(".image.tag") == ["image", "tag"]
+    assert parse_path("image.tag") == ["image", "tag"]
+    assert parse_path(".warmRuntimes.configs[0].image") == ["warmRuntimes", "configs", 0, "image"]
+    assert parse_path("a[10][2].b") == ["a", 10, 2, "b"]
+
+
+@pytest.mark.parametrize("bad", ["", ".", "   "])
+def test_parse_path_rejects_empty(bad):
+    with pytest.raises(BumpError):
+        parse_path(bad)
+
+
+def test_changes_only_the_target_line():
+    new_text, old = set_scalar(SAMPLE, parse_path(".image.tag"), "sha-new1111")
+    assert old == "sha-old0000"
+
+    before, after = _lines(SAMPLE), _lines(new_text)
+    assert len(before) == len(after)
+    differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+    assert differing == [3]  # only `  tag: sha-old0000`
+    assert after[3] == "  tag: sha-new1111"
+
+
+def test_picks_correct_tag_among_many():
+    # The nested kvm tags and the warmRuntimes image must be untouched.
+    new_text, _ = set_scalar(SAMPLE, parse_path(".image.tag"), "sha-new1111")
+    assert "tag: v1.20.11" in new_text
+    assert 'tag: "1.36"  # trailing comment stays' in new_text
+    assert 'image: "ghcr.io/openhands/agent-server:1.28.0-python"' in new_text
+
+
+def test_preserves_blank_lines_and_comments():
+    new_text, _ = set_scalar(SAMPLE, parse_path(".image.tag"), "sha-new1111")
+    assert new_text.count("\n\n") == SAMPLE.count("\n\n")
+    assert "# top comment" in new_text
+    assert "# trailing comment stays" in new_text
+
+
+def test_does_not_normalize_unrelated_scalars():
+    # A full ruamel round-trip would rewrite `False` -> `false`; we must not.
+    new_text, _ = set_scalar(SAMPLE, parse_path(".image.tag"), "sha-new1111")
+    assert "flag: False" in new_text
+
+
+def test_preserves_double_quotes():
+    new_text, old = set_scalar(SAMPLE, parse_path(".kvm.initImage.tag"), "1.40")
+    assert old == "1.36"
+    assert 'tag: "1.40"  # trailing comment stays' in new_text
+
+
+def test_updates_nested_tag_keeps_siblings():
+    new_text, old = set_scalar(SAMPLE, parse_path(".kvm.image.tag"), "v2.0.0")
+    assert old == "v1.20.11"
+    assert "tag: v2.0.0" in new_text
+    assert "  tag: sha-old0000" in new_text  # top-level image.tag untouched
+
+
+def test_list_index_with_quotes():
+    new_text, old = set_scalar(
+        SAMPLE, parse_path(".warmRuntimes.configs[0].image"), "ghcr.io/x/y:9.9.9"
+    )
+    assert old == "ghcr.io/openhands/agent-server:1.28.0-python"
+    assert 'image: "ghcr.io/x/y:9.9.9"' in new_text
+
+
+def test_idempotent_returns_none_and_unchanged_text():
+    new_text, old = set_scalar(SAMPLE, parse_path(".image.tag"), "sha-old0000")
+    assert old is None
+    assert new_text == SAMPLE
+
+
+def test_missing_path_raises():
+    with pytest.raises(BumpError, match="Path not found"):
+        set_scalar(SAMPLE, parse_path(".image.nope"), "x")
+
+
+def test_descend_into_scalar_raises():
+    with pytest.raises(BumpError, match="not navigable"):
+        set_scalar(SAMPLE, parse_path(".image.tag.deeper"), "x")
+
+
+def test_target_is_mapping_raises():
+    with pytest.raises(BumpError, match="not a scalar"):
+        set_scalar(SAMPLE, parse_path(".image"), "x")
+
+
+def test_numeric_tag_that_would_coerce_raises():
+    # Original is unquoted; writing a bare number would change the YAML type.
+    # The post-edit verification must catch it rather than write bad YAML.
+    with pytest.raises(BumpError, match="verification failed|numeric"):
+        set_scalar(SAMPLE, parse_path(".image.tag"), "123")
+
+
+def test_run_writes_file_and_is_idempotent(tmp_path):
+    f = tmp_path / "values.yaml"
+    f.write_text(SAMPLE)
+
+    assert run(f, ".image.tag", "sha-new1111", dry_run=False) is True
+    assert "tag: sha-new1111" in f.read_text()
+
+    # Second run with the same value is a no-op.
+    assert run(f, ".image.tag", "sha-new1111", dry_run=False) is False
+
+
+def test_run_dry_run_does_not_write(tmp_path):
+    f = tmp_path / "values.yaml"
+    f.write_text(SAMPLE)
+    assert run(f, ".image.tag", "sha-new1111", dry_run=True) is True
+    assert f.read_text() == SAMPLE
+
+
+def test_run_missing_file_raises(tmp_path):
+    with pytest.raises(BumpError, match="File not found"):
+        run(tmp_path / "nope.yaml", ".image.tag", "x", dry_run=False)
+
+
+def test_main_returns_nonzero_on_error(tmp_path, capsys):
+    f = tmp_path / "values.yaml"
+    f.write_text(SAMPLE)
+    rc = bump_image_tag.main(["--file", str(f), "--path", ".image.nope", "--tag", "x"])
+    assert rc == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Components like runtime-api and automation each cut their own releases, but bumping the image tag they ship in this chart has been a manual edit. This adds a reusable workflow they can call from their release pipeline to open that PR automatically.

It updates only the `image.tag` scalar, so the bump is a one-line diff with no `Chart.yaml` version change. Auth reuses the shared release github app (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) via `secrets: inherit`, the same setup as release-actions.

## Helm Chart Checklist

N/A - this PR doesn't modify any charts (it's a CI workflow, a helper script, and docs).

## Additional Notes

The bump PRs this opens only touch the tag, so Validate Chart Versions fails on them by design until the chart version is bumped at merge.

The Validate Chart Versions action is going to be removed when we start using `release-please` inside of this repository, so I am not bumping the chart versions through this action. With `release-please`, we will not bump the version with every commit.