### PR TITLE
fix(integrations-hub): align chart env vars with INTHUB_*-only backend

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.39.0
-version: 0.7.76
+version: 0.7.77
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -2,25 +2,25 @@
   Environment variables consumed by the Integrations Hub backend
   (Python/FastAPI on the `development` branch of OpenHands/integrations-hub).
 
-  The backend reads its config in backend/app/config.py using the prefix
-  `INTHUB_*`, with legacy unprefixed fallbacks for backwards compatibility:
+  The backend reads its config in backend/app/config.py using the `INTHUB_*`
+  prefix only. Legacy unprefixed fallbacks were removed in
+  OpenHands/integrations-hub#264, so every variable below uses the prefixed
+  name:
 
-    INTHUB_POSTGRES_URL              fallback: POSTGRES_URL, DATABASE_URL
+    INTHUB_POSTGRES_URL              (built from database.* below, or database.url)
     INTHUB_DISABLE_AUTH              (bool, defaults to false)
-    INTHUB_OPENHANDS_BASE_URL        fallback: OPENHANDS_BASE_URL
-    INTHUB_OPENHANDS_AUTH_COOKIE_NAME  fallback: OPENHANDS_AUTH_COOKIE_NAME
-    INTHUB_INTERNAL_AUTH_SECRET      fallback: INTERNAL_AUTH_SECRET, AUTH_SECRET, NEXTAUTH_SECRET
-    INTHUB_CRON_SECRET               fallback: CRON_SECRET
-    APP_ADMIN_EMAILS                 (use the unprefixed name; the prefixed
-                                      form is JSON-decoded by the SDK env
-                                      parser and would require list syntax)
-    INTHUB_CREDENTIAL_ENCRYPTION_KEY fallback: CREDENTIAL_ENCRYPTION_KEY
+    INTHUB_OPENHANDS_BASE_URL
+    INTHUB_OPENHANDS_AUTH_COOKIE_NAME
+    INTHUB_INTERNAL_AUTH_SECRET
+    INTHUB_CRON_SECRET
+    INTHUB_APP_ADMIN_EMAILS          (comma-separated; JSON array also accepted)
+    INTHUB_CREDENTIAL_ENCRYPTION_KEY
     INTHUB_STATIC_DIR                set in the Dockerfile to /app/out
     INTHUB_ROOT_PATH                 sub-path mount from .Values.rootPath
 
   In addition, backend/app/oauth_flow.py reads:
-    AUTH_REDIRECT_PROXY_URL          stable origin for OAuth callback proxy
-    AUTH_URL / NEXTAUTH_URL          preview-deployment callback target
+    INTHUB_OAUTH_REDIRECT_PROXY_URL  stable origin for OAuth callback proxy
+    AUTH_URL                         preview-deployment callback target
 */}}
 {{- define "integrations-hub.env.defaults" }}
 # Database connection -- backend reads INTHUB_POSTGRES_URL first; we build
@@ -102,11 +102,10 @@
       key: {{ .Values.auth.internalSecretKey | default "internal-auth-secret" }}
 {{- end }}
 
-# Admin allowlist for /api/admin/* routes. Use the unprefixed name --
-# INTHUB_APP_ADMIN_EMAILS goes through the SDK env parser which expects
-# JSON list syntax.
+# Admin allowlist for /api/admin/* routes. The backend reads
+# INTHUB_APP_ADMIN_EMAILS and accepts comma-separated (or JSON array) syntax.
 {{- if .Values.admin.emails }}
-- name: APP_ADMIN_EMAILS
+- name: INTHUB_APP_ADMIN_EMAILS
   value: {{ .Values.admin.emails | quote }}
 {{- end }}
 
@@ -121,7 +120,7 @@
 # callbacks register/exchange against the stable origin and then forward
 # back to the preview deployment captured in OAuth state.
 {{- if .Values.openhands.redirectProxyUrl }}
-- name: AUTH_REDIRECT_PROXY_URL
+- name: INTHUB_OAUTH_REDIRECT_PROXY_URL
   value: {{ .Values.openhands.redirectProxyUrl | quote }}
 {{- end }}
 {{- if .Values.openhands.authUrl }}

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -78,10 +78,9 @@ openhands:
   # Backend env var: INTHUB_OPENHANDS_AUTH_COOKIE_NAME
   authCookieName: "keycloak_auth"
   # Stable-origin URL used as the OAuth callback proxy for preview
