### PR TITLE
Require Bitbucket DC bot token + username when BBDC auth enabled

### DIFF
--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -116,12 +116,17 @@ Use patterns that make it easy for chart consumers to override defaults. Environ
 - Dependencies should be conditional where possible
 - Version constraints should be explicit
 
+### Integration Credential Enforcement (KOTS layer, not Helm `required`)
+
+Required credentials/identities for integrations (Jira DC, Bitbucket DC, Azure DevOps, etc.) — service-account emails/PATs, bot tokens, bot usernames — are enforced in `replicated/config.yaml` with `required: true` + `when: "<integration>_enabled"`. That is the install path every customer uses. By established convention the chart itself does **not** use Helm's `required` to fail-fast these: secrets are wired as `secretKeyRef … optional: true` and non-secret values default to empty. This is consistent across all integrations (e.g. Jira DC's `service-account-email` / `service-account-pat`). A chart that enables a new integration this way — empty/optional in `_env.yaml`, `required` in `replicated/config.yaml` — is following the pattern, not introducing a gap. Tightening the bare-`helm install` path to fail-fast is a worthwhile but deliberate, chart-wide change tracked in its own PR; it is out of scope for an integration-wiring PR.
+
 ## What NOT to Comment On
 
 - Minor style preferences that don't affect functionality
 - Praise for code that follows best practices (just approve)
 - Obvious or self-explanatory configuration
 - Third-party env var naming (these follow external conventions)
+- Integration credentials rendered empty/`optional` in `_env.yaml` when `replicated/config.yaml` already marks them `required` (KOTS-layer enforcement is the convention — see Integration Credential Enforcement)
 
 ## Communication Style
 

--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -116,17 +116,12 @@ Use patterns that make it easy for chart consumers to override defaults. Environ
 - Dependencies should be conditional where possible
 - Version constraints should be explicit
 
-### Integration Credential Enforcement (KOTS layer, not Helm `required`)
-
-Required credentials/identities for integrations (Jira DC, Bitbucket DC, Azure DevOps, etc.) — service-account emails/PATs, bot tokens, bot usernames — are enforced in `replicated/config.yaml` with `required: true` + `when: "<integration>_enabled"`. That is the install path every customer uses. By established convention the chart itself does **not** use Helm's `required` to fail-fast these: secrets are wired as `secretKeyRef … optional: true` and non-secret values default to empty. This is consistent across all integrations (e.g. Jira DC's `service-account-email` / `service-account-pat`). A chart that enables a new integration this way — empty/optional in `_env.yaml`, `required` in `replicated/config.yaml` — is following the pattern, not introducing a gap. Tightening the bare-`helm install` path to fail-fast is a worthwhile but deliberate, chart-wide change tracked in its own PR; it is out of scope for an integration-wiring PR.
-
 ## What NOT to Comment On
 
 - Minor style preferences that don't affect functionality
 - Praise for code that follows best practices (just approve)
 - Obvious or self-explanatory configuration
 - Third-party env var naming (these follow external conventions)
-- Integration credentials rendered empty/`optional` in `_env.yaml` when `replicated/config.yaml` already marks them `required` (KOTS-layer enforcement is the convention — see Integration Credential Enforcement)
 
 ## Communication Style
 

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.61
+version: 0.7.62
 maintainers:
   - name: rbren
   - name: xingyao

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -200,6 +200,8 @@
 {{- if .Values.bitbucketDataCenter.enabled }}
 - name: BITBUCKET_DATA_CENTER_HOST
   value: {{ .Values.bitbucketDataCenter.host }}
+- name: BITBUCKET_DATA_CENTER_BOT_USERNAME
+  value: {{ .Values.bitbucketDataCenter.botUsername | quote }}
 - name: BITBUCKET_DATA_CENTER_CLIENT_ID
   valueFrom:
     secretKeyRef:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -123,6 +123,7 @@ secretsChecksum: ""
 bitbucketDataCenter:
   enabled: false
   host: ""
