### PR TITLE
feat(agent-canvas): add staticServer.lockToCloud chart value

### DIFF
--- a/charts/agent-canvas/Chart.yaml
+++ b/charts/agent-canvas/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-canvas
 description: Frontend-only deployment of OpenHands Agent Canvas (UI shell pointing at user-managed backends)
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"

--- a/charts/agent-canvas/README.md
+++ b/charts/agent-canvas/README.md
@@ -30,3 +30,20 @@ agent-canvas:
       enabled: true
       secretName: agent-canvas-tls
 ```
+
+### Locking the UI to a single OpenHands Cloud host
+
+Set `staticServer.lockToCloud` to pass `--lock-to-cloud <url>` to
+`static-server.mjs`. The UI then locks backend setup to a single
+OpenHands Cloud host (skipping the "Manage Backends" flow), e.g. for a
+dedicated `canvas.<env>.all-hands.dev` deployment:
+
+```yaml
+agent-canvas:
+  enabled: true
+  staticServer:
+    lockToCloud: https://app.all-hands.dev
+  ingress:
+    enabled: true
+    host: canvas.staging.all-hands.dev
+```

--- a/charts/agent-canvas/templates/deployment.yaml
+++ b/charts/agent-canvas/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             {{- if .Values.staticServer.authRequired }}
             - --auth-required
             {{- end }}
+            {{- with .Values.staticServer.lockToCloud }}
+            - --lock-to-cloud
+            - {{ . | quote }}
+            {{- end }}
             {{- range .Values.staticServer.rejectPrefixes }}
             - --reject-prefix
             - {{ . | quote }}

--- a/charts/agent-canvas/values.yaml
+++ b/charts/agent-canvas/values.yaml
@@ -43,6 +43,12 @@ ingress:
 # normally proxy to a local backend (since this deployment has none).
 staticServer:
   authRequired: true
+  # When set, passes `--lock-to-cloud <url>` to static-server.mjs, which
+  # injects window.__AGENT_CANVAS_LOCK_TO_CLOUD__ so the UI locks backend
+  # setup to a single OpenHands Cloud host (e.g.
+  # https://app.all-hands.dev). Leave empty for the standard
+  # user-managed "Manage Backends" flow.
+  lockToCloud: ""
   rejectPrefixes:
     - /api
     - /server_info

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.65
+version: 0.7.66
 dependencies:
   - name: keycloak
     version: 24.7.5
@@ -53,5 +53,5 @@ dependencies:
     condition: integrations-hub.enabled
   - name: agent-canvas
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.1.1
+    version: 0.1.2
     condition: agent-canvas.enabled


### PR DESCRIPTION
## Why

OpenHands/agent-canvas#1389 added a `--lock-to-cloud <url>` mode to `static-server.mjs` (injects `window.__AGENT_CANVAS_LOCK_TO_CLOUD__` so the UI locks backend setup to a single OpenHands Cloud host, skipping the "Manage Backends" flow). The `agent-canvas` Helm chart currently hardcodes the static-server args and has **no way to pass that flag**, so deployments can't actually use lock-to-cloud.

## What

- Add a typed `staticServer.lockToCloud` value to the `agent-canvas` chart; when non-empty, the deployment template renders `--lock-to-cloud <url>` (after `--auth-required`, before the `--reject-prefix` list).
- Empty by default → existing deployments render identically (verified: 0 `lock-to-cloud` occurrences in the default `helm template`).
- Bump `agent-canvas` chart `0.1.1` → `0.1.2`.
- Bump the `openhands` parent chart `0.7.65` → `0.7.66` and its `agent-canvas` dependency to `0.1.2`.
  - Note: `0.7.65` was taken by #742 (runtime-api agent-server bump), so this PR bumps from the new main HEAD `0.7.65` → `0.7.66`. Rebased onto main; preserves #742's `runtime-api` `0.3.13` dep.

## Verification

- `helm lint charts/agent-canvas` passes.
- `helm template charts/agent-canvas --set staticServer.lockToCloud=https://app.all-hands.dev` renders `- --lock-to-cloud - "https://app.all-hands.dev"` correctly.
- `helm template charts/agent-canvas` (defaults) renders **no** `--lock-to-cloud` arg (0 occurrences).

## Notes

- `charts/openhands/Chart.lock` is intentionally left unchanged — it is already stale in `main` (doesn't list `agent-canvas`, shows older subchart versions), and CI regenerates it at publish time (`update_dependencies: 'true'`, with `agent-canvas` ordered before `openhands`).
- The `preview-helm-charts` PR workflow rewrites the `openhands` dependency to the PR-preview version of `agent-canvas` when both charts change in the same PR, so the openhands lint/template check resolves the local 0.1.2 preview rather than failing on the not-yet-published tag.

## Downstream

Once this merges and publishes `agent-canvas` 0.1.2 / `openhands` **0.7.66**, a follow-up in `OpenHands/saas-deploy` (#67) will bump the staging `openhands` chart dependency to `0.7.66`, set `agent-canvas.staticServer.lockToCloud: https://app.all-hands.dev`, and roll the agent-canvas image tag to the SHA from agent-canvas#1389 (`sha-bea10d8`).

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository contributor._