### PR TITLE
feat: wire runtime file archive config into Helm and Replicated (APP-2405)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.38.0
-version: 0.7.67
+version: 0.7.68
 dependencies:
   - name: keycloak
     version: 24.7.5
@@ -34,7 +34,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/openhands/helm-charts
-    version: 0.3.13
+    version: 0.3.14
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/openhands/helm-charts

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -43,6 +43,8 @@
   value: {{ .Values.runtimeFileArchive.bucket | quote }}
 - name: RUNTIME_FILE_ARCHIVE_PREFIX
   value: {{ .Values.runtimeFileArchive.prefix | default "workspace-archives" | quote }}
+- name: RUNTIME_FILE_ARCHIVE_PATH
+  value: {{ .Values.runtimeFileArchive.path | default "/workspace/project" | quote }}
 - name: RUNTIME_FILE_ARCHIVE_FORMAT
   value: {{ .Values.runtimeFileArchive.format | default "git-delta" | quote }}
 - name: RUNTIME_FILE_ARCHIVE_REQUIRED

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -36,6 +36,18 @@
 
 - name: FILE_STORE_PATH
   value: {{ .Values.filestore.bucket }}
+{{- if .Values.runtimeFileArchive.enabled }}
+- name: RUNTIME_FILE_ARCHIVE_ENABLED
+  value: "true"
+- name: RUNTIME_FILE_ARCHIVE_BUCKET
+  value: {{ .Values.runtimeFileArchive.bucket | quote }}
+- name: RUNTIME_FILE_ARCHIVE_PREFIX
+  value: {{ .Values.runtimeFileArchive.prefix | default "workspace-archives" | quote }}
+- name: RUNTIME_FILE_ARCHIVE_FORMAT
+  value: {{ .Values.runtimeFileArchive.format | default "git-delta" | quote }}
+- name: RUNTIME_FILE_ARCHIVE_REQUIRED
+  value: {{ .Values.runtimeFileArchive.required | default false | quote }}
+{{- end }}
 - name: SANDBOX_KEEP_RUNTIME_ALIVE
   value: 'true'
 - name: SANDBOX_CLOSE_DELAY

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -77,6 +77,20 @@ filestore:
   ephemeral: false
   bucket: openhands-sessions
 
+# Workspace archiving (app-server side): when a still-running sandbox is deleted
+# explicitly, copy its workspace to object storage before stopping the runtime,
+# so it survives deletion and can feed eval/dataset creation. Disabled by
+# default. The app-server ServiceAccount must have write access to the bucket
+# (GCS: roles/storage.objectAdmin on the bucket, via Workload Identity).
+# The idle/expiry reap is archived separately by the runtime-api cleanup
+# CronJob (see runtime-api.runtimeFileArchive).
+runtimeFileArchive:
+  enabled: false
+  bucket: "" # Object-storage bucket that receives the archives.
+  prefix: workspace-archives # Key prefix within the bucket.
+  format: git-delta # git-delta (compact), tar.gz, or zip.
+  required: false # When true, a failed archive blocks the delete (retry later).
+
 github:
   enabled: false
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -88,6 +88,7 @@ runtimeFileArchive:
   enabled: false
   bucket: "" # Object-storage bucket that receives the archives.
   prefix: workspace-archives # Key prefix within the bucket.
+  path: /workspace/project # Source path to archive (git repo root, not /workspace).
   format: git-delta # git-delta (compact), tar.gz, or zip.
   required: false # When true, a failed archive blocks the delete (retry later).
 

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.3.13 # Change this to trigger a new helm chart version being published
+version: 0.3.14 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -23,6 +23,8 @@
   value: {{ .Values.runtimeFileArchive.bucket | quote }}
 - name: RUNTIME_FILE_ARCHIVE_PREFIX
   value: {{ .Values.runtimeFileArchive.prefix | default "workspace-archives" | quote }}
+- name: RUNTIME_FILE_ARCHIVE_PATH
+  value: {{ .Values.runtimeFileArchive.path | default "/workspace/project" | quote }}
 - name: RUNTIME_FILE_ARCHIVE_FORMAT
   value: {{ .Values.runtimeFileArchive.format | default "git-delta" | quote }}
 {{- end }}

--- a/charts/runtime-api/templates/_env.yaml
+++ b/charts/runtime-api/templates/_env.yaml
@@ -16,6 +16,16 @@
   value: {{ .Values.cleanup.idle_seconds | default 1200 | quote }}
 - name: RUNTIME_DEAD_SECONDS
   value: {{ printf "%.0f" .Values.cleanup.dead_seconds | quote }}
+{{- if .Values.runtimeFileArchive.enabled }}
+- name: RUNTIME_FILE_ARCHIVE_ENABLED
+  value: "true"
+- name: RUNTIME_FILE_ARCHIVE_BUCKET
+  value: {{ .Values.runtimeFileArchive.bucket | quote }}
+- name: RUNTIME_FILE_ARCHIVE_PREFIX
+  value: {{ .Values.runtimeFileArchive.prefix | default "workspace-archives" | quote }}
+- name: RUNTIME_FILE_ARCHIVE_FORMAT
+  value: {{ .Values.runtimeFileArchive.format | default "git-delta" | quote }}
+{{- end }}
 {{- if .Values.runtimeInSameCluster }}
 - name: RUNTIME_IN_SAME_CLUSTER
   value: "true"

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -256,6 +256,7 @@ runtimeFileArchive:
   enabled: false
   bucket: "" # Object-storage bucket that receives the archives.
   prefix: workspace-archives # Key prefix within the bucket.
