### PR TITLE
feat(charts): trust operator CA bundle in laminar

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 24.7.5
 - name: laminar
   repository: https://lmnr-ai.github.io/lmnr-helm
-  version: 0.1.13
+  version: 0.2.2
 - name: litellm-helm
   repository: oci://ghcr.io/berriai
   version: 0.1.831
@@ -38,5 +38,5 @@ dependencies:
 - name: agent-canvas
   repository: ""
   version: '*'
-digest: sha256:28ddec4afdd16d99b204ea0f6de99cbe483a3b1087a6eb8a37a569c61fc5017b
-generated: "2026-06-23T00:00:00Z"
+digest: sha256:40485c9d50eaec81c717aaf76c1bbbe08dfeb5a288cd606a6bda929416c6ec91
+generated: "2026-06-25T15:27:15.536667-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.75
+version: 0.7.76
 dependencies:
   - name: keycloak
     version: 24.7.5
@@ -10,7 +10,7 @@ dependencies:
     condition: keycloak.enabled
   - name: laminar
     repository: https://lmnr-ai.github.io/lmnr-helm
-    version: 0.1.13
+    version: 0.2.2
     condition: laminar.enabled
   - name: litellm-helm
     repository: oci://ghcr.io/berriai

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -925,6 +925,36 @@ spec:
           appServer:
             loadBalancer:
               enabled: false
+            # caBundle wiring: mount the trust-manager Bundle ConfigMap so the
+            # Rust app-server trusts an operator-supplied custom/self-signed CA
+            # on outbound HTTPS + gRPC. Needs the volume knobs added in the fork.
+            extraEnv:
+              - name: SSL_CERT_FILE
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+              - name: GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+            extraVolumes:
+              - name: openhands-ca-bundle
+                configMap:
+                  name: openhands-ca-bundle
+            extraVolumeMounts:
+              - name: openhands-ca-bundle
+                mountPath: /etc/openhands/ca-bundle
+                readOnly: true
+          appServerConsumer:
+            extraEnv:
+              - name: SSL_CERT_FILE
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+              - name: GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+            extraVolumes:
+              - name: openhands-ca-bundle
+                configMap:
+                  name: openhands-ca-bundle
+            extraVolumeMounts:
+              - name: openhands-ca-bundle
+                mountPath: /etc/openhands/ca-bundle
+                readOnly: true
           global:
             cloudProvider: "aws"
           clickhouse:
@@ -946,6 +976,22 @@ spec:
                     key: client-secret
               - name: AUTH_KEYCLOAK_ISSUER
                 value: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://auth.app.{{repl ConfigOption "base_domain"}}/realms/allhands{{repl else}}https://{{repl ConfigOption "auth_hostname"}}/realms/allhands{{repl end}}'
+              # caBundle wiring (appended to the existing list — recursiveMerge
+              # REPLACES arrays, so these must live alongside the Keycloak vars).
+              # Next.js is Node, which honors NODE_EXTRA_CA_CERTS, not SSL_CERT_FILE;
+              # set both (SSL_CERT_FILE is harmless and helps any subprocess).
+              - name: NODE_EXTRA_CA_CERTS
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+              - name: SSL_CERT_FILE
+                value: /etc/openhands/ca-bundle/ca-bundle.crt
+            extraVolumes:
+              - name: openhands-ca-bundle
+                configMap:
+                  name: openhands-ca-bundle
+            extraVolumeMounts:
+              - name: openhands-ca-bundle
+                mountPath: /etc/openhands/ca-bundle
+                readOnly: true
             ingress:
               enabled: true
               hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'


### PR DESCRIPTION
## Description

Self-hosted (replicated/KOTS) operators can upload a custom or self-signed CA. The parent `openhands` chart turns that into a trust-manager `Bundle` and fans it out as the `openhands-ca-bundle` ConfigMap (key `ca-bundle.crt`). A subchart only trusts that CA if it actually mounts the ConfigMap and points its TLS stack at the file. Otherwise any outbound HTTPS/gRPC to an endpoint signed by the operator CA fails verification.

This is the companion to #750, which already wired `automation` and `plugin-directory`. laminar was the holdout: its chart had no way to mount a volume through values at all, so the CA couldn't be attached even though the env vars were settable. The volume/mount knobs were added upstream and shipped in the official laminar chart `0.2.2`.

So this PR bumps the laminar dependency (official repo) from `0.1.13` to `0.2.2` and sets the CA values in `replicated/openhands.yaml` for the three laminar components that make outbound TLS:

- `frontend` - server-side OIDC to keycloak.
- `app-server` and `app-server-consumer` - HTTPS to the LLM provider, plus gRPC.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

The parent `openhands` chart is bumped 0.7.75 -> 0.7.76. No new required values and nothing breaking (the laminar `extra*` knobs render nothing unless set), so no README change is needed. The upgrade-path and backwards-compat boxes are checked off the back of a live Replicated test - see below.

## Additional Notes

- **Per-runtime env vars.** The CA file is the same, but the var that activates it differs by runtime. node (laminar frontend) honors `NODE_EXTRA_CA_CERTS`. The rust services (`app-server`, `app-server-consumer`) use `SSL_CERT_FILE` + `GRPC_DEFAULT_SSL_ROOTS_FILE_PATH`. node ignores `SSL_CERT_FILE`, so getting the frontend var right is the easy bug to make here.

- **What's intentionally left out.** clickhouse, postgres, quickwit, redis, and rabbitmq don't get the mount. In the default install they talk in-cluster over plaintext, not TLS to an operator-CA endpoint. The clickhouse/quickwit S3 paths would only need a CA if pointed at an S3-compatible store behind a private CA, which isn't the default, so I left them off rather than mount a bundle nothing reads.

- **laminar frontend env ordering.** Its `extraEnv` already carries the keycloak vars. recursiveMerge replaces arrays rather than appending, so the CA vars live in that same list instead of a separate block.

- **What I verified.** I've deployed this to a live Replicated instance and confirmed it works there. Earlier I'd also rendered the laminar `0.2.2` subchart with the exact CA values from `replicated/openhands.yaml` and checked that app-server, app-server-consumer, and frontend each get the `openhands-ca-bundle` volume, the mount at `/etc/openhands/ca-bundle`, and the correct env var - and that app-server keeps its existing nginx-config volume.

