### PR TITLE
Make Keycloak SSO session lifetime config options optional

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1132,7 +1132,7 @@ spec:
             How long a login session stays valid without activity before the user must sign in again. Default is 1800 (30 minutes).
           type: text
           default: "1800"
-          required: true
+          required: false
           validation:
             regex:
               pattern: '^[1-9][0-9]*$'
@@ -1143,7 +1143,7 @@ spec:
             Maximum total lifetime of a login session before the user must sign in again, regardless of activity. Default is 36000 (10 hours). Each forced re-login also re-authorizes the configured identity provider (for example, Bitbucket Data Center records a new authorized-application grant), so raising this reduces how often that happens.
           type: text
           default: "36000"
-          required: true
+          required: false
           validation:
             regex:
               pattern: '^[1-9][0-9]*$'


### PR DESCRIPTION
## What

Flip `required: true` → `required: false` on the two Keycloak SSO session-lifetime KOTS config options added in #694:

- `keycloak_sso_session_idle_timeout` (Login Session Idle Timeout, default `1800`s / 30 min)
- `keycloak_sso_session_max_lifespan` (Login Session Max Duration, default `36000`s / 10 hrs)

## Why

In KOTS, `required: true` is **not** satisfied by a `default:` — it hard-blocks every fresh install and every upgrade until the admin manually re-types a value in the Admin Console. Since these two fields ship with sensible defaults, forcing input adds a confusing mandatory prompt for new customers (and an extra step on every existing customer's next upgrade).

Making them optional lets the defaults apply silently while keeping them fully overridable. Matches how the sibling text options in this config (e.g. `custom_llm_extra_headers`) are already declared.

No behavior change for anyone who does set a value; the helm mapping (`ssoSessionIdleTimeout` / `ssoSessionMaxLifespan`) is unchanged.