+  path: /workspace/project # Source path to archive (git repo root, not /workspace).
   format: git-delta # git-delta (compact), tar.gz, or zip.
 
 warmRuntimes:

--- a/charts/runtime-api/values.yaml
+++ b/charts/runtime-api/values.yaml
@@ -247,6 +247,17 @@ cleanup:
   idle_seconds: 1200 # Default to 20 minutes
   dead_seconds: 86400 # Default to 1 day
 
+# Workspace archiving: before the cleanup CronJob pauses/stops a runtime (while
+# the pod is still reachable), copy the workspace to object storage so it
+# survives PVC deletion and can feed eval/dataset creation. Disabled by default.
+# The cleanup ServiceAccount must have write access to the bucket
+# (GCS: roles/storage.objectAdmin on the bucket, via Workload Identity).
+runtimeFileArchive:
+  enabled: false
+  bucket: "" # Object-storage bucket that receives the archives.
+  prefix: workspace-archives # Key prefix within the bucket.
+  format: git-delta # git-delta (compact), tar.gz, or zip.
+
 warmRuntimes:
   enabled: false
   configMapName: warm-runtimes-config

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -894,6 +894,29 @@ spec:
             regex:
               pattern: ^[1-9][0-9]*$
               message: Must be a positive integer (in seconds)
+        - name: sandbox_archive_enabled
+          title: Archive Workspaces Before Deletion
+          help_text: >-
+            Copy each conversation's workspace to object storage before the
+            sandbox is paused/stopped or deleted, so it survives deletion (e.g.
+            for building evaluation datasets). The OpenHands and runtime-api
+            service accounts must have write access to the bucket below.
+          type: bool
+          default: "0"
+        - name: sandbox_archive_bucket
+          title: Archive Bucket
+          help_text: Object-storage bucket that receives workspace archives.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "sandbox_archive_enabled" "1" }}'
+          required: true
+        - name: sandbox_archive_required
+          title: Require Archive to Succeed Before Deleting
+          help_text: >-
+            When enabled, an explicit sandbox deletion is blocked (and retried
+            later) if its workspace archive fails, instead of deleting anyway.
+          type: bool
+          default: "0"
+          when: 'repl{{ ConfigOptionEquals "sandbox_archive_enabled" "1" }}'
         - name: sandbox_storage_size
           title: Storage Size
           help_text: How much persistent storage each sandbox gets.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -294,6 +294,9 @@ spec:
       cleanup:
         idle_seconds: repl{{ ConfigOption "sandbox_idle_seconds" }}
         dead_seconds: repl{{ ConfigOption "sandbox_dead_seconds" }}
+      runtimeFileArchive:
+        enabled: repl{{ ConfigOptionEquals "sandbox_archive_enabled" "1" }}
+        bucket: 'repl{{ ConfigOption "sandbox_archive_bucket" }}'
       env:
         DB_HOST: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
         DB_PORT: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
@@ -385,6 +388,10 @@ spec:
         password: '{{repl ConfigOption "redis_password" | Base64Encode }}'
     filestore:
       ephemeral: true
+    runtimeFileArchive:
+      enabled: repl{{ ConfigOptionEquals "sandbox_archive_enabled" "1" }}
+      bucket: 'repl{{ ConfigOption "sandbox_archive_bucket" }}'
+      required: repl{{ ConfigOptionEquals "sandbox_archive_required" "1" }}
     minio:
       persistence:
         enabled: true


### PR DESCRIPTION
## Description

Wires the workspace **archive-before-delete** feature into the Helm charts and Replicated config so it can be enabled in deployed environments (APP-2405, OpenHands-Cloud#729).

There are two consumers of the same `RUNTIME_FILE_ARCHIVE_*` env, so config is plumbed to both:
- **runtime-api** cleanup CronJob — the primary, pause-time archive of the dominant idle/expiry reap (PLTF-3112, runtime-api#623).
- **OpenHands app-server** — the explicit-delete-while-running path (APP-2403, OpenHands#14953).

Changes:
- `charts/runtime-api`: new `runtimeFileArchive.{enabled,bucket,prefix,format}` → `RUNTIME_FILE_ARCHIVE_*` env in the shared `runtime-api.env` (so the cleanup CronJob and deployment both get it).
- `charts/openhands`: new `runtimeFileArchive.{enabled,bucket,prefix,format,required}` → `RUNTIME_FILE_ARCHIVE_*` env on the app-server.
- `replicated/`: new **Sandbox Configuration** options (archive enabled / bucket / require-on-delete) mapped into both the `runtime-api` subchart and the app-server values in `openhands.yaml`.
- **Default disabled** — existing deployments are unchanged. Bucket write access is granted to the service accounts via Workload Identity (noted in `values.yaml`; GCS: `roles/storage.objectAdmin` on the bucket).

Verified with `helm template` on both charts: with the feature off, **no** `RUNTIME_FILE_ARCHIVE_*` env is rendered; with it on, the vars render on the cleanup CronJob and the app-server. Replicated `config.yaml` parses; the new ConfigOptions map through `openhands.yaml`.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (runtime-api 0.3.13 → 0.3.14 + openhands dep pin; openhands 0.7.67 → 0.7.68)
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations (feature defaults off; no env emitted when disabled)
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values (none — additive, optional values; documented inline in values.yaml)

## Additional Notes

This was marked Done in Linear earlier without code; reopened and implemented here. Credentials are intentionally **not** a new secret — archiving uses the existing GCS Workload Identity of the runtime-api / app-server service accounts, consistent with the current `filestore` setup.
