### PR TITLE
feat(openhands): add openOrgCreation.enabled feature switch

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.71
+version: 0.7.72
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -348,6 +348,11 @@
   value: "true"
 {{- end }}
 
+{{- if .Values.openOrgCreation.enabled }}
+- name: OPEN_ORG_CREATION_ENABLED
+  value: "true"
+{{- end }}
+
 {{- $dbSslMode := "prefer" }}
 {{- if not .Values.postgresql.enabled }}
 {{- $dbSslMode = .Values.externalDatabase.sslMode | default "prefer" }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -44,6 +44,14 @@ debuggingRoutes:
 userProvisioning:
   enabled: false
 
+# POST /api/organizations org-creation endpoint. By default this endpoint
+# is restricted to @openhands.dev admin users. When enabled, the enterprise
+# app server sets OPEN_ORG_CREATION_ENABLED=true and any authenticated user
+# is allowed to create an organization. This should only be enabled for OHE
+# deployments where end users are expected to self-serve organizations.
+openOrgCreation:
+  enabled: false
+
 databaseMigrations:
   waitForDatabase: true
   createDatabases: false


### PR DESCRIPTION
## Why

Adds a Helm-driven feature switch for the new `OPEN_ORG_CREATION_ENABLED` gate on `POST /api/organizations` that was added to the enterprise app server in OpenHands/OpenHands#14864.

By default, `POST /api/organizations` is restricted to `@openhands.dev` admin users (existing behavior, unchanged). When this switch is enabled, the enterprise app server allows any authenticated user to create an organization — useful for OHE deployments where end users are expected to self-serve organizations.

This mirrors the [`userProvisioning.enabled`](https://github.com/OpenHands/OpenHands-Cloud/pull/728) switch added immediately above it.

## What

- **`charts/openhands/values.yaml`** — new `openOrgCreation.enabled` value, defaulting to `false`. Staging and production inherit the off state unless an env-specific override flips it on.
- **`charts/openhands/templates/_env.yaml`** — when `openOrgCreation.enabled` is true, project `OPEN_ORG_CREATION_ENABLED=true` into the deployment env. The enterprise app server reads this var (accepting both `'true'` and `'1'` per AGENTS.md) to decide whether to require `@openhands.dev` email on `POST /api/organizations`. Sits right next to the existing `userProvisioning.enabled` gate for symmetry.
- **`charts/openhands/Chart.yaml`** — bump version `0.7.71` → `0.7.72`.

When the flag is off, the route still works but stays restricted to admin email users (current production behavior is preserved).

## Companion PR

- Backend gate that consumes the switch: OpenHands/OpenHands#14864 — adds `OPEN_ORG_CREATION_ENABLED` constant and `get_org_creator_user_id` FastAPI dependency.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('charts/openhands/values.yaml'))"` — values.yaml parses cleanly.
- `helm lint charts/openhands` → `1 chart(s) linted, 0 chart(s) failed`.
- `helm template test charts/openhands --set openOrgCreation.enabled=true | grep OPEN_ORG_CREATION_ENABLED` → renders `OPEN_ORG_CREATION_ENABLED: "true"` env entries on the relevant pod specs.
- `helm template test charts/openhands | grep -c OPEN_ORG_CREATION_ENABLED` → `0` (no leakage when the switch is off, matching the existing `userProvisioning` behavior).
- Backend unit tests covering `'true'`/`'1'`/unset env parsing are in the companion OpenHands PR (`enterprise/tests/unit/server/test_constants.py::TestOpenOrgCreationEnabled`).

---

_This PR was opened by an AI agent (OpenHands) on behalf of @chuckbutkus._

@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3f9f64b2-bfaa-4631-b900-9dd9255e6554)