### PR TITLE
Unify support-bundle log window to 336h (14d)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.62
+version: 0.7.63
 maintainers:
   - name: rbren
   - name: xingyao
@@ -38,7 +38,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.10
+    version: 0.3.11
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -28,6 +28,8 @@ spec:
         name: keycloak-realm
         namespace: {{ .Release.Namespace }}
         includeValue: false
+    # Log volume is bounded by kubelet rotation (~tens of MB/pod), not maxAge,
+    # so 336h is free on chatty pods and only adds history on quiet ones.
     # OpenHands main application logs
     - logs:
         name: app/openhands/logs
@@ -35,7 +37,7 @@ spec:
         selector:
           - app=openhands
         limits:
-          maxAge: 720h
+          maxAge: 336h
     # OpenHands integrations deployment logs
     - logs:
         name: app/openhands-integrations/logs
@@ -43,7 +45,7 @@ spec:
         selector:
           - app=openhands-integrations
         limits:
-          maxAge: 720h
+          maxAge: 336h
     # OpenHands MCP deployment logs
     - logs:
         name: app/openhands-mcp/logs
@@ -51,7 +53,7 @@ spec:
         selector:
           - app=openhands-mcp
         limits:
-          maxAge: 720h
+          maxAge: 336h
     {{- if .Values.postgresql.enabled }}
     # PostgreSQL logs (Bitnami chart)
     - logs:
@@ -61,10 +63,10 @@ spec:
           - app.kubernetes.io/name=postgresql
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 168h
+          maxAge: 336h
     {{- end }}
     {{- if .Values.redis.enabled }}
-    # Redis logs (Bitnami chart). 720h to match app pods: session bugs are slow-burn.
+    # Redis logs (Bitnami chart)
     - logs:
         name: app/{{ .Release.Name }}-redis/logs
         namespace: {{ .Release.Namespace }}
@@ -72,10 +74,10 @@ spec:
           - app.kubernetes.io/name=redis
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 720h
+          maxAge: 336h
     {{- end }}
     {{- if .Values.keycloak.enabled }}
-    # Keycloak logs (Bitnami chart). 720h to match app pods: auth/session bugs are slow-burn.
+    # Keycloak logs (Bitnami chart)
     - logs:
         name: app/{{ .Release.Name }}-keycloak/logs
         namespace: {{ .Release.Namespace }}
@@ -83,7 +85,7 @@ spec:
           - app.kubernetes.io/name=keycloak
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 720h
+          maxAge: 336h
     {{- end }}
     {{- if .Values.filestore.ephemeral }}
     # MinIO logs (MinIO chart)
@@ -94,7 +96,7 @@ spec:
           - app=minio
           - release={{ .Release.Name }}
         limits:
-          maxAge: 168h
+          maxAge: 336h
     {{- end }}
     {{- if index .Values "runtime-api" "enabled" }}
     # Runtime API logs
@@ -105,7 +107,7 @@ spec:
           - app.kubernetes.io/name=runtime-api
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 168h
+          maxAge: 336h
     # Runtime sandbox pod logs. Pod names are dynamic (runtime-*) and the
     # logs collector has no glob-name support, so select by the runtime_id
     # label — a bare key matches "label exists with any value". Pod/event
@@ -115,7 +117,7 @@ spec:
         selector:
           - runtime_id
         limits:
-          maxAge: 168h
+          maxAge: 336h
         timestamps: true
     # Read-only runtimes dump via the runtime-api pod's own DB creds (pg8000,
     # runtime_api_db). Surfaces custom sandbox images + status; never selects
@@ -185,7 +187,7 @@ spec:
           - app.kubernetes.io/name=litellm
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 168h
+          maxAge: 336h
     # Live LiteLLM proxy model list (/model/info): config-rendered models
     # plus any models added at runtime via the LiteLLM dashboard
     # (store_model_in_db). Authenticates with the proxy's own
@@ -348,7 +350,7 @@ spec:
         selector:
           - app=automation
         limits:
-          maxAge: 720h
+          maxAge: 336h
     # Automation events-service (webhook receiver) logs
     - logs:
         name: app/automation-events/logs
@@ -356,7 +358,7 @@ spec:
         selector:
           - app=automation-events
         limits:
-          maxAge: 720h
+          maxAge: 336h
     # Read-only automation DB dump via the automation pod's own creds (asyncpg).
     # Webhook/automation/run metadata only — never webhook_secret, prompts,
     # tarball paths, event payloads or error detail.
