### PR TITLE
ci: require opt-in flag for make release on main/Unstable

### DIFF
--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
-        run: make release
+        run: make release ALLOW_MAIN_RELEASE=1

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,16 @@ CHART_YAMLS := $(shell find $(CHARTDIR) -name 'Chart.yaml')
 # Release metadata: version comes from the openhands chart, channel from the current git branch
 VERSION     ?= $(shell yq .version $(CHARTDIR)/openhands/Chart.yaml)
 REPLICATED_APP ?= openhands
-CHANNEL     := $(shell git branch --show-current)
+BRANCH      := $(shell git branch --show-current)
+CHANNEL     := $(BRANCH)
 ifeq ($(CHANNEL), main)
 	CHANNEL=Unstable
 endif
+
+# Guard: releasing from the main branch (which maps to the Unstable channel)
+# or to the Unstable channel directly is reserved for CI. Require an explicit
+# opt-in flag so a human can't accidentally publish local work to Unstable.
+ALLOW_MAIN_RELEASE ?=
 
 BUILDDIR      := $(PROJECTDIR)/build
 RELEASE_FILES :=
@@ -92,9 +98,19 @@ clean:
 lint: clean $(RELEASE_FILES)
 	replicated release lint --yaml-dir $(BUILDDIR)
 
+# Refuse to release from main or to the Unstable channel unless explicitly
+# allowed via ALLOW_MAIN_RELEASE=1. CI passes this flag; humans should not.
+.PHONY: check-release-guard
+check-release-guard:
+	@if [ -z "$(ALLOW_MAIN_RELEASE)" ] && { [ "$(BRANCH)" = "main" ] || [ "$(CHANNEL)" = "Unstable" ]; }; then \
+		echo "ERROR: refusing to release from 'main' or to the 'Unstable' channel (branch=$(BRANCH) channel=$(CHANNEL))."; \
+		echo "       This is reserved for CI. If you really mean to do this, re-run with ALLOW_MAIN_RELEASE=1."; \
+		exit 1; \
+	fi
+
 # Build everything, lint, then publish a release to the Replicated channel
 .PHONY: release
-release: clean $(RELEASE_FILES) lint
+release: check-release-guard clean $(RELEASE_FILES) lint
 	replicated release create \
 	 	--app $(REPLICATED_APP) \
 		--version $(VERSION) \


### PR DESCRIPTION
## Description

`make release` derives its channel from the current git branch, and `main` maps to `Unstable`. So anyone running `make release` locally while on `main` (or with `CHANNEL=Unstable`) publishes straight to the Unstable channel. That's only ever supposed to happen from CI on a push to `main` - a human doing it by accident clobbers the channel with local, possibly uncommitted work.

This adds a guard that refuses to release from `main` or to the `Unstable` channel unless you explicitly opt in with `ALLOW_MAIN_RELEASE=1`. The `release-replicated` workflow passes that flag, so CI keeps working as the sanctioned path.

The guard runs as the first prerequisite of `release`, so it fails fast before any clean/build/lint/publish work happens.

## Helm Chart Checklist

N/A - no Helm charts modified.

- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

I kept the opt-in as a make variable (`ALLOW_MAIN_RELEASE=1`) rather than a `--flag`, since make reserves `--options` for itself and can't take a custom dashed flag without a wrapper.

The guard checks both conditions the user cares about: the raw branch being `main`, and the resolved channel being `Unstable` (which also catches a manual `CHANNEL=Unstable` override from any branch).

Verified locally:
- normal branch -> passes the guard
- `main` / `Unstable`, no flag -> fails before build or publish (no `build/` dir created)
- either case with `ALLOW_MAIN_RELEASE=1` -> passes