### PR TITLE
Wire OpenAI/DeepSeek/Mistral/Groq/OpenRouter/Gemini as managed LiteLLM providers

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -161,6 +161,13 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "openai" }}'
           required: true
+        - name: openai_models
+          title: OpenAI Models
+          help_text: OpenAI model IDs served through the bundled LiteLLM proxy, one per line (e.g., gpt-5).
+          type: textarea
+          value: "gpt-5\ngpt-4.1"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "openai" }}'
+          required: true
         - name: google_api_type
           title: Google API Type
           help_text: Choose between Google AI Studio (Gemini API) or Google Cloud Platform (Vertex AI)
@@ -176,6 +183,13 @@ spec:
           title: Google Gemini API Key
           help_text: Your Google AI Studio API key for Gemini models
           type: password
+          when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
+          required: true
+        - name: gemini_models
+          title: Gemini Models
+          help_text: Google AI Studio (Gemini) model IDs served through the bundled LiteLLM proxy, one per line (e.g., gemini-2.5-pro).
+          type: textarea
+          value: "gemini-2.5-pro\ngemini-2.5-flash"
           when: 'repl{{ and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
           required: true
         - name: google_vertex_project_id
@@ -210,10 +224,24 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "deepseek" }}'
           required: true
+        - name: deepseek_models
+          title: DeepSeek Models
+          help_text: DeepSeek model IDs served through the bundled LiteLLM proxy, one per line (e.g., deepseek-chat).
+          type: textarea
+          value: "deepseek-chat\ndeepseek-reasoner"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "deepseek" }}'
+          required: true
         - name: mistral_api_key
           title: Mistral API Key
           help_text: Your Mistral AI API key
           type: password
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "mistral" }}'
+          required: true
+        - name: mistral_models
+          title: Mistral Models
+          help_text: Mistral AI model IDs served through the bundled LiteLLM proxy, one per line (e.g., mistral-large-latest).
+          type: textarea
+          value: "mistral-large-latest\ncodestral-latest"
           when: 'repl{{ ConfigOptionEquals "llm_provider" "mistral" }}'
           required: true
         - name: azure_auth_method
@@ -286,10 +314,24 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "llm_provider" "groq" }}'
           required: true
+        - name: groq_models
+          title: Groq Models
+          help_text: Groq model IDs served through the bundled LiteLLM proxy, one per line (e.g., llama-3.3-70b-versatile).
+          type: textarea
+          value: "llama-3.3-70b-versatile"
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "groq" }}'
+          required: true
         - name: openrouter_api_key
           title: OpenRouter API Key
           help_text: Your OpenRouter API key
           type: password
+          when: 'repl{{ ConfigOptionEquals "llm_provider" "openrouter" }}'
+          required: true
+        - name: openrouter_models
+          title: OpenRouter Models
+          help_text: OpenRouter model IDs served through the bundled LiteLLM proxy, one per line, as provider/model (e.g., anthropic/claude-sonnet-4.5).
+          type: textarea
+          value: "anthropic/claude-sonnet-4.5"
           when: 'repl{{ ConfigOptionEquals "llm_provider" "openrouter" }}'
           required: true
         - name: aws_auth_method

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -881,6 +881,71 @@ spec:
             # region-only litellm_params (credentials come from the instance
             # profile).
             model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "bedrock_model_ids" | replace "\r" "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "bedrock/%s" $m) "aws_region_name" "os.environ/AWS_REGION_NAME")) }}repl{{ end }}repl{{ end }}repl{{ if and $models (not (hasKey $seen "bedrock")) }}repl{{ $models = append $models (dict "model_name" "bedrock" "litellm_params" (index (index $models 0) "litellm_params") "model_info" (dict "openhands_hidden" true "openhands_canonical" (index (index $models 0) "model_name"))) }}repl{{ end }}repl{{ $models | mustToJson }}
+    # OpenAI — one <id> -> openai/<id> entry per non-empty line of the "OpenAI
+    # Models" textarea (comma- or newline-separated, trimmed, deduped). Key-only
+    # provider routed entirely through the proxy, mirroring the anthropic base.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "openai" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "openai_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "openai_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "openai/%s" $m) "api_key" "os.environ/OPENAI_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    # DeepSeek — one <id> -> deepseek/<id> entry per line of the "DeepSeek
+    # Models" textarea.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "deepseek" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "deepseek_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "deepseek_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "deepseek/%s" $m) "api_key" "os.environ/DEEPSEEK_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    # Mistral — one <id> -> mistral/<id> entry per line of the "Mistral Models"
+    # textarea.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "mistral" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "mistral_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "mistral_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "mistral/%s" $m) "api_key" "os.environ/MISTRAL_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    # Groq — one <id> -> groq/<id> entry per line of the "Groq Models" textarea.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "groq" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "groq_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "groq_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "groq/%s" $m) "api_key" "os.environ/GROQ_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    # OpenRouter — one <provider/model> -> openrouter/<provider/model> entry per
+    # line of the "OpenRouter Models" textarea. OR_SITE_URL / OR_APP_NAME come
+    # from the base block's proxy_config.environment_variables.
+    - when: '{{repl ConfigOptionEquals "llm_provider" "openrouter" }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "openrouter_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "openrouter_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "openrouter/%s" $m) "api_key" "os.environ/OPENROUTER_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
+    # Google AI Studio (Gemini) — one <id> -> gemini/<id> entry per line of the
+    # "Gemini Models" textarea. Gated on google_api_type=gemini AND
+    # llm_provider=google because google_api_type defaults to "gemini" (so the
+    # type check alone would fire for every other provider). LiteLLM's gemini
+    # provider defaults to GEMINI_API_KEY, but an explicit api_key wins, so it
+    # reads GOOGLE_API_KEY (the name litellm-env-secrets exports).
+    - when: '{{repl and (ConfigOptionEquals "llm_provider" "google") (ConfigOptionEquals "google_api_type" "gemini") }}'
+      recursiveMerge: true
+      values:
+        env:
+          LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "gemini_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
+        litellm-helm:
+          proxy_config:
+            model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "gemini_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "gemini/%s" $m) "api_key" "os.environ/GOOGLE_API_KEY")) }}repl{{ end }}repl{{ end }}repl{{ $models | mustToJson }}
     # Path-based sandbox routing: route every runtime at <base>/{id} through a
     # shared Gateway instead of per-sandbox Ingresses at {id}.<base>. Traefik's
     # kubernetesGateway provider (enabled in embedded-cluster.yaml) installs