@@ -426,7 +428,7 @@ spec:
           - app.kubernetes.io/name=ingress-nginx
         namespace: ingress-nginx
         limits:
-          maxAge: 168h
+          maxAge: 336h
     {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
     - postgresql:
         collectorName: postgresql

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.10 # Change this to trigger a new helm chart version being published
+version: 0.3.11 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
+++ b/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Release.Name }}-support-bundle
 spec:
   collectors: {{- include "runtime.troubleshoot.collectors.shared" .  | nindent 4 }}
+    # Log volume is bounded by kubelet rotation (~tens of MB/pod), not maxAge,
+    # so 336h is free on chatty pods and only adds history on quiet ones.
     # Runtime API application logs
     - logs:
         name: app/{{ include "runtime-api.fullname" . }}/logs
@@ -13,7 +15,7 @@ spec:
           - app.kubernetes.io/name={{ include "runtime-api.name" . }}
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 720h
+          maxAge: 336h
     {{- if .Values.postgresql.enabled }}
     # PostgreSQL logs (Bitnami chart)
     - logs:
@@ -23,7 +25,7 @@ spec:
           - app.kubernetes.io/name=postgresql
           - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
-          maxAge: 168h
+          maxAge: 336h
     - postgresql:
         collectorName: postgresql
         uri: postgresql://postgres:@{{ include "runtime-api.postgresql.host" . }}:5432/{{ .Values.postgresql.auth.database | default "runtime_api" }}?sslmode=disable


### PR DESCRIPTION
## What

Makes the `maxAge` log-collection window uniform at **336h (14d)** across every `logs` collector in both support-bundle specs (`charts/openhands` and `charts/runtime-api`), replacing the previous mix of 168h/720h. Collapses the scattered per-collector rationale into one short comment.

Before, the openhands spec was a split:
- 720h: openhands, integrations, mcp, redis, keycloak, automation, automation-events
- 168h: postgresql, minio, runtime-api, runtime-sandboxes, litellm, ingress-nginx

## Why

The split was based on an incorrect mental model of `maxAge`, and was self-inconsistent:

1. **`maxAge` is an upper-bound filter, not a retention extender.** The troubleshoot `logs` collector only reads the Kubernetes log API, which serves on-disk container logs. The real cap on collected bytes is **kubelet log rotation** (`containerLogMaxSize` × `containerLogMaxFiles`, ~tens of MB/container by default). The window only changes how much of that buffer is returned — a busy pod churns its buffer in well under 14d, so it returns the same bytes regardless of window; a longer window only adds history on **quiet** pods (where sparse old logs survive on disk), which is exactly where slow-burn auth/session/integration bugs live.

2. **`maxAge` does not bound bundle size** — rotation does — so the old 168h on infra pods wasn't buying smaller bundles, just discarding potentially-useful old lines on the quiet ones.

3. **The split contradicted its own rationale.** redis was bumped to 720h "because session bugs are slow-burn," but **postgres — which actually holds that state — stayed at 168h.** Same bug class, shorter window on the more relevant pod.

A single 14-day window removes the "why is this 168 and that 720?" question and matches a two-week triage horizon.

## Does this bloat support bundles? (measured)

Checked on a live install (R02) rather than reasoning from theory:
- kubelet uses **defaults** → ~50MB/container on-disk ceiling, independent of the window.
- Measured collected bytes for the affected pods at **168h vs 720h were identical** (runtime-api 9,109 == 9,109; openhands app 1,805 == 1,805) — the window change added **0 bytes**, because busy pods churn their rotation buffer faster than the window and young/idle pods have no older logs to add.
- Of the pods this PR moves off 168h, only runtime-api exists as a non-trivial pod on embedded-cluster (postgres is external, ingress-nginx doesn't exist — EC uses traefik, litellm/minio are <1MB). The chatty heavy-hitters were already on the longer window.

So bundle size is bounded by rotation, not the window, on idle and busy installs alike.

## Deliberately not done

No explicit `limitBytes` size guard: rotation already bounds per-stream size, and its truncation direction (it keeps the *oldest* bytes in the window) would cut the most-recent logs — wrong for a support artifact. Out of scope; can revisit if we ever want a hard, rotation-independent ceiling.

## Validation

- Rendered both specs with `helm template` (openhands troubleshoot templates embedded in the production-style `Secret` block scalar; runtime-api full chart).
- Embedded `SupportBundle` YAML parses cleanly; **13 log collectors, single distinct `maxAge: 336h`, zero `168h`/`720h` remaining.**