### PR TITLE
fix(charts): trust custom CA in automation and plugin-directory

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.72
+version: 0.7.73
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/charts/automation/templates/deployment.yaml
+++ b/charts/openhands/charts/automation/templates/deployment.yaml
@@ -23,6 +23,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.caBundle.enabled }}
+      volumes:
+        - name: openhands-ca-bundle
+          configMap:
+            name: {{ .Values.caBundle.name }}
+      {{- end }}
       initContainers:
       {{- if .Values.database.createDatabaseUser }}
       # Create automation database and user in an existing PostgreSQL instance
@@ -156,3 +162,15 @@ spec:
           failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
         env:
         {{- include "automation.env" . | nindent 8 }}
+        {{- if .Values.caBundle.enabled }}
+        - name: SSL_CERT_FILE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        - name: REQUESTS_CA_BUNDLE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        {{- end }}
+        {{- if .Values.caBundle.enabled }}
+        volumeMounts:
+        - name: openhands-ca-bundle
+          mountPath: {{ .Values.caBundle.mountPath }}
+          readOnly: true
+        {{- end }}

--- a/charts/openhands/charts/automation/templates/events-deployment.yaml
+++ b/charts/openhands/charts/automation/templates/events-deployment.yaml
@@ -24,6 +24,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.caBundle.enabled }}
+      volumes:
+        - name: openhands-ca-bundle
+          configMap:
+            name: {{ .Values.caBundle.name }}
+      {{- end }}
       initContainers:
       - name: migrate
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
@@ -70,4 +76,16 @@ spec:
           failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
         env:
         {{- include "automation.env" . | nindent 8 }}
+        {{- if .Values.caBundle.enabled }}
+        - name: SSL_CERT_FILE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        - name: REQUESTS_CA_BUNDLE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        {{- end }}
+        {{- if .Values.caBundle.enabled }}
+        volumeMounts:
+        - name: openhands-ca-bundle
+          mountPath: {{ .Values.caBundle.mountPath }}
+          readOnly: true
+        {{- end }}
 {{- end }}

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -4,6 +4,20 @@ image:
 
 imagePullSecrets: []
 
+# Mount a trust-manager / user-supplied CA bundle into the automation pods and
+# point the Python TLS stack (httpx + requests) at it. Required when automation
+# makes outbound HTTPS calls to endpoints served by a cert signed by a CA that
+# isn't in the OS trust store — e.g. the OpenHands app at openhandsApiUrl /
+# automationBaseUrl when an operator uploads a self-signed/custom cert.
+# Otherwise TLS verification fails and callbacks/dispatches silently break.
+# The named ConfigMap is created by the parent openhands chart's trust-manager
+# Bundle; this subchart only mounts it.
+caBundle:
+  enabled: false
+  name: openhands-ca-bundle
+  key: ca-bundle.crt
+  mountPath: /etc/openhands/ca-bundle
+
 deployment:
   replicas: 1
   resources:

--- a/charts/openhands/charts/plugin-directory/templates/deployment.yaml
+++ b/charts/openhands/charts/plugin-directory/templates/deployment.yaml
@@ -23,6 +23,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.caBundle.enabled }}
+      volumes:
+        - name: openhands-ca-bundle
+          configMap:
+            name: {{ .Values.caBundle.name }}
+      {{- end }}
       initContainers:
       {{- include "plugin-directory.dbInitContainers" . | nindent 6 }}
       containers:
@@ -36,8 +42,20 @@ spec:
             protocol: TCP
         env:
         {{- include "plugin-directory.env.server" . | nindent 8 }}
+        {{- if .Values.caBundle.enabled }}
+        - name: SSL_CERT_FILE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        - name: REQUESTS_CA_BUNDLE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        {{- end }}
         resources:
           {{- toYaml .Values.server.resources | nindent 10 }}
+        {{- if .Values.caBundle.enabled }}
+        volumeMounts:
+        - name: openhands-ca-bundle
+          mountPath: {{ .Values.caBundle.mountPath }}
+          readOnly: true
+        {{- end }}
         startupProbe:
           httpGet:
             path: /health/live
@@ -69,8 +87,26 @@ spec:
             protocol: TCP
         env:
         {{- include "plugin-directory.env.client" . | nindent 8 }}
+        {{- if .Values.caBundle.enabled }}
+        # The client is a Node.js SSR server: Node honors NODE_EXTRA_CA_CERTS for
+        # its outbound TLS (e.g. OIDC to Keycloak at oidc.issuerUrl). SSL_CERT_FILE
+        # and REQUESTS_CA_BUNDLE are inert for Node itself but cover any subprocess
+        # it shells out to and keep the env set uniform with the server container.
+        - name: NODE_EXTRA_CA_CERTS
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        - name: SSL_CERT_FILE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        - name: REQUESTS_CA_BUNDLE
+          value: {{ .Values.caBundle.mountPath }}/{{ .Values.caBundle.key }}
+        {{- end }}
         resources:
           {{- toYaml .Values.client.resources | nindent 10 }}