+  botUsername: ""
 
 azureDevOps:
   enabled: false

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -559,8 +559,7 @@ spec:
             access to the target repos. OpenHands posts comments and reactions
             as this bot -- not as the mentioning user -- so its own replies
             don't re-trigger jobs; the agent still runs on the invoking user's
-            workspace. Use a dedicated account, since OpenHands ignores comments
-            authored by this bot.
+            workspace.
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -553,14 +553,24 @@ spec:
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true
         - name: bitbucket_data_center_bot_token
-          title: Bitbucket Data Center Bot Token (strongly recommended)
+          title: Bitbucket Data Center Bot Token (required)
           help_text: >-
-            HTTP access token for a dedicated bot user with repo access. When
-            set, OpenHands posts comments and reactions as the bot instead of
-            as the mentioning user or installer; jobs still run on the invoking
-            user's workspace.
+            HTTP access token (Repository write) for a dedicated bot user with
+            access to the target repos. OpenHands posts comments and reactions
+            as this bot -- not as the mentioning user -- which is required so the
+            bot's own replies don't re-trigger jobs. The agent still runs on the
+            invoking user's workspace. Do not sign in to OpenHands as this user.
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
+          required: true
+        - name: bitbucket_data_center_bot_username
+          title: Bitbucket Data Center Bot Username
+          help_text: >-
+            Username (slug) of the bot account above, e.g. openhands. Used to
+            ignore the bot's own comments so its replies don't re-trigger jobs.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
+          required: true
 
     - name: azure_devops_authentication
       title: Azure DevOps Authentication

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -553,13 +553,14 @@ spec:
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true
         - name: bitbucket_data_center_bot_token
-          title: Bitbucket Data Center Bot Token (required)
+          title: Bitbucket Data Center Bot Token
           help_text: >-
             HTTP access token (Repository write) for a dedicated bot user with
             access to the target repos. OpenHands posts comments and reactions
-            as this bot -- not as the mentioning user -- which is required so the
-            bot's own replies don't re-trigger jobs. The agent still runs on the
-            invoking user's workspace. Do not sign in to OpenHands as this user.
+            as this bot -- not as the mentioning user -- so its own replies
+            don't re-trigger jobs; the agent still runs on the invoking user's
+            workspace. Use a dedicated account, since OpenHands ignores comments
+            authored by this bot.
           type: password
           when: 'repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}'
           required: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -403,6 +403,7 @@ spec:
     bitbucketDataCenter:
       enabled: repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}
       host: 'repl{{ ConfigOption "bitbucket_data_center_domain" }}'
+      botUsername: 'repl{{ ConfigOption "bitbucket_data_center_bot_username" }}'
     azureDevOps:
       enabled: repl{{ ConfigOptionEquals "azure_devops_auth_enabled" "1" }}
       tenantId: 'repl{{ ConfigOption "azure_devops_tenant_id" }}'


### PR DESCRIPTION
## What

When Bitbucket Data Center authentication is enabled, **require** the bot account:
- `bitbucket_data_center_bot_token` → now `required: true` (was "strongly recommended").
- New `bitbucket_data_center_bot_username` (the bot account's username/slug) → `required: true`, wired to the `BITBUCKET_DATA_CENTER_BOT_USERNAME` env (`_env.yaml` / `openhands.yaml` / `values.yaml`).
- `openhands` chart `0.7.61` → `0.7.62`.

## Why

OpenHands must post BBDC comments/reactions **as the bot**, never as the mentioning user — a user-authored reply containing `@openhands` re-triggers the webhook and spawns a duplicate conversation (confirmed from a customer support bundle). The app-side fix (OpenHands enterprise) posts as the bot and ignores the bot's own comments using the configured **username (slug)** — BBDC payloads carry the slug, not a reliable email. Making both required ensures the integration is always in the correct, non-duplicating configuration. Pairs with the OpenHands enterprise PR (BBDC → Jira DC parity).
