### PR TITLE
Align RUNTIME_DEAD_SECONDS default to 60 days (match prod)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.40.0
-version: 0.7.82
+version: 0.7.83
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -245,7 +245,7 @@ cleanup:
   enabled: true
   schedule: "*/5 * * * *"
   idle_seconds: 1200 # Default to 20 minutes
-  dead_seconds: 86400 # Default to 1 day
+  dead_seconds: 5184000 # Default to 60 days (stopgap until workspace archiving ships; runtime-api#624)
 
 warmRuntimes:
   enabled: false

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -889,7 +889,7 @@ spec:
           title: Deletion Time (seconds)
           help_text: How long (in seconds) before paused conversations are permanently deleted. Once deleted, the conversation's storage is freed and it can no longer be accessed.
           type: text
-          default: "86400"
+          default: "5184000"
           validation:
             regex:
               pattern: ^[1-9][0-9]*$


### PR DESCRIPTION
## Summary

Updates the default for **`RUNTIME_DEAD_SECONDS`** — how long a *paused* conversation/runtime is retained before its PVC/storage is **permanently deleted** — from **1 day (`86400`)** to **60 days (`5184000`)**, so the chart and Replicated defaults match the production SaaS value.

Two files changed:

| File | Setting | Before | After |
|---|---|---|---|
| `charts/openhands/charts/runtime-api/values.yaml` | `cleanup.dead_seconds` | `86400` (1 day) | `5184000` (60 days) |
| `replicated/config.yaml` | `sandbox_dead_seconds` default | `"86400"` (1 day) | `"5184000"` (60 days) |

These flow into the runtime-api `cleanup.dead_seconds` helm value → `RUNTIME_DEAD_SECONDS` env var (`templates/_env.yaml`), which the cleanup cronjob uses in `delete_old_runtimes()` to delete paused/old runtimes once they exceed the threshold.

## Why

Production SaaS (`OpenHands/saas-deploy`) sets `dead_seconds: 5184000 # 60 days (stopgap until workspace archiving ships; runtime-api#624)`. The chart and Replicated config, however, still shipped the original **1-day** default.

History check (git blame) confirms this was **never an intentional, separately-tuned value** — it has been `86400` since each surface was first created and simply never got updated to match prod:
- `charts/.../runtime-api/values.yaml` `dead_seconds: 86400`: present since the first chart commit (`cbd2b3f`, "add first charts"); only ever touched for whitespace/relocation since.
- `replicated/config.yaml` `sandbox_dead_seconds` default `"86400"`: present since it was introduced in #449 (`128df7b`, "Add Sandbox Configuration Settings"); unchanged since.

So bumping both to 60 days aligns Enterprise/self-hosted and chart defaults with the production retention window.

## Impact

- Paused conversations/runtimes will be retained for 60 days (instead of 1 day) before their storage is permanently deleted, on installs using the defaults.
- Operators can still override **Deletion Time** on the Replicated "Sandbox Configuration" screen (`sandbox_dead_seconds`); only the default changes.
- No change to the idle→pause threshold (`RUNTIME_IDLE_SECONDS` / `sandbox_idle_seconds`).

## Notes

- This is a stopgap that mirrors the production rationale (runtime-api#624 — until workspace archiving ships). When archiving lands, this retention window may be revisited.

---
This PR was created by an AI agent (OpenHands) on behalf of the user.

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9c8a250a-30a1-4ab7-a4ab-b2bb70168352)