### PR TITLE
Fix integrations hub migration working directory

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.72
+version: 0.7.73
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/deployment.yaml
@@ -120,6 +120,7 @@ spec:
       # Run database migrations before starting the main container
       - name: migrate
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+        workingDir: /app/backend
         command: ["alembic", "upgrade", "head"]
         env:
         {{- include "integrations-hub.env" . | nindent 8 }}


### PR DESCRIPTION
## Summary\n- Run the integrations-hub migration init container from /app/backend so Alembic can find backend/alembic.ini and the relative migration scripts.\n- Bump the OpenHands chart version to 0.7.73 so the fixed chart can be published.\n\n## Context\nStaging integrations-hub is returning 503 after the saas-deploy rollout. Datadog Kubernetes/container events show the integrations-hub pod's migrate init container repeatedly exiting with code 255 before the main container becomes ready. The image stores Alembic config under /app/backend, but the chart currently runs alembic from the image default working directory.\n\n## Validation\n- git diff --check\n- Parsed charts/openhands/Chart.yaml with Python/PyYAML\n- Verified deployment template contains workingDir: /app/backend\n\nThis PR was created by an AI agent (OpenHands) on behalf of Graham Neubig.