### PR TITLE
chore(charts): bump enterprise-server to cloud-1.40.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.39.0
-version: 0.7.79
+appVersion: cloud-1.40.0
+version: 0.7.80
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -159,7 +159,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.39.0
+  tag: cloud-1.40.0
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Description

Routine bump of the enterprise-server image to the latest release, `cloud-1.40.0`. Updates `appVersion` and the `image.tag` in the openhands chart, and bumps the chart `version` to `0.7.80`.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Version-only change, no values schema changes. I haven't tested the upgrade path locally.