### PR TITLE
Expose Laminar signal LLM settings for VM installs

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1096,6 +1096,55 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "analytics_enabled" "1" }}'
           required: false
+        - name: laminar_signals_enabled
+          title: Enable Laminar Signals
+          help_text: Configure the LLM settings Laminar uses for AI features such as signals, chat-with-trace, and SQL-with-AI.
+          type: bool
+          default: "0"
+          when: 'repl{{ ConfigOptionEquals "analytics_enabled" "1" }}'
+        - name: laminar_llm_provider
+          title: Laminar LLM Provider
+          help_text: LLM provider Laminar uses for AI features.
+          type: dropdown
+          default: "openai"
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          items:
+            - name: "gemini"
+              title: "Gemini"
+            - name: "openai"
+              title: "OpenAI or OpenAI-compatible"
+            - name: "bedrock"
+              title: "AWS Bedrock"
+        - name: laminar_llm_api_key
+          title: Laminar LLM API Key
+          help_text: API key Laminar uses for Gemini, OpenAI, or OpenAI-compatible gateways. Leave blank when using Bedrock.
+          type: password
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          required: false
+        - name: laminar_llm_base_url
+          title: Laminar LLM Base URL
+          help_text: Optional base URL for an OpenAI-compatible gateway such as LiteLLM, OpenRouter, or vLLM.
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          required: false
+        - name: laminar_llm_model_small
+          title: Laminar Small Model
+          help_text: Optional model override for Laminar's small-model tier.
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          required: false
+        - name: laminar_llm_model_medium
+          title: Laminar Medium Model
+          help_text: Optional model override for Laminar's medium-model tier.
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          required: false
+        - name: laminar_llm_model_large
+          title: Laminar Large Model
+          help_text: Optional model override for Laminar's large-model tier.
+          type: text
+          when: 'repl{{ and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}'
+          required: false
 
     - name: automations_configuration
       title: Automations

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -355,6 +355,12 @@ spec:
               LMNR_FORCE_HTTP: &lmnr_force_http '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}true{{repl end }}'
               LMNR_HTTP_PORT: &lmnr_http_port '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}8000{{repl end }}'
               LMNR_PROJECT_API_KEY: &lmnr_project_api_key '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}{{repl ConfigOption "laminar_project_api_key"}}{{repl end }}'
+              LLM_PROVIDER: &laminar_llm_provider '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_provider"}}{{repl end }}'
+              LLM_API_KEY: &laminar_llm_api_key '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_api_key"}}{{repl end }}'
+              LLM_BASE_URL: &laminar_llm_base_url '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_base_url"}}{{repl end }}'
+              LLM_MODEL_SMALL: &laminar_llm_model_small '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_model_small"}}{{repl end }}'
+              LLM_MODEL_MEDIUM: &laminar_llm_model_medium '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_model_medium"}}{{repl end }}'
+              LLM_MODEL_LARGE: &laminar_llm_model_large '{{repl if and (ConfigOptionEquals "analytics_enabled" "1") (ConfigOptionEquals "laminar_signals_enabled" "1") }}{{repl ConfigOption "laminar_llm_model_large"}}{{repl end }}'
             command:
               - /usr/local/bin/openhands-agent-server
               - "--port"
@@ -399,7 +405,7 @@ spec:
     # Grouped in order: LLM provider keys; app/infra secrets (admin, postgres,
     # redis, jwt, keycloak, litellm, sandbox, plugin-directory, automation); then
     # auth/integration secrets (bitbucket DC, jira DC, github, gitlab, slack, laminar).