+        {{- if .Values.caBundle.enabled }}
+        volumeMounts:
+        - name: openhands-ca-bundle
+          mountPath: {{ .Values.caBundle.mountPath }}
+          readOnly: true
+        {{- end }}
         startupProbe:
           httpGet:
             path: /plugins/health/live

--- a/charts/openhands/charts/plugin-directory/values.yaml
+++ b/charts/openhands/charts/plugin-directory/values.yaml
@@ -35,6 +35,21 @@ server:
     limits:
       memory: 512Mi
 
+# Mount a trust-manager / user-supplied CA bundle into the plugin-directory
+# pod and point the runtimes at it. Required when the pod makes outbound HTTPS
+# calls to endpoints served by a cert signed by a CA that isn't in the OS trust
+# store — e.g. the server fetching the marketplace catalog from MARKETPLACE_SOURCE
+# (an https:// or github:// URL) and the client's SSR loader reaching Keycloak at
+# oidc.issuerUrl when an operator uploads a self-signed/custom cert. Otherwise TLS
+# verification fails and the marketplace/login silently break. The named ConfigMap
+# is created by the parent openhands chart's trust-manager Bundle; this subchart
+# only mounts it.
+caBundle:
+  enabled: false
+  name: openhands-ca-bundle
+  key: ca-bundle.crt
+  mountPath: /etc/openhands/ca-bundle
+
 # Deployment configuration
 deployment:
   replicas: 1

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -560,6 +560,13 @@ spec:
           secretKey: webhook-secret
         automation:
           enabled: true
+          # caBundle wiring: mount the trust-manager Bundle ConfigMap and point
+          # the Python TLS stack (httpx + requests) at the merged PEM. Required
+          # so automation can verify the OpenHands app cert (openhandsApiUrl /
+          # automationBaseUrl below) when the operator uploads a custom CA —
+          # otherwise outbound HTTPS callbacks/dispatches fail TLS verification.
+          caBundle:
+            enabled: true
           image:
             repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/automation'
           imagePullSecrets:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -969,6 +969,14 @@ spec:
       values:
         plugin-directory:
           enabled: true
+          # caBundle wiring: mount the trust-manager Bundle ConfigMap and point
+          # the server (Python) and client (Node, via NODE_EXTRA_CA_CERTS) at the
+          # merged PEM. Required so the server can verify the marketplace catalog
+          # host (MARKETPLACE_SOURCE) and the client's SSR loader can verify
+          # Keycloak (oidc.issuerUrl) when the operator uploads a custom CA —
+          # otherwise outbound HTTPS fails TLS verification.
+          caBundle:
+            enabled: true
           appUrl: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}/plugins'
           # OpenHands API host (same host as appUrl, without the /plugins path).
           # The curl template appends /api/v1/app-conversations to this base.


### PR DESCRIPTION
## Description

Replicated installs fan out an operator-supplied CA (self-signed or private) as a trust-manager bundle, and components mount it so their outbound HTTPS trusts that CA. automation and plugin-directory weren't wired to mount it, so their TLS calls failed against a custom CA. automation reaches the app API; plugin-directory reaches the app API, keycloak for OIDC, and the marketplace catalog.

This wires both to mount the `openhands-ca-bundle` ConfigMap and point their TLS stack at it, following the existing runtime-api pattern: an inline per-subchart `caBundle` block, enabled from the replicated layer. It's default-off, so existing installs render identically to before.

One non-obvious bit: plugin-directory's client is a node.js server, which ignores `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` and needs `NODE_EXTRA_CA_CERTS`.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (only the umbrella `openhands` needs it, 0.7.72 -> 0.7.73; the automation and plugin-directory subcharts are inert `version: 0.0.0` and ship with the umbrella)
- [x] I have tested the chart upgrade path from the previous version (deployed to a Replicated instance, which rolls out via `helm upgrade --install`; created an automation and configured the plugin directory, both working with the CA wiring active)
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values (none - the new values default off)

## Additional Notes

I deployed this to a Replicated instance and exercised it end to end: I created an automation and configured the plugin directory, both working with the CA-bundle wiring active. I also validated locally with `helm template` (enabled, disabled, and a combined umbrella render) and `helm lint`. The change is additive and guarded by `caBundle.enabled` (default false), so it's a no-op for any consumer that doesn't enable it.

laminar isn't included. I looked into it, but its chart (lmnr-helm 0.1.13 and upstream 0.2.1) exposes `extraEnv` and no volume-mount knob, so the CA ConfigMap can't be mounted via values. Wiring it needs an upstream lmnr-helm change or a fork. It only affects installs with analytics enabled and a custom CA.