-  # deployments (mirrors the AUTH_REDIRECT_PROXY_URL pattern used by
-  # Auth.js on Vercel). Leave empty to register callbacks against the
+  # deployments. Leave empty to register callbacks against the
   # request host directly.
-  # Backend env var: AUTH_REDIRECT_PROXY_URL
+  # Backend env var: INTHUB_OAUTH_REDIRECT_PROXY_URL
   redirectProxyUrl: ""
   # Optional callback target for preview deployments; used when
   # redirectProxyUrl is set and oauth_flow.py needs to forward back to
@@ -107,7 +106,7 @@ auth:
   internalSecretKey: "internal-auth-secret"
 
 # Admin configuration
-# Backend env var: APP_ADMIN_EMAILS (comma-separated)
+# Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted)
 admin:
   # Comma-separated list of admin email addresses.
   emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1131,7 +1131,7 @@ integrations-hub:
     # Backend env var: INTHUB_OPENHANDS_AUTH_COOKIE_NAME
     authCookieName: "keycloak_auth"
     # Stable-origin URL used as the OAuth callback proxy for preview
-    # deployments. Backend env var: AUTH_REDIRECT_PROXY_URL.
+    # deployments. Backend env var: INTHUB_OAUTH_REDIRECT_PROXY_URL.
     redirectProxyUrl: ""
     # Optional callback target for preview deployments paired with
     # redirectProxyUrl. Backend env var: AUTH_URL.
@@ -1152,7 +1152,7 @@ integrations-hub:
     internalSecretKey: "internal-auth-secret"
 
   # Admin allowlist for /api/admin/* routes.
-  # Backend env var: APP_ADMIN_EMAILS (comma-separated).
+  # Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted).
   admin:
     emails: ""
 


### PR DESCRIPTION
## Summary

Companion to **OpenHands/integrations-hub#264**, which removed the legacy unprefixed env-var fallbacks from the FastAPI backend. After #264 the backend reads **only** the `INTHUB_*`-prefixed names. This chart had two env vars still on the old unprefixed names, so they would silently stop being read once #264 lands.

> _This PR was created by an AI agent (OpenHands) on behalf of Graham Neubig._

## Changes

### `APP_ADMIN_EMAILS` → `INTHUB_APP_ADMIN_EMAILS` *(required by #264)*
The admin allowlist would have gone **empty** after #264, locking out `/api/admin/*` access in Kubernetes deployments. The backend now accepts **comma-separated** syntax for the prefixed name (the parser in `backend/app/config.py::_parse_email_list` also accepts JSON arrays), so the old chart comment — *"use the unprefixed name; the prefixed form is JSON-decoded by the SDK env parser and would require list syntax"* — is obsolete and removed.

### `AUTH_REDIRECT_PROXY_URL` → `INTHUB_OAUTH_REDIRECT_PROXY_URL` *(pre-existing mismatch)*
`backend/app/oauth_flow.py` already reads the **prefixed** name (`INTHUB_OAUTH_REDIRECT_PROXY_URL`), so the chart's unprefixed `AUTH_REDIRECT_PROXY_URL` was never wired through — the OAuth callback proxy was a no-op whenever this chart set it. Fixed here while aligning the rest of the chart with the `INTHUB_*`-only backend. (`AUTH_URL` stays unprefixed — the backend reads it unprefixed.)

### Docs
- Refreshed the header doc block in `templates/_env.yaml` to drop the removed fallback chain and list the canonical `INTHUB_*` names.
- Refreshed the matching comments in the subchart `values.yaml` and the parent `charts/openhands/values.yaml`.

## Verification
- `values.yaml` (subchart + parent) parse cleanly (`yaml.safe_load`).
- No remaining unprefixed `APP_ADMIN_EMAILS` / `AUTH_REDIRECT_PROXY_URL` references in the integrations-hub chart or parent values.
- CI (`preview-helm-charts.yml`) will render the templates.

## Deployment note
This should land **together with** (or after) integrations-hub#264. Landing #264 without this chart update would empty the admin allowlist in K8s.

## Related
- OpenHands/integrations-hub#264 — remove legacy env-var fallbacks + unify to `INTHUB_*`

## Issue

Closes #757
