### PR TITLE
feat(openhands): add userProvisioning.enabled feature switch

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.59
+version: 0.7.60
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -341,6 +341,11 @@
   value: "1"
 {{- end }}
 
+{{- if .Values.userProvisioning.enabled }}
+- name: USER_PROVISIONING_ENABLED
+  value: "true"
+{{- end }}
+
 {{- $dbSslMode := "prefer" }}
 {{- if not .Values.postgresql.enabled }}
 {{- $dbSslMode = .Values.externalDatabase.sslMode | default "prefer" }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -36,6 +36,14 @@ datadog:
 debuggingRoutes:
   enabled: false
 
+# Admin POST /api/organizations/provision-user endpoint. When enabled,
+# the enterprise app server registers the user-provisioning router and
+# sets USER_PROVISIONING_ENABLED=true. Off by default in staging and
+# production; flipped to true via env-specific values overrides (see
+# the deploy repo's openhands/envs/<env>/values.yaml).
+userProvisioning:
+  enabled: false
+
 databaseMigrations:
   waitForDatabase: true
   createDatabases: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -38,9 +38,9 @@ debuggingRoutes:
 
 # Admin POST /api/organizations/provision-user endpoint. When enabled,
 # the enterprise app server registers the user-provisioning router and
-# sets USER_PROVISIONING_ENABLED=true. Off by default in staging and
-# production; flipped to true via env-specific values overrides (see
-# the deploy repo's openhands/envs/<env>/values.yaml).
+# sets USER_PROVISIONING_ENABLED=true. This endpoint should only be
+# enabled for OHE deployments when the customer needs to create users
+# without any user input.
 userProvisioning:
   enabled: false
 


### PR DESCRIPTION
## Why

Adds a Helm-driven feature switch for the new admin `POST /api/organizations/provision-user` endpoint introduced in OpenHands/OpenHands#14864. The endpoint is privileged (creates Keycloak users, mints API keys, bypasses the email-verification / TOS interstitials) so we want it gated per-environment rather than always-on.

## What

- **`charts/openhands/values.yaml`** — new `userProvisioning.enabled` value, defaulting to `false`. Staging and production inherit the off state unless an env-specific override flips it on.
- **`charts/openhands/templates/_env.yaml`** — when `userProvisioning.enabled` is true, project `USER_PROVISIONING_ENABLED=true` into the deployment env. The enterprise app server reads this var (accepting both `'true'` and `'1'` per AGENTS.md) to decide whether to register the user-provisioning router. Sits right next to the existing `ADD_DEBUGGING_ROUTES` gate for symmetry.

When the flag is off, the route is not registered on the FastAPI app at all — clients calling it get a clean 404.

## Companion PRs

- Backend gate that consumes the switch: OpenHands/OpenHands#14864
- Deploy override that flips it true for per-branch feature deployments: OpenHands/deploy PR `feature/user-provisioning-switch`

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('charts/openhands/values.yaml'))"` — values.yaml parses cleanly.
- The `_env.yaml` change is structurally identical to the existing `.Values.debuggingRoutes.enabled` block immediately above it.
- Backend unit tests covering the `'true'`/`'1'`/unset cases of the env var are in the companion OpenHands PR (`tests/unit/server/test_constants.py::TestUserProvisioningEnabled`).

---

_This PR was opened by an AI agent (OpenHands) on behalf of @chuckbutkus._


@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7ff2d6b2-4f58-4a0e-a220-2f1f16402970)