-    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "litellm_admin_password") (ConfigOption "litellm_salt_key") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "azure_devops_client_secret") (ConfigOption "jira_data_center_client_secret") (ConfigOption "jira_data_center_service_account_email") (ConfigOption "jira_data_center_service_account_pat") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key")) }}'
+    secretsChecksum: 'repl{{ sha256sum (printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (ConfigOption "anthropic_api_key") (ConfigOption "openai_api_key") (ConfigOption "google_gemini_api_key") (ConfigOption "deepseek_api_key") (ConfigOption "mistral_api_key") (ConfigOption "azure_api_key") (ConfigOption "azure_client_secret") (ConfigOption "groq_api_key") (ConfigOption "openrouter_api_key") (ConfigOption "aws_secret_access_key") (ConfigOption "custom_api_key") (ConfigOption "admin_password") (ConfigOption "postgres_password") (ConfigOption "redis_password") (ConfigOption "jwt_secret") (ConfigOption "keycloak_admin_password") (ConfigOption "keycloak_client_secret") (ConfigOption "litellm_api_key") (ConfigOption "litellm_admin_password") (ConfigOption "litellm_salt_key") (ConfigOption "default_api_key") (ConfigOption "sandbox_api_key") (ConfigOption "keycloak_smtp_password") (ConfigOption "plugin_directory_identity_shared_secret") (ConfigOption "plugin_directory_session_secret") (ConfigOption "automation_service_key") (ConfigOption "automation_webhook_secret") (ConfigOption "bitbucket_data_center_client_secret") (ConfigOption "bitbucket_data_center_bot_token") (ConfigOption "azure_devops_client_secret") (ConfigOption "jira_data_center_client_secret") (ConfigOption "jira_data_center_service_account_email") (ConfigOption "jira_data_center_service_account_pat") (ConfigOption "github_oauth_client_secret") (ConfigOption "github_app_webhook_secret") (ConfigOption "gitlab_oauth_client_secret") (ConfigOption "slack_client_secret") (ConfigOption "slack_signing_secret") (ConfigOption "external_postgres_password") (ConfigOption "custom_sandbox_image_registry_password") (ConfigOption "laminar_project_api_key") (ConfigOption "laminar_llm_api_key")) }}'
     bitbucketDataCenter:
       enabled: repl{{ ConfigOptionEquals "bitbucket_data_center_auth_enabled" "1" }}
       host: 'repl{{ ConfigOption "bitbucket_data_center_domain" }}'
@@ -631,6 +637,12 @@ spec:
                   LMNR_FORCE_HTTP: *lmnr_force_http
                   LMNR_HTTP_PORT: *lmnr_http_port
                   LMNR_PROJECT_API_KEY: *lmnr_project_api_key
+                  LLM_PROVIDER: *laminar_llm_provider
+                  LLM_API_KEY: *laminar_llm_api_key
+                  LLM_BASE_URL: *laminar_llm_base_url
+                  LLM_MODEL_SMALL: *laminar_llm_model_small
+                  LLM_MODEL_MEDIUM: *laminar_llm_model_medium
+                  LLM_MODEL_LARGE: *laminar_llm_model_large
                 command:
                   - /usr/local/bin/openhands-agent-server
                   - "--port"
@@ -919,6 +931,12 @@ spec:
           LMNR_FORCE_HTTP: *lmnr_force_http
           LMNR_HTTP_PORT: *lmnr_http_port
           LMNR_PROJECT_API_KEY: *lmnr_project_api_key
+          LLM_PROVIDER: *laminar_llm_provider
+          LLM_API_KEY: *laminar_llm_api_key
+          LLM_BASE_URL: *laminar_llm_base_url
+          LLM_MODEL_SMALL: *laminar_llm_model_small
+          LLM_MODEL_MEDIUM: *laminar_llm_model_medium
+          LLM_MODEL_LARGE: *laminar_llm_model_large
         laminar:
           enabled: true
           httpPort: 8000


### PR DESCRIPTION
## Summary
- Add Replicated Admin Console fields for enabling Laminar signals and configuring Laminar `LLM_*` settings
- Wire the configured `LLM_PROVIDER`, `LLM_API_KEY`, `LLM_BASE_URL`, and model-tier values into OpenHands and warm runtime env
- Include the new Laminar LLM API key in `secretsChecksum` so Admin Console secret updates roll the OpenHands pod

## Testing
- `git diff --check`
- `uv run --with pyyaml python scripts/check_secret_checksum.py`
- `PATH=/tmp/darwin-arm64:$PATH uv run --with pytest --with pyyaml pytest -q scripts/test_openhands_secrets_template.py scripts/test_keycloak_realm_template.py`
- `PATH=/tmp/darwin-arm64:$PATH helm lint charts/openhands`
- `PATH=/tmp/darwin-arm64:$PATH helm template charts/openhands --debug >/tmp/openhands-default-rendered.yaml`
- `PATH=/tmp/darwin-arm64:$PATH helm template openhands charts/openhands --set laminar.enabled=true --set env.LLM_PROVIDER=openai --set env.LLM_API_KEY=test-key --set env.LLM_BASE_URL=https://llm-proxy.example.com --set env.LLM_MODEL_SMALL=gpt-small --set env.LLM_MODEL_MEDIUM=gpt-medium --set env.LLM_MODEL_LARGE=gpt-large >/tmp/openhands-signals-rendered.yaml`
