### PR TITLE
chore: bump openhands and agent-canvas charts

### DIFF
--- a/charts/agent-canvas/Chart.yaml
+++ b/charts/agent-canvas/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-canvas
 description: Frontend-only deployment of OpenHands Agent Canvas (UI shell pointing at user-managed backends)
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.54
+version: 0.7.55
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -57,5 +57,5 @@ dependencies:
     condition: integrations-hub.enabled
   - name: agent-canvas
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.0
+    version: 0.1.1
     condition: agent-canvas.enabled


### PR DESCRIPTION
## Summary
- Bump `charts/openhands` chart version from `0.7.54` to `0.7.55`.
- Bump `charts/agent-canvas` chart version from `0.1.0` to `0.1.1`.
- Update the `openhands` chart dependency on `agent-canvas` to `0.1.1` so preview/main publishing can publish the dependency before packaging the umbrella chart.
- Follow-up to unblock main CI after #684 changed the `openhands` chart and introduced the new `agent-canvas` dependency, but the main publish run failed before publishing `agent-canvas:0.1.0`.

## Testing
- GitHub Actions rerun pending after branch update.

_This PR was updated by an AI agent (OpenHands) on behalf of the user._