### PR TITLE
Bump OpenHands chart to 0.7.74

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.73
+version: 0.7.74
 dependencies:
   - name: keycloak
     version: 24.7.5


### PR DESCRIPTION
## Summary\n- Bump the OpenHands chart version from 0.7.73 to 0.7.74.\n\n## Context\nOpenHands/OpenHands-Cloud#751 merged the integrations-hub migration working directory fix, but its post-merge publish workflow failed because 0.7.73 had already been published by OpenHands/OpenHands-Cloud#750. The existing stable 0.7.73 artifact therefore lacks:\n\n```yaml\nworkingDir: /app/backend\n```\n\nThis version bump creates a new stable chart version that includes the already-merged fix.\n\n## Validation\n- git diff --check\n- helm dependency update charts/openhands\n- helm lint charts/openhands\n- helm template charts/openhands --debug\n- helm package charts/openhands and verified the packaged integrations-hub template contains `workingDir: /app/backend`\n\nThis PR was created by an AI agent (OpenHands) on behalf of Graham Neubig.