### PR DESCRIPTION
## The gap (#735)

The OHE chart only registered a LiteLLM `model_list` for 5 providers — **anthropic, azure, Google Vertex (`google_api_type=vertex`), bedrock, custom**. The other selectable `llm_provider` options — **openai, deepseek, mistral, groq, openrouter, and Google AI Studio / Gemini (`google_api_type=gemini`)** — wrote only an API key to `litellm-env-secrets` but registered **no model**, set **no `LITELLM_DEFAULT_MODEL`**, and had **no wildcard**. Selecting any of them produced `ProxyModelNotFound` / a fallback to an unauthenticated Anthropic route.

This PR wires those six providers the same way the working ones are wired.

## What each provider now wires

For each provider this adds a `<provider>_models` textarea (`replicated/config.yaml`, gated on the same `when` as its API-key field) and a `when`-gated `litellm-helm` `model_list` block + matching `LITELLM_DEFAULT_MODEL` override (`replicated/openhands.yaml`). The `litellm_params` per provider:

| Provider | `model` prefix | api key env | extra |
| --- | --- | --- | --- |
| OpenAI | `openai/<id>` | `os.environ/OPENAI_API_KEY` | — |
| DeepSeek | `deepseek/<id>` | `os.environ/DEEPSEEK_API_KEY` | — |
| Mistral | `mistral/<id>` | `os.environ/MISTRAL_API_KEY` | — |
| Groq | `groq/<id>` | `os.environ/GROQ_API_KEY` | — |
| OpenRouter | `openrouter/<provider/model>` | `os.environ/OPENROUTER_API_KEY` | `OR_SITE_URL`/`OR_APP_NAME` already set in the base block's `proxy_config.environment_variables` |
| Gemini (AI Studio) | `gemini/<id>` | `os.environ/GOOGLE_API_KEY` | — |

These are all key-only providers routed entirely through the bundled proxy, so they mirror the **anthropic base block** (no `OH_AGENT_SERVER_ENV` credential injection — anthropic, the canonical working key-only provider, doesn't do it either).

### Non-obvious details
- **Gemini env name:** LiteLLM's gemini provider defaults to `GEMINI_API_KEY`, but an explicit `api_key` in `litellm_params` wins. `litellm-env-secrets` already exports the Gemini key as `GOOGLE_API_KEY` (from `google_gemini_api_key`), so the block references `os.environ/GOOGLE_API_KEY` — no chart/secret edit needed.
- **Gemini `when` gating:** gated on `llm_provider=google` **AND** `google_api_type=gemini`. `google_api_type` defaults to `"gemini"`, so a `google_api_type`-only check (like the vertex block uses) would fire for every other provider too.
- **OpenRouter route names** keep the full `provider/model` slug as `model_name` (e.g. `litellm_proxy/anthropic/claude-sonnet-4.5`).

## Defaults shipped (admin-editable, prefilled)
openai `gpt-5` / `gpt-4.1`; gemini `gemini-2.5-pro` / `gemini-2.5-flash`; deepseek `deepseek-chat` / `deepseek-reasoner`; mistral `mistral-large-latest` / `codestral-latest`; groq `llama-3.3-70b-versatile`; openrouter `anthropic/claude-sonnet-4.5`.

## Pattern + comma-tolerance
Mirrors the existing wired-provider pattern exactly (list/dict/append/seen/`mustToJson`; `LITELLM_DEFAULT_MODEL` = `litellm_proxy/<first id>`). Because KOTS `recursiveMerge` REPLACES the `model_list` array, each provider carries its own complete block. Parsing is **comma- and newline-tolerant from the start**: `... | replace "\r" "\n" | replace "," "\n" | splitList "\n"` → trim → dedupe.

## Verification
- Rendered the `model_list` + `LITELLM_DEFAULT_MODEL` sprig for openai + gemini through a throwaway `helm template` chart with both comma- and newline-separated input (incl. spaces + duplicates): produced separate, correctly-prefixed entries, trimmed and deduped, with the right key env per provider.
- `replicated/config.yaml` and `replicated/openhands.yaml` parse as valid YAML.
- `replicated/`-only change (no `charts/**`), so no chart-version bump — same shape as the prior comma-tolerance fix.
- grep-verified each provider has a textarea, a `model_list` block, a `LITELLM_DEFAULT_MODEL`, and references its api-key env, with no cross-provider copy/paste.

> This still needs QA on a real install (select each provider, confirm a conversation routes through the proxy without `ProxyModelNotFound`) before merge. The shipped default model IDs should be sanity-checked against current provider/LiteLLM catalogs at merge time.

Closes #735
