### PR TITLE
fix(openhands): bump agent-server image tag to 1.29.0-python

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.70
+version: 0.7.71
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -246,7 +246,7 @@ resendSync:
 runtime:
   image:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.28.0-python
+    tag: 1.29.0-python
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress


### PR DESCRIPTION
## Description

Conversations in staging were failing with "agent server version does not match".

The app image moved to `cloud-1.39.0`, which bundles `openhands-sdk` 1.29 and refuses to talk to an agent-server running a different minor. But the chart's `runtime.image.tag` - the value that becomes the app's `AGENT_SERVER_IMAGE_TAG` - was still pinned to `1.28.0-python`. So the app kept requesting a 1.28 agent-server and rejecting it.

#747 bumped `appVersion` to `cloud-1.39.0` and the warm-runtimes image, but left this one `runtime.image.tag` default behind. This bumps it to `1.29.0-python` so the default agent-server matches the app's SDK.

`runtime.image.tag` doesn't fall back to `.Chart.AppVersion` the way the enterprise-server image does, so it has to be bumped explicitly each release - that's how it drifted.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

This only touches the `openhands` chart, matching #747's scope. `charts/image-loader` and `replicated/` still pin `1.28.0-python`. Those don't affect the SaaS request failures, but the on-prem/replicated path and the node image preloader will need the same bump separately.

I haven't tested the upgrade path locally - it's a single default-value change with no schema change, so existing overrides keep working, but I'm flagging that I didn't run an actual upgrade.