### PR TITLE
feat(charts): map-based warm runtimes + global agent-server image

### DIFF
--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -27,14 +27,14 @@ jobs:
           # Extract image tags from chart values using yq
           RUNTIME_API_TAG=$(yq '.image.tag' charts/openhands/charts/runtime-api/values.yaml)
           ENTERPRISE_TAG=$(yq '.image.tag' charts/openhands/values.yaml)
-          RUNTIME_TAG=$(yq '.runtime.image.tag' charts/openhands/values.yaml)
+          AGENT_SERVER_TAG=$(yq '.global.agentServerImage.tag' charts/openhands/values.yaml)
 
           # Build the image list as JSON array
           IMAGES=$(jq -n -c \
             --arg runtime_api "openhands/runtime-api:${RUNTIME_API_TAG}" \
             --arg enterprise "openhands/enterprise-server:${ENTERPRISE_TAG}" \
-            --arg runtime "openhands/agent-server:${RUNTIME_TAG}" \
-            '[$runtime_api, $enterprise, $runtime]')
+            --arg agent_server "openhands/agent-server:${AGENT_SERVER_TAG}" \
+            '[$runtime_api, $enterprise, $agent_server]')
 
           echo "images=${IMAGES}" >> $GITHUB_OUTPUT
           echo "Discovered images: ${IMAGES}"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.40.0
-version: 0.7.81
+version: 0.7.82
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.40.0
-version: 0.7.80
+version: 0.7.81
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
@@ -13,6 +13,8 @@
 {{- $configs = append $configs (merge (dict "name" $name) $config) }}
 {{- end }}
 {{- end }}
+{{- /* Default image for any entry that omits one: the global agent-server image. */ -}}
+{{- $agentServerImage := printf "%s:%s" .Values.global.agentServerImage.repository .Values.global.agentServerImage.tag }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,7 +30,7 @@ data:
         {{- if $index }},{{ end }}
         {
           "name": {{ $config.name | quote }},
-          "image": {{ $config.image | quote }},
+          "image": {{ $config.image | default $agentServerImage | quote }},
           "working_dir": {{ $config.working_dir | quote }},
           {{- with $config.count }}
           "count": {{ $config.count }},

--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
@@ -1,4 +1,18 @@
 {{- if .Values.warmRuntimes.enabled }}
+{{- /*
+  Normalize warm-runtime configs into a list of entries. The legacy list form
+  (.configs) wins when non-empty, for backwards compatibility; otherwise the map
+  form (.configsByName) is used, promoting each key to the entry's "name".
+  Prefer the map: maps merge cleanly across values layers, so a consumer can
+  override one field of one entry without re-declaring the whole list.
+*/ -}}
+{{- $configs := .Values.warmRuntimes.configs }}
+{{- if not $configs }}
+{{- $configs = list }}
+{{- range $name, $config := .Values.warmRuntimes.configsByName }}
+{{- $configs = append $configs (merge (dict "name" $name) $config) }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +24,7 @@ data:
     {
       "count": {{ .Values.warmRuntimes.count }},
       "configs": [
-        {{- range $index, $config := .Values.warmRuntimes.configs }}
+        {{- range $index, $config := $configs }}
         {{- if $index }},{{ end }}
         {
           "name": {{ $config.name | quote }},

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -261,7 +261,7 @@ warmRuntimes:
   # override one field of one entry without re-declaring every entry.
   configsByName:
     default:
-      image: "ghcr.io/openhands/agent-server:1.29.0-python"
+      # image omitted -> defaults to global.agentServerImage (repo:tag).
       working_dir: "/workspace"
       environment:
         # LMNR_* mirror the always-emit request env (="" when Laminar off) so warm matching succeeds.
@@ -321,3 +321,9 @@ global:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267
     allowInsecureImages: true
+  # Canonical agent-server image. Defaults any warm-runtime configsByName entry
+  # that omits its own `image`. In the openhands umbrella the parent chart's
+  # global wins; this default only applies when rendering the subchart alone.
+  agentServerImage:
+    repository: ghcr.io/openhands/agent-server
+    tag: 1.29.0-python

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -253,8 +253,14 @@ warmRuntimes:
   enabled: false
   configMapName: warm-runtimes-config
   count: 0
-  configs:
-    - name: default
+  # Legacy list form. Kept for backwards compatibility: when non-empty it takes
+  # precedence over configsByName. Prefer configsByName for new configuration.
+  configs: []
+  # Canonical map form. Each key is the config's name (promoted to "name" in the
+  # rendered JSON). Maps merge cleanly across values layers, so consumers can
+  # override one field of one entry without re-declaring every entry.
+  configsByName:
+    default:
       image: "ghcr.io/openhands/agent-server:1.29.0-python"
       working_dir: "/workspace"
       environment:

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -75,9 +75,9 @@
 - name: NO_SETUP
   value: 'true'
 - name: AGENT_SERVER_IMAGE_REPOSITORY
-  value: "{{ .Values.runtime.image.repository }}"
+  value: "{{ .Values.runtime.image.repository | default .Values.global.agentServerImage.repository }}"
 - name: AGENT_SERVER_IMAGE_TAG
-  value: "{{ .Values.runtime.image.tag }}"
+  value: "{{ .Values.runtime.image.tag | default .Values.global.agentServerImage.tag }}"
 - name: SANDBOX_REMOTE_RUNTIME_API_URL
   value: {{ .Values.sandbox.apiHostname }}
 - name: SANDBOX_API_KEY

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -672,8 +672,10 @@ runtime-api:
   warmRuntimes:
     enabled: true
     count: 1
-    configs:
-      - name: default
+    # Map form keyed by config name; see runtime-api subchart values for the
+    # legacy `configs` list and precedence rules.
+    configsByName:
+      default:
         image: "ghcr.io/openhands/agent-server:1.29.0-python"
         working_dir: "/workspace"
         environment:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -254,9 +254,10 @@ resendSync:
       cpu: 200m
 
 runtime:
+  # repository/tag fall back to .Values.global.agentServerImage when left empty.
   image:
-    repository: ghcr.io/openhands/agent-server
-    tag: 1.29.0-python
+    repository: ""
+    tag: ""
 
 sandbox:
   # REQUIRED: Update so this matches what you have set in the runtime api ingress
@@ -676,7 +677,7 @@ runtime-api:
     # legacy `configs` list and precedence rules.
     configsByName:
       default:
-        image: "ghcr.io/openhands/agent-server:1.29.0-python"
+        # image omitted -> defaults to global.agentServerImage (repo:tag).
         working_dir: "/workspace"
         environment:
           # LMNR_* mirror the always-emit request env (="" when Laminar off) so warm matching succeeds.
@@ -996,6 +997,12 @@ global:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267
     allowInsecureImages: true
+  # Canonical agent-server image. Defaults the runtime image (runtime.image) and
+  # any warm-runtime configsByName entry that omits its own `image`. Override
+  # either of those for per-use exceptions; set it here to move them together.
+  agentServerImage:
+    repository: ghcr.io/openhands/agent-server
+    tag: 1.29.0-python
 
 vertexAI:
   enabled: false

--- a/docs/automated-image-tag-bumps.md
+++ b/docs/automated-image-tag-bumps.md
@@ -110,7 +110,7 @@ A ready-to-copy version is in
 | `component` | yes | — | Used in the branch, PR title, and commit message. |
 | `chart_file` | yes | — | YAML file to edit, relative to the chart repo root. |
 | `tag` | yes | — | New image tag to set. Must match the tag you pushed. |
-| `image_tag_path` | no | `.image.tag` | yq-style path to the tag scalar. Supports nested keys and list indices, e.g. `.warmRuntimes.configs[0].image`. |
+| `image_tag_path` | no | `.image.tag` | yq-style path to the tag scalar. Supports nested keys, e.g. `.warmRuntimes.configsByName.default.image`, and list indices, e.g. `.containers[0].image`. |
 | `base_branch` | no | `main` | Branch to open the PR against. |
 | `chart_repo` | no | `OpenHands/OpenHands-Cloud` | Repo to update, `owner/name`. |
 | `pr_branch` | no | `bump-image-tag/<component>` | Head branch. The default rolls a single open PR per component, advancing it to the latest tag. Set something tag-specific (e.g. `bump-image-tag/runtime-api/${{ needs.prepare-tag.outputs.tag }}`) to get one PR per release. |

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -14,6 +14,13 @@ spec:
       imageRegistry: 'images.r9.all-hands.dev'
       imagePullSecrets:
         - '{{repl ImagePullSecretName }}'
+      # Canonical agent-server image. runtime.image and every warmRuntimes
+      # configsByName entry fall back to this, so the proxy / custom-sandbox /
+      # local-registry variants only override the repository (and tag, for the
+      # admin-supplied custom image). The default tag is pinned in the chart's
+      # global.agentServerImage.
+      agentServerImage:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
@@ -83,10 +90,6 @@ spec:
       enabled: true
       env: '{{repl Namespace }}'
 
-    runtime:
-      image:
-        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
-        # Do not override the image tag here. Pin to a stable version in the chart.
     keycloak:
       enabled: true
       url: 'http://keycloak'
@@ -323,9 +326,11 @@ spec:
       warmRuntimes:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
-        configs:
-          - name: default
-            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.29.0-python{{repl end}}'
+        configsByName:
+          default:
+            # image omitted -> inherits global.agentServerImage. Proxy by
+            # default; when custom_sandbox_image_enabled / HasLocalRegistry are
+            # active, the optionalValues blocks below override the global instead.
             working_dir: "/workspace"
             environment:
               LOG_JSON: "1"
@@ -590,8 +595,8 @@ spec:
     - when: '{{repl ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
       recursiveMerge: true
       values:
-        runtime:
-          image:
+        global:
+          agentServerImage:
             repository: 'repl{{ ConfigOption "custom_sandbox_image_repository" }}'
             tag: 'repl{{ ConfigOption "custom_sandbox_image_tag" }}'
     - when: '{{repl HasLocalRegistry }}'
@@ -599,46 +604,12 @@ spec:
       values:
         global:
           imageRegistry: '{{repl LocalRegistryHost }}'
+          # agent-server comes from the local registry; runtime.image and the
+          # warmRuntimes default entry both inherit this. Tag pinned in the chart.
+          agentServerImage:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
         image:
           repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/deploy'
-        runtime:
-          image:
-            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            # Do not override the image tag here. Pin to a stable version in the chart.
-          warmRuntimes:
-            configs:
-              - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.29.0-python'
-                working_dir: "/workspace"
-                environment:
-                  LOG_JSON: "1"
-                  LOG_JSON_LEVEL_KEY: "severity"
-                  OH_ALLOW_CORS_ORIGINS_0: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
-                  OH_BASH_EVENTS_DIR: "/workspace/bash_events"
-                  OH_CONVERSATIONS_PATH: "/workspace/conversations"
-                  OH_ENABLE_VNC: "0"
-                  OH_VSCODE_PORT: "60001"
-                  OH_WEBHOOKS_0_BASE_URL: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}/api/v1/webhooks'
-                  OPENVSCODE_SERVER_ROOT: "/openhands/.openvscode-server"
-                  VSCODE_PORT: "60001"
-                  WORKER_1: "12000"
-                  WORKER_2: "12001"
-                  CURL_CA_BUNDLE: "/etc/openhands/ca-bundle/ca-bundle.crt"
-                  GIT_SSL_CAINFO: "/etc/openhands/ca-bundle/ca-bundle.crt"
-                  NODE_EXTRA_CA_CERTS: "/etc/openhands/ca-bundle/ca-bundle.crt"
-                  REQUESTS_CA_BUNDLE: "/etc/openhands/ca-bundle/ca-bundle.crt"
-                  SSL_CERT_FILE: "/etc/openhands/ca-bundle/ca-bundle.crt"
-                  LMNR_BASE_URL: *lmnr_base_url
-                  LMNR_FORCE_HTTP: *lmnr_force_http
-                  LMNR_HTTP_PORT: *lmnr_http_port
-                  LMNR_PROJECT_API_KEY: *lmnr_project_api_key
-                command:
-                  - /usr/local/bin/openhands-agent-server
-                  - "--port"
-                  - "60000"
-                run_as_user: 10001
-                run_as_group: 10001
-                fs_group: 10001
         keycloak:
           image:
             repository: '{{repl LocalRegistryNamespace }}/keycloak'

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -326,7 +326,12 @@ appVersion: "1.0.0"
 
 @pytest.fixture
 def sample_openhands_values_full():
-    """Sample openhands values.yaml with all image tags."""
+    """Sample openhands values.yaml.
+
+    The agent-server image lives once in global.agentServerImage; runtime.image
+    and the warmRuntimes configsByName entry omit it and fall back to the global,
+    mirroring the real chart.
+    """
     return """\
 allowedUsers: null
 
@@ -336,8 +341,8 @@ image:
 
 runtime:
   image:
-    repository: ghcr.io/openhands/agent-server
-    tag: 1.0.0-python
+    repository: ""
+    tag: ""
   runAsRoot: true
 
 runtime-api:
@@ -346,38 +351,43 @@ runtime-api:
   warmRuntimes:
     enabled: true
     count: 1
-    configs:
-      - name: default
-        image: "ghcr.io/openhands/agent-server:1.0.0-python"
+    configsByName:
+      default:
         working_dir: "/openhands/code/"
+
+global:
+  agentServerImage:
+    repository: ghcr.io/openhands/agent-server
+    tag: 1.0.0-python
 """
 
 
 @pytest.fixture
 def sample_openhands_values_minimal():
-    """Minimal openhands values.yaml for dry-run tests."""
+    """Minimal openhands values.yaml for dry-run tests.
+
+    Carries the two tags update_openhands_values touches: the enterprise-server
+    image tag and the global agent-server image tag.
+    """
     return """\
 image:
   repository: ghcr.io/openhands/enterprise-server
   tag: cloud-1.0.0
 
-runtime:
-  image:
+global:
+  agentServerImage:
     repository: ghcr.io/openhands/agent-server
     tag: 1.0.0-python
-
-runtime-api:
-  enabled: true
-  warmRuntimes:
-    configs:
-      - name: default
-        image: "ghcr.io/openhands/agent-server:1.0.0-python"
 """
 
 
 @pytest.fixture
 def sample_runtime_api_values():
-    """Sample runtime-api values.yaml."""
+    """Sample runtime-api values.yaml.
+
+    The subchart carries its own global.agentServerImage default; the warmRuntimes
+    configsByName entry omits its image and falls back to it.
+    """
     return """\
 nameOverride: ""
 fullnameOverride: ""
@@ -393,11 +403,15 @@ warmRuntimes:
   enabled: false
   configMapName: warm-runtimes-config
   count: 0
-  configs:
-    - name: default
-      image: "ghcr.io/openhands/agent-server:1.0.0-python"
+  configsByName:
+    default:
       working_dir: "/openhands/code/"
       environment: {}
+
+global:
+  agentServerImage:
+    repository: ghcr.io/openhands/agent-server
+    tag: 1.0.0-python
 """
 
 

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -38,7 +38,7 @@ import base64
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 from ruamel.yaml import YAML
@@ -416,28 +416,6 @@ global:
 
 
 @pytest.fixture
-def sample_automation_values():
-    """Sample automation values.yaml."""
-    return """\
-image:
-  repository: ghcr.io/openhands/automation
-  tag: sha-c58faa1
-
-imagePullSecrets: []
-
-deployment:
-  replicas: 1
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 100m
-    limits:
-      memory: 512Mi
-      cpu: 500m
-"""
-
-
-@pytest.fixture
 def sample_image_loader_values():
     """Sample image-loader values.yaml with the agent-server image pre-loaded on nodes."""
     return """\
@@ -618,7 +596,7 @@ def stub_latest_cloud_tag(monkeypatch):
 def stub_process_updates_chain(monkeypatch):
     """Factory fixture for stubbing the call chain inside process_updates().
 
-    Defaults give a fully-successful chain up to the deploy-config fetch.
+    Defaults give a fully-successful chain through the agent-server tag fetch.
     Pass None to any kwarg to simulate that step failing — this triggers the
     corresponding early-return guard so tests can verify downstream calls
     are skipped.
@@ -651,15 +629,16 @@ def stub_process_updates_chain(monkeypatch):
 
 @pytest.fixture
 def make_workflow_response():
-    """Factory fixture for creating mock GitHub API responses with workflow content.
+    """Factory fixture for creating mock GitHub API responses with file content.
 
     Returns a function that creates a mock response object with base64-encoded
-    YAML content. Use this to test get_deploy_config with various workflow
-    configurations without repeating the mock setup boilerplate.
+    content, mirroring the GitHub "get repository content" API. Use this to test
+    functions that fetch and decode a file from GitHub without repeating the mock
+    setup boilerplate.
 
     Usage:
         def test_something(make_workflow_response, monkeypatch):
-            response = make_workflow_response("env:\\n  RUNTIME_API_SHA: abc123")
+            response = make_workflow_response("AGENT_SERVER_IMAGE = 'x:1.2.3'")
             monkeypatch.setattr("update_openhands_charts.requests.get",
                                MagicMock(return_value=response))
             # ... test code ...
@@ -672,54 +651,6 @@ def make_workflow_response():
         return mock_response
 
     return _make_response
-
-
-# =============================================================================
-# Mock response helpers for get_deploy_config error path tests
-# These plain functions (not fixtures) are used inside @pytest.mark.parametrize
-# decorators, which are evaluated at class scope where fixtures cannot be
-# injected. They centralize mock-response construction for error scenarios.
-# =============================================================================
-
-def make_http_error_response(status_code: int, message: str) -> Mock:
-    """Create a mock requests.get that raises an exception on raise_for_status()."""
-    mock_response = Mock()
-    mock_response.status_code = status_code
-    mock_response.raise_for_status.side_effect = Exception(f"HTTP {status_code}: {message}")
-    return Mock(return_value=mock_response)
-
-
-def make_json_error_response() -> Mock:
-    """Create a mock requests.get whose .json() call raises an exception."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.json.side_effect = Exception("Invalid JSON")
-    return Mock(return_value=mock_response)
-
-
-def make_missing_key_response(json_data: dict) -> Mock:
-    """Create a mock requests.get returning JSON with the given (possibly incomplete) data."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.json.return_value = json_data
-    return Mock(return_value=mock_response)
-
-
-def make_invalid_base64_response(invalid_content: str) -> Mock:
-    """Create a mock requests.get returning JSON with malformed base64 content."""
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.json.return_value = {"content": invalid_content}
-    return Mock(return_value=mock_response)
-
-
-def make_invalid_yaml_response(invalid_yaml: str) -> Mock:
-    """Create a mock requests.get returning valid base64 but invalid YAML content."""
-    encoded = base64.b64encode(invalid_yaml.encode()).decode()
-    mock_response = Mock()
-    mock_response.raise_for_status = Mock()
-    mock_response.json.return_value = {"content": encoded}
-    return Mock(return_value=mock_response)
 
 
 @pytest.fixture

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -496,46 +496,6 @@ spec:
 """
 
 
-@pytest.fixture
-def sample_replicated_openhands_wrapper_values():
-    """Sample replicated openhands wrapper YAML with agent-server image references.
-
-    The proxy block wraps its agent-server repository/tag/image refs in the
-    custom_sandbox_image_enabled KOTS conditional, mirroring the real
-    replicated/openhands.yaml: when the toggle is on an admin-supplied
-    repository/tag takes over, otherwise the Replicated-proxied image is used.
-    The proxy URL therefore no longer sits flush against the opening quote.
-
-    A commented-out alternate repository line sits between repository: and tag:
-    to exercise the pattern's tolerance of interleaved comments.
-    """
-    return """\
-spec:
-  values:
-    runtime:
-      image:
-        # this is what we need to use for real deployments
-        repository: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server{{repl end}}'
-        # repository: 'ghcr.io/openhands/agent-server'
-        tag: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}1.19.0-python{{repl end}}'
-      warmRuntimes:
-        configs:
-          - name: default
-            image: '{{repl if ConfigOptionEquals "custom_sandbox_image_enabled" "1"}}{{repl ConfigOption "custom_sandbox_image_repository"}}:{{repl ConfigOption "custom_sandbox_image_tag"}}{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server:1.19.0-python{{repl end}}'
-    helmChart:
-      values:
-        runtime:
-          image:
-            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
-            tag: '1.19.0-python'
-          warmRuntimes:
-            configs:
-              - name: default
-                image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.19.0-python'
-"""
-
-
-
 # =============================================================================
 # GitHub API mock fixtures
 # =============================================================================
@@ -802,23 +762,21 @@ def mock_github_ref(monkeypatch):
 
 @pytest.fixture
 def openhands_workflow_mocks(monkeypatch):
-    """Patch the four inner functions called by update_openhands_workflow.
+    """Patch the three inner functions called by update_openhands_workflow.
 
     Returns a namespace exposing each MagicMock by name (`.values`,
-    `.replicated`, `.replicated_config`, `.chart`) so each workflow-contract
-    test asserts on the calls it focuses on without depending on a positional
-    return shape. The values mock reports has_changes=True so the chart-bump
-    path is exercised; the others return a no-change UpdateResult and exist to
-    prevent writes to the real files.
+    `.replicated_config`, `.chart`) so each workflow-contract test asserts on
+    the calls it focuses on without depending on a positional return shape. The
+    values mock reports has_changes=True so the chart-bump path is exercised;
+    the others return a no-change UpdateResult and exist to prevent writes to
+    the real files.
     """
     mocks = SimpleNamespace(
         values=MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True)),
-        replicated=MagicMock(return_value=update_openhands_charts.UpdateResult()),
         replicated_config=MagicMock(return_value=update_openhands_charts.UpdateResult()),
         chart=MagicMock(return_value=update_openhands_charts.UpdateResult()),
     )
     monkeypatch.setattr("update_openhands_charts.update_openhands_values", mocks.values)
-    monkeypatch.setattr("update_openhands_charts.update_replicated_openhands_values", mocks.replicated)
     monkeypatch.setattr("update_openhands_charts.update_replicated_config", mocks.replicated_config)
     monkeypatch.setattr("update_openhands_charts.update_openhands_chart", mocks.chart)
     return mocks

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -63,7 +63,6 @@ from update_openhands_charts import (
     update_openhands_values,
     update_openhands_workflow,
     update_replicated_config,
-    update_replicated_openhands_values,
     update_runtime_api_values,
     update_runtime_api_workflow,
     update_automation_workflow,
@@ -1120,83 +1119,6 @@ serviceAccount:
 
 
 
-class TestUpdateReplicatedOpenhandsValues:
-    """Tests for replicated/openhands.yaml agent-server image updates."""
-
-    @pytest.fixture
-    def temp_replicated_wrapper_file(self, make_temp_yaml_file, sample_replicated_openhands_wrapper_values):
-        """Create a temporary replicated wrapper YAML file."""
-        return make_temp_yaml_file(sample_replicated_openhands_wrapper_values)
-
-    @pytest.mark.parametrize("expected_content", [
-        pytest.param(
-            "tag: '{{repl if ConfigOptionEquals \"custom_sandbox_image_enabled\" \"1\"}}{{repl ConfigOption \"custom_sandbox_image_tag\"}}{{repl else}}1.19.1-python{{repl end}}'",
-            id="proxy runtime tag (conditional preserved)",
-        ),
-        pytest.param(
-            "{{repl else}}images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue \"appSlug\"}}/ghcr.io/openhands/agent-server:1.19.1-python{{repl end}}'",
-            id="proxy warmRuntimes image (conditional preserved)",
-        ),
-        pytest.param(
-            "tag: '1.19.1-python'",
-            id="local registry tag",
-        ),
-        pytest.param(
-            "image: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server:1.19.1-python'",
-            id="local registry image",
-        ),
-    ])
-    def test_replicated_wrapper_file_content_updated(self, temp_replicated_wrapper_file, expected_content):
-        """Test that each agent-server tag location in the replicated wrapper file is updated."""
-        update_replicated_openhands_values(
-            temp_replicated_wrapper_file,
-            runtime_image_tag="1.19.1-python",
-        )
-
-        assert_file_contains(temp_replicated_wrapper_file, expected_content)
-
-    @pytest.mark.parametrize("change_key", [
-        "replicated runtime image tag",
-        "replicated warmRuntimes image tag",
-        "replicated local registry runtime image tag",
-        "replicated local registry warmRuntimes image tag",
-    ])
-    def test_result_records_replicated_wrapper_change(self, temp_replicated_wrapper_file, change_key):
-        """Test that each replicated wrapper tag key is recorded as changed in the result."""
-        result = update_replicated_openhands_values(
-            temp_replicated_wrapper_file,
-            runtime_image_tag="1.19.1-python",
-        )
-
-        assert result.has_change_for(change_key)
-
-    @pytest.fixture
-    def reapplied_replicated_wrapper_result(self, temp_replicated_wrapper_file):
-        """Apply identical replicated wrapper values twice and return the second-call UpdateResult."""
-        update_replicated_openhands_values(
-            temp_replicated_wrapper_file,
-            runtime_image_tag="1.19.1-python",
-        )
-        return update_replicated_openhands_values(
-            temp_replicated_wrapper_file,
-            runtime_image_tag="1.19.1-python",
-        )
-
-    def test_reapplying_same_replicated_wrapper_values_reports_no_changes(self, reapplied_replicated_wrapper_result):
-        """Reapplying identical replicated wrapper values sets has_changes=False."""
-        assert reapplied_replicated_wrapper_result.has_changes is False
-
-    @pytest.mark.parametrize("unchanged_key", [
-        "replicated runtime image tag",
-        "replicated warmRuntimes image tag",
-        "replicated local registry runtime image tag",
-        "replicated local registry warmRuntimes image tag",
-    ])
-    def test_reapplying_same_replicated_wrapper_values_marks_key_unchanged(self, reapplied_replicated_wrapper_result, unchanged_key):
-        """Each replicated wrapper tag key is reported as unchanged when reapplied."""
-        assert reapplied_replicated_wrapper_result.is_unchanged(unchanged_key)
-
-
 class TestUpdateReplicatedConfig:
     """Tests for replicated/config.yaml sandbox image tag updates.
 
@@ -1478,19 +1400,6 @@ class TestReplicatedPatternsMatchRealFile:
             copy_path.write_text(real_path.read_text())
             return copy_path
         return _copy
-
-    def test_every_agent_server_ref_in_real_file_is_matched(self, copy_of_real_file):
-        """Running the updater against the real file reports zero unmatched patterns."""
-        result = update_replicated_openhands_values(
-            copy_of_real_file(update_openhands_charts.REPLICATED_OPENHANDS_PATH),
-            runtime_image_tag="0.0.0-canary",
-            dry_run=True,
-        )
-
-        assert result.errors == [], (
-            "A pattern stopped matching the real replicated/openhands.yaml — likely a "
-            "ref was wrapped in new templating. Loosen the affected pattern: " + "; ".join(result.errors)
-        )
 
     def test_every_sandbox_tag_ref_in_real_replicated_config_is_matched(self, copy_of_real_file):
         """Running the config updater against the real replicated/config.yaml reports zero unmatched patterns."""
@@ -2381,23 +2290,22 @@ class TestUpdateOpenhandsWorkflow:
 
     @pytest.fixture
     def make_patched_inner_calls(self, monkeypatch):
-        """Factory mocking all four inner update functions.
+        """Factory mocking all three inner update functions.
 
         Accepts values_changed to control the openhands values result. Returns
         the values/chart mocks asserted by this workflow-contract test class.
-        The replicated mocks are intentionally not returned here; they are
-        patched only to prevent writes to the real replicated files and have
-        dedicated assertions in the focused replicated workflow test classes.
+        The replicated_config mock is intentionally not returned here; it is
+        patched only to prevent writes to the real replicated/config.yaml and
+        has dedicated assertions in the focused replicated-config workflow test
+        class.
         """
         def _patch(values_changed: bool = True):
             mock_values = MagicMock(
                 return_value=update_openhands_charts.UpdateResult(has_changes=values_changed)
             )
-            mock_replicated = MagicMock(return_value=update_openhands_charts.UpdateResult())
             mock_replicated_config = MagicMock(return_value=update_openhands_charts.UpdateResult())
             mock_chart = MagicMock(return_value=update_openhands_charts.UpdateResult())
             monkeypatch.setattr("update_openhands_charts.update_openhands_values", mock_values)
-            monkeypatch.setattr("update_openhands_charts.update_replicated_openhands_values", mock_replicated)
             monkeypatch.setattr("update_openhands_charts.update_replicated_config", mock_replicated_config)
             monkeypatch.setattr("update_openhands_charts.update_openhands_chart", mock_chart)
             return mock_values, mock_chart
@@ -2520,17 +2428,14 @@ class TestSubchartChangeBumpsOpenhandsChartEndToEnd:
         make_temp_yaml_file,
         sample_openhands_chart_minimal,
         sample_openhands_values_minimal,
-        sample_replicated_openhands_wrapper_values,
         sample_replicated_config,
     ):
         """Point the workflow at temp copies of every file it touches."""
         chart_path = make_temp_yaml_file(sample_openhands_chart_minimal)
         values_path = make_temp_yaml_file(sample_openhands_values_minimal)
-        replicated_path = make_temp_yaml_file(sample_replicated_openhands_wrapper_values)
         replicated_config_path = make_temp_yaml_file(sample_replicated_config)
         monkeypatch.setattr("update_openhands_charts.CHART_PATH", chart_path)
         monkeypatch.setattr("update_openhands_charts.VALUES_PATH", values_path)
-        monkeypatch.setattr("update_openhands_charts.REPLICATED_OPENHANDS_PATH", replicated_path)
         monkeypatch.setattr("update_openhands_charts.REPLICATED_CONFIG_PATH", replicated_config_path)
         return chart_path, values_path
 
@@ -2562,46 +2467,6 @@ class TestSubchartChangeBumpsOpenhandsChartEndToEnd:
         )
 
         assert get_chart_value(chart_path, "version") == OPENHANDS_CHART_VERSION
-
-
-class TestUpdateOpenhandsWorkflowReplicated:
-    """Tests that update_openhands_workflow also updates replicated/openhands.yaml.
-
-    The replicated KOTS wrapper embeds its own copy of the agent-server image tag
-    (proxy + LocalRegistry variants) that the chart-values updater cannot reach.
-    The workflow must update that file too, or Replicated installs ship a stale tag.
-    """
-
-    def test_replicated_updater_invoked_with_replicated_openhands_path(self, openhands_workflow_mocks):
-        """The workflow points the replicated updater at replicated/openhands.yaml."""
-        update_openhands_workflow(
-            openhands_version="cloud-1.0.0",
-            runtime_image_tag="tag",
-            dry_run=False,
-        )
-
-        assert openhands_workflow_mocks.replicated.call_args.args[0] == update_openhands_charts.REPLICATED_OPENHANDS_PATH
-
-    def test_replicated_updater_receives_runtime_image_tag(self, openhands_workflow_mocks):
-        """runtime_image_tag is forwarded to the replicated updater."""
-        update_openhands_workflow(
-            openhands_version="cloud-1.0.0",
-            runtime_image_tag="9.9.9-python",
-            dry_run=False,
-        )
-
-        assert openhands_workflow_mocks.replicated.call_args.args[1] == "9.9.9-python"
-
-    @pytest.mark.parametrize("dry_run", [True, False])
-    def test_replicated_updater_receives_dry_run(self, openhands_workflow_mocks, dry_run):
-        """The dry_run flag is forwarded to the replicated updater."""
-        update_openhands_workflow(
-            openhands_version="cloud-1.0.0",
-            runtime_image_tag="tag",
-            dry_run=dry_run,
-        )
-
-        assert openhands_workflow_mocks.replicated.call_args.kwargs["dry_run"] is dry_run
 
 
 class TestUpdateOpenhandsWorkflowReplicatedConfig:

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -22,12 +22,6 @@ from conftest import (
     assert_version_bumped,
     get_chart_value,
     get_dependency_version,
-    # Mock response helpers for get_deploy_config error path tests
-    make_http_error_response,
-    make_invalid_base64_response,
-    make_invalid_yaml_response,
-    make_json_error_response,
-    make_missing_key_response,
     # Fixture baseline constants for self-documenting assertions
     IMAGE_LOADER_CHART_APP_VERSION,
     IMAGE_LOADER_CHART_VERSION,
@@ -41,22 +35,17 @@ from conftest import (
     RUNTIME_IMAGE_TAG,
 )
 from update_openhands_charts import (
-    DeployConfig,
     bump_chart_version,
     bump_patch_version,
     cloud_tag_exists,
     extract_version_from_cloud_tag,
-    format_sha_tag,
     get_current_app_version,
-    get_deploy_config,
     get_latest_cloud_tag,
     get_runtime_image_tag_from_sandbox_spec,
-    get_short_sha,
     main,
     parse_args,
     process_updates,
     resolve_openhands_version,
-    update_automation_values,
     update_image_loader_values,
     update_image_loader_workflow,
     update_openhands_chart,
@@ -65,7 +54,6 @@ from update_openhands_charts import (
     update_replicated_config,
     update_runtime_api_values,
     update_runtime_api_workflow,
-    update_automation_workflow,
 )
 
 
@@ -129,51 +117,6 @@ class TestExtractVersionFromCloudTag:
         safely filter cloud tags from mixed tag lists without try/except blocks.
         """
         assert extract_version_from_cloud_tag(invalid_tag) is None
-
-
-class TestGetShortSha:
-    """Tests for get_short_sha function.
-
-    Git short SHAs are conventionally 7 characters for readability while
-    maintaining uniqueness in most repositories.
-
-    TDD Rationale: Tests drive a simple slice operation. Boundary cases
-    (exactly 7 chars, shorter than 7) ensure the implementation handles
-    edge cases gracefully without raising IndexError.
-    """
-
-    @pytest.mark.parametrize("sha,expected", [
-        # Happy path: typical input longer than 7 chars
-        ("abcdefghijklmnop", "abcdefg"),
-        # Real-world: full 40-character git SHA (most common input)
-        ("6ccd42bb2975866f1abc21e635c01d2afbdd1acf", "6ccd42b"),
-        # Boundary: input exactly 7 chars (no truncation needed)
-        ("a1b2c3d", "a1b2c3d"),
-        # Boundary: input shorter than 7 chars (returns full input)
-        pytest.param("abc", "abc", id="input shorter than 7 chars"),
-    ])
-    def test_short_sha_is_first_seven_characters_of_full_sha(self, sha, expected):
-        """Verify short SHA extraction returns exactly 7 characters or full input if shorter."""
-        assert get_short_sha(sha) == expected
-
-
-class TestFormatShaTag:
-    """Tests for format_sha_tag function.
-
-    Container registries use 'sha-<hash>' tags to identify images built from
-    specific commits. Note: Truncation behavior is tested in TestGetShortSha.
-    These tests focus on the sha- prefix formatting.
-    """
-
-    @pytest.mark.parametrize("sha,expected", [
-        # Happy path: verifies "sha-" prefix is prepended
-        ("abcdefghijklmnop", "sha-abcdefg"),
-        # Real-world: actual GitHub Actions workflow SHA (ensures production compatibility)
-        ("743f6256a690efc388af6e960ad8009f5952e721", "sha-743f625"),
-    ])
-    def test_sha_tag_format_is_sha_prefix_followed_by_short_sha(self, sha, expected):
-        """Verify SHA tag format follows the 'sha-<7-char-hash>' convention used in container registries."""
-        assert format_sha_tag(sha) == expected
 
 
 class TestFindRepoRoot:
@@ -629,265 +572,6 @@ def get_agent_server_image():
         out = capsys.readouterr().out
         assert "Error fetching sandbox spec" in out
         assert "AGENT_SERVER_IMAGE" in out
-
-
-class TestGetDeployConfig:
-    """Tests for get_deploy_config function.
-
-    Uses parameterized tests for comprehensive error path coverage.
-    All error scenarios should return None and print an error message.
-    """
-
-    # Valid workflow YAML for success case tests
-    VALID_WORKFLOW_YAML = """\
-env:
-  RUNTIME_API_SHA: abc123def456
-  AUTOMATION_SHA: 1234567890abcdef1234567890abcdef12345678
-  OTHER_VAR: value
-"""
-
-    def test_returns_deploy_config_instance_on_success(self, monkeypatch, make_workflow_response):
-        """Test that a valid response yields a non-None DeployConfig instance.
-
-        Type-level contract: callers rely on the returned object being a
-        DeployConfig (so they can access typed fields like runtime_api_sha).
-        Kept separate from the value-extraction test below so a failure here
-        unambiguously signals "wrong return type or None" rather than a parsing
-        regression.
-        """
-        monkeypatch.setattr(
-            "update_openhands_charts.requests.get",
-            Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        )
-
-        result = get_deploy_config("fake-token", "owner/repo", ref="1.0.0")
-
-        assert isinstance(result, DeployConfig)
-
-    def test_runtime_api_sha_parsed_from_workflow_env(self, monkeypatch, make_workflow_response):
-        """Test that runtime_api_sha is correctly extracted from the workflow env section.
-
-        Value-extraction contract: the RUNTIME_API_SHA key in the workflow's
-        env section must surface as DeployConfig.runtime_api_sha. A failure
-        here unambiguously signals a regression in the env-parsing logic.
-        """
-        monkeypatch.setattr(
-            "update_openhands_charts.requests.get",
-            Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        )
-
-        result = get_deploy_config("fake-token", "owner/repo", ref="1.0.0")
-
-        assert result.runtime_api_sha == "abc123def456"
-
-    def test_automation_sha_parsed_from_workflow_env(self, monkeypatch, make_workflow_response):
-        """Test that automation_sha is correctly extracted from the workflow env section."""
-        monkeypatch.setattr(
-            "update_openhands_charts.requests.get",
-            Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        )
-
-        result = get_deploy_config("fake-token", "owner/repo", ref="1.0.0")
-
-        assert result.automation_sha == "1234567890abcdef1234567890abcdef12345678"
-
-    def test_constructs_correct_url_without_ref(self, monkeypatch, make_workflow_response):
-        """Test that URL is constructed correctly without ref parameter."""
-        mock_get = Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
-
-        get_deploy_config("fake-token", "owner/repo")
-
-        called_url = mock_get.call_args[0][0]
-        assert called_url == "https://api.github.com/repos/owner/repo/contents/.github/workflows/deploy.yaml"
-
-    def test_constructs_correct_url_with_ref(self, monkeypatch, make_workflow_response):
-        """Test that URL includes ref parameter when provided."""
-        mock_get = Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
-
-        get_deploy_config("fake-token", "owner/repo", ref="v1.2.3")
-
-        called_url = mock_get.call_args[0][0]
-        assert "?ref=v1.2.3" in called_url
-
-    def test_includes_authorization_header(self, monkeypatch, make_workflow_response):
-        """Test that Authorization header is included with token."""
-        mock_get = Mock(return_value=make_workflow_response(self.VALID_WORKFLOW_YAML))
-        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
-
-        get_deploy_config("my-secret-token", "owner/repo")
-
-        called_headers = mock_get.call_args[1]["headers"]
-        assert called_headers["Authorization"] == "Bearer my-secret-token"
-
-    def test_returns_empty_string_when_env_key_missing(self, monkeypatch, make_workflow_response):
-        """Test that missing env keys return empty string (not None).
-
-        Edge case: Workflow has env section but lacks expected keys.
-        This tests graceful handling via dict.get() default behavior.
-        """
-        # Workflow without expected keys - simulates incomplete workflow config
-        response = make_workflow_response("env:\n  OTHER_VAR: value\n")
-        monkeypatch.setattr(
-            "update_openhands_charts.requests.get",
-            Mock(return_value=response)
-        )
-
-        result = get_deploy_config("token", "owner/repo")
-
-        assert result is not None
-        assert result.runtime_api_sha == ""
-        assert result.automation_sha == ""
-
-    def test_returns_empty_string_when_env_section_missing(self, monkeypatch, make_workflow_response):
-        """Test that missing env section returns empty string.
-
-        Edge case: Valid workflow YAML but no env section at all.
-        This tests defensive handling when expected structure is absent.
-        """
-        # Workflow without env section - simulates minimal workflow file
-        response = make_workflow_response("name: deploy\njobs: {}\n")
-        monkeypatch.setattr(
-            "update_openhands_charts.requests.get",
-            Mock(return_value=response)
-        )
-
-        result = get_deploy_config("token", "owner/repo")
-
-        assert result is not None
-        assert result.runtime_api_sha == ""
-        assert result.automation_sha == ""
-
-    # =========================================================================
-    # Parameterized error path tests
-    #
-    # Recovery behavior: All errors return None rather than raising exceptions.
-    # This design allows the caller (main()) to gracefully skip the update when
-    # deploy config is unavailable, rather than failing the entire CI/CD run.
-    # The printed error message enables operators to diagnose issues from logs.
-    # =========================================================================
-
-    _error_scenarios = pytest.mark.parametrize("error_name,setup_mock", [
-        # =====================================================================
-        # Network-level errors (transient, typically retryable)
-        # Recovery: Caller should retry with exponential backoff or skip update
-        # =====================================================================
-        (
-            "connection_timeout",
-            lambda: Mock(side_effect=Exception("Connection timed out")),
-        ),
-        (
-            "connection_refused",
-            lambda: Mock(side_effect=Exception("Connection refused")),
-        ),
-        (
-            "dns_resolution_failed",
-            lambda: Mock(side_effect=Exception("Name resolution failed")),
-        ),
-        # =====================================================================
-        # HTTP error responses (4xx client errors vs 5xx server errors)
-        # Recovery: 4xx errors indicate config issues (check token/repo path);
-        #           5xx errors are transient (retry or wait for GitHub recovery)
-        # =====================================================================
-        (
-            "http_401_unauthorized",
-            lambda: make_http_error_response(401, "Unauthorized"),
-        ),
-        (
-            "http_403_forbidden",
-            lambda: make_http_error_response(403, "Forbidden"),
-        ),
-        (
-            "http_404_not_found",
-            lambda: make_http_error_response(404, "Not Found"),
-        ),
-        (
-            "http_500_server_error",
-            lambda: make_http_error_response(500, "Internal Server Error"),
-        ),
-        (
-            "http_502_bad_gateway",
-            lambda: make_http_error_response(502, "Bad Gateway"),
-        ),
-        (
-            "http_503_unavailable",
-            lambda: make_http_error_response(503, "Service Unavailable"),
-        ),
-        # =====================================================================
-        # Response parsing errors (data corruption or API contract violations)
-        # Recovery: These indicate unexpected API behavior; check GitHub status
-        #           or report bug if persistent. Update should be skipped.
-        # =====================================================================
-        (
-            "invalid_json_response",
-            lambda: make_json_error_response(),
-        ),
-        (
-            "missing_content_key",
-            lambda: make_missing_key_response({}),
-        ),
-        (
-            "null_content_value",
-            lambda: make_missing_key_response({"content": None}),
-        ),
-        # =====================================================================
-        # Base64 decoding errors (corrupted file content in repository)
-        # Recovery: Check the workflow file in the repository for corruption;
-        #           these errors indicate the file content itself is invalid.
-        # =====================================================================
-        (
-            "invalid_base64_content",
-            lambda: make_invalid_base64_response("not-valid-base64!!!"),
-        ),
-        (
-            "corrupted_base64_content",
-            lambda: make_invalid_base64_response("YWJj==="),  # Invalid padding
-        ),
-        # =====================================================================
-        # YAML parsing errors (malformed workflow file syntax)
-        # Recovery: Fix the workflow YAML syntax in the source repository.
-        #           These errors indicate the deploy workflow file is invalid.
-        # =====================================================================
-        (
-            "invalid_yaml_syntax",
-            lambda: make_invalid_yaml_response("{{invalid: yaml: ::"),
-        ),
-        (
-            "yaml_with_tabs",
-            lambda: make_invalid_yaml_response("env:\n\t\tinvalid_indent: true"),
-        ),
-    ])
-    @_error_scenarios
-    def test_returns_none_on_error(self, error_name, setup_mock, monkeypatch):
-        """Every error path returns None (not raising), enabling graceful degradation.
-
-        This fail-safe design lets CI/CD pipelines continue even when the deploy
-        config is temporarily unavailable.
-        """
-        mock_get = setup_mock()
-        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
-
-        result = get_deploy_config("fake-token", "owner/repo")
-
-        assert result is None, f"Expected None for {error_name}, got {result}"
-
-    @_error_scenarios
-    def test_prints_error_on_error(self, error_name, setup_mock, monkeypatch, capsys):
-        """Every error path prints a message containing "Error fetching deploy config".
-
-        Clear diagnostic output lets operators investigate and resolve the
-        underlying issue.
-        """
-        mock_get = setup_mock()
-        monkeypatch.setattr("update_openhands_charts.requests.get", mock_get)
-
-        get_deploy_config("fake-token", "owner/repo")
-
-        captured = capsys.readouterr()
-        assert "Error fetching deploy config" in captured.out, (
-            f"Expected error message for {error_name}, got: {captured.out}"
-        )
 
 
 class TestResolveOpenhandsVersion:
@@ -1437,54 +1121,31 @@ class TestReplicatedPatternsMatchRealFile:
         """
         assert get_chart_value(update_openhands_charts.IMAGE_LOADER_CHART_PATH, "name") == "image-loader"
 
-    @pytest.mark.parametrize("path_constant,relative_parts", [
-        pytest.param(
-            "RUNTIME_API_VALUES_PATH",
-            ("charts", "openhands", "charts", "runtime-api", "values.yaml"),
-            id="runtime-api embedded values path",
-        ),
-        pytest.param(
-            "AUTOMATION_VALUES_PATH",
-            ("charts", "openhands", "charts", "automation", "values.yaml"),
-            id="automation embedded values path",
-        ),
-    ])
-    def test_embedded_subchart_values_path_resolves_to_real_file(self, path_constant, relative_parts):
-        """The subchart values path constants point at the embedded subchart locations.
+    def test_embedded_subchart_values_path_resolves_to_real_file(self):
+        """The runtime-api subchart values path constant points at the embedded location.
 
-        runtime-api and automation moved from charts/<name>/ into
-        charts/openhands/charts/<name>/; if a constant still pointed at the old
-        standalone location, the script would update a file Helm never packages.
+        runtime-api moved from charts/runtime-api/ into
+        charts/openhands/charts/runtime-api/; if the constant still pointed at the
+        old standalone location, the script would update a file Helm never packages.
         """
-        path = getattr(update_openhands_charts, path_constant)
-        assert path == update_openhands_charts.REPO_ROOT.joinpath(*relative_parts)
+        path = update_openhands_charts.RUNTIME_API_VALUES_PATH
+        assert path == update_openhands_charts.REPO_ROOT.joinpath(
+            "charts", "openhands", "charts", "runtime-api", "values.yaml"
+        )
         assert path.is_file()
 
-    def test_every_runtime_api_ref_in_real_embedded_values_is_matched(self, copy_of_real_file):
+    def test_agent_server_ref_in_real_embedded_runtime_api_values_is_matched(self, copy_of_real_file):
         """Running the runtime-api updater against the real embedded values.yaml reports zero unmatched patterns."""
         result = update_runtime_api_values(
             copy_of_real_file(update_openhands_charts.RUNTIME_API_VALUES_PATH),
-            runtime_api_sha="0000000cafef00d",
             runtime_image_tag="0.0.0-canary",
             dry_run=True,
         )
 
         assert result.errors == [], (
-            "A pattern stopped matching the real embedded runtime-api values.yaml — "
-            "likely the image block was restructured. Fix the pattern: " + "; ".join(result.errors)
-        )
-
-    def test_automation_ref_in_real_embedded_values_is_matched(self, copy_of_real_file):
-        """Running the automation updater against the real embedded values.yaml reports zero unmatched patterns."""
-        result = update_automation_values(
-            copy_of_real_file(update_openhands_charts.AUTOMATION_VALUES_PATH),
-            automation_sha="0000000cafef00d",
-            dry_run=True,
-        )
-
-        assert result.errors == [], (
-            "The automation image pattern stopped matching the real embedded "
-            "automation values.yaml. Fix the pattern: " + "; ".join(result.errors)
+            "The agent-server image pattern stopped matching the real embedded "
+            "runtime-api values.yaml — likely global.agentServerImage was "
+            "restructured. Fix the pattern: " + "; ".join(result.errors)
         )
 
 
@@ -1677,32 +1338,24 @@ class TestDryRun:
 
 
 class TestUpdateRuntimeApiValues:
-    """Tests for update_runtime_api_values function."""
+    """Tests for update_runtime_api_values function.
+
+    The runtime-api image is pinned to a manually-released semver tag, so the
+    updater only bumps the global agent-server image tag from the sandbox spec.
+    """
 
     @pytest.fixture
     def temp_runtime_api_values_file(self, make_temp_yaml_file, sample_runtime_api_values):
         """Create a temporary runtime-api values.yaml file using shared fixtures."""
         return make_temp_yaml_file(sample_runtime_api_values)
 
-    def test_update_image_tag(self, temp_runtime_api_values_file):
-        """Test that runtime-api image tag is updated correctly."""
-        update_runtime_api_values(
-            temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
-            runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
-        )
-
-        assert_file_contains(temp_runtime_api_values_file, "tag: sha-abc1234")
-
     def test_update_agent_server_image_uses_runtime_image_tag(self, temp_runtime_api_values_file):
-        """Test that the global agent-server image tag uses the value from deploy config."""
+        """Test that the global agent-server image tag uses the value from the sandbox spec."""
         update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
-        # Should use runtime_image_tag from deploy config
         assert_file_contains(temp_runtime_api_values_file, f"tag: {NEW_RUNTIME_IMAGE_TAG}")
 
     @pytest.fixture
@@ -1714,12 +1367,10 @@ class TestUpdateRuntimeApiValues:
         """
         update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
         return update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
@@ -1727,19 +1378,14 @@ class TestUpdateRuntimeApiValues:
         """Reapplying identical runtime-api values sets has_changes=False."""
         assert reapplied_runtime_api_values_result.has_changes is False
 
-    @pytest.mark.parametrize("unchanged_key", [
-        "runtime-api image tag",
-        "runtime-api agent-server image tag",
-    ])
-    def test_reapplying_same_runtime_api_values_marks_key_unchanged(self, reapplied_runtime_api_values_result, unchanged_key):
-        """Each runtime-api image-tag key is reported as unchanged when reapplied."""
-        assert reapplied_runtime_api_values_result.is_unchanged(unchanged_key)
+    def test_reapplying_same_runtime_api_values_marks_key_unchanged(self, reapplied_runtime_api_values_result):
+        """The agent-server image-tag key is reported as unchanged when reapplied."""
+        assert reapplied_runtime_api_values_result.is_unchanged("runtime-api agent-server image tag")
 
     def test_preserves_other_content(self, temp_runtime_api_values_file):
         """Test that other content is preserved."""
         update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
@@ -1754,7 +1400,6 @@ class TestUpdateRuntimeApiValues:
 
         update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
             dry_run=True,
         )
@@ -1765,117 +1410,10 @@ class TestUpdateRuntimeApiValues:
         """Test that function returns True when changes are made."""
         result = update_runtime_api_values(
             temp_runtime_api_values_file,
-            runtime_api_sha="abc1234567890def",
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
         assert result.has_changes is True
-
-
-class TestUpdateAutomationValues:
-    """Tests for update_automation_values function."""
-
-    @pytest.fixture
-    def temp_automation_values_file(self, make_temp_yaml_file, sample_automation_values):
-        """Create a temporary automation values.yaml file."""
-        return make_temp_yaml_file(sample_automation_values)
-
-    def test_updates_automation_image_tag(self, temp_automation_values_file):
-        """Test that automation image tag is written from the deploy-config SHA."""
-        sha = "1234567890abcdef1234567890abcdef12345678"
-
-        update_automation_values(temp_automation_values_file, automation_sha=sha)
-
-        assert_file_contains(temp_automation_values_file, "tag: sha-1234567\n")
-
-    def test_reports_has_changes_when_automation_tag_updated(self, temp_automation_values_file):
-        """Test that updating the automation tag reports has_changes is True."""
-        sha = "1234567890abcdef1234567890abcdef12345678"
-
-        result = update_automation_values(temp_automation_values_file, automation_sha=sha)
-
-        assert result.has_changes is True
-
-    def test_bare_short_automation_sha_matches_prefixed_chart_tag(self, temp_automation_values_file):
-        """Test that a short bare automation SHA still follows the sha-<short> tag convention."""
-        result = update_automation_values(temp_automation_values_file, automation_sha="c58faa1")
-
-        assert_file_contains(temp_automation_values_file, "tag: sha-c58faa1\n")
-        assert result.has_changes is False
-        assert result.is_unchanged("automation image tag")
-
-    def test_idempotent_when_reapplying_same_values(self, temp_automation_values_file):
-        """Test that reapplying the same automation tag reports no changes."""
-        result = update_automation_values(
-            temp_automation_values_file,
-            automation_sha="c58faa1000000000000000000000000000000000",
-        )
-
-        assert result.has_changes is False
-        assert result.is_unchanged("automation image tag")
-
-    def test_preserves_other_content(self, temp_automation_values_file):
-        """Test that other content is preserved."""
-        update_automation_values(
-            temp_automation_values_file,
-            automation_sha="1234567890abcdef1234567890abcdef12345678",
-        )
-
-        assert_file_contains_all(temp_automation_values_file, [
-            "repository: ghcr.io/openhands/automation",
-            "replicas: 1",
-            "memory: 256Mi",
-        ])
-
-    def test_dry_run_no_file_changes(self, temp_automation_values_file):
-        """Test that dry-run doesn't modify the file."""
-        original_content = temp_automation_values_file.read_text()
-
-        update_automation_values(
-            temp_automation_values_file,
-            automation_sha="1234567890abcdef1234567890abcdef12345678",
-            dry_run=True,
-        )
-
-        assert temp_automation_values_file.read_text() == original_content
-
-    def test_missing_automation_sha_reports_error_without_file_changes(self, temp_automation_values_file):
-        """Test that missing deploy config input does not corrupt the image tag."""
-        original_content = temp_automation_values_file.read_text()
-
-        result = update_automation_values(temp_automation_values_file, automation_sha="")
-
-        assert temp_automation_values_file.read_text() == original_content
-        assert result.has_changes is False
-        assert result.has_error_containing("AUTOMATION_SHA missing from deploy config")
-
-    def test_missing_automation_sha_returns_before_reading_values_file(self, tmp_path):
-        """Test that missing deploy config input does not require values.yaml to exist."""
-        result = update_automation_values(tmp_path / "missing-values.yaml", automation_sha="")
-
-        assert result.has_changes is False
-        assert result.has_error_containing("AUTOMATION_SHA missing from deploy config")
-
-    def test_direct_version_tag_is_not_treated_as_managed_automation_tag(self, make_temp_yaml_file):
-        """Test that automation only updates tags following the sha-<short> convention."""
-        values_file = make_temp_yaml_file("""\
-image:
-  repository: ghcr.io/openhands/automation
-  tag: 1.20.0
-
-deployment:
-  replicas: 1
-""")
-        original_content = values_file.read_text()
-
-        result = update_automation_values(
-            values_file,
-            automation_sha="1234567890abcdef1234567890abcdef12345678",
-        )
-
-        assert values_file.read_text() == original_content
-        assert result.has_changes is False
-        assert result.has_error_containing("Could not find automation image tag in values.yaml")
 
 
 class TestBumpChartVersion:
@@ -1972,67 +1510,25 @@ class TestProcessUpdates:
     """
 
     def test_returns_early_when_version_resolution_fails(self, monkeypatch, stub_process_updates_chain):
-        """When resolve_openhands_version returns None, no deploy config fetch is attempted."""
+        """When resolve_openhands_version returns None, no file updates are attempted."""
         stub_process_updates_chain(openhands_version=None)
-        mock_get_deploy_config = MagicMock()
-        monkeypatch.setattr("update_openhands_charts.get_deploy_config", mock_get_deploy_config)
+        mock_update_runtime_api = MagicMock()
+        monkeypatch.setattr("update_openhands_charts.update_runtime_api_workflow", mock_update_runtime_api)
 
         process_updates("token")
 
-        mock_get_deploy_config.assert_not_called()
+        mock_update_runtime_api.assert_not_called()
 
     def test_returns_early_when_runtime_image_tag_unavailable(self, monkeypatch, stub_process_updates_chain, capsys):
-        """When runtime image tag fetch fails, no deploy config fetch is attempted."""
+        """When the agent-server tag fetch fails, no file updates are attempted."""
         stub_process_updates_chain(runtime_image_tag=None)
-        mock_get_deploy_config = MagicMock()
-        monkeypatch.setattr("update_openhands_charts.get_deploy_config", mock_get_deploy_config)
-
-        process_updates("token")
-
-        mock_get_deploy_config.assert_not_called()
-        assert "Could not fetch runtime image tag" in capsys.readouterr().out
-
-    def test_returns_early_when_deploy_config_unavailable(self, monkeypatch, stub_process_updates_chain, capsys):
-        """When deploy config fetch fails, no file updates are attempted."""
-        stub_process_updates_chain()
-        monkeypatch.setattr(
-            "update_openhands_charts.get_deploy_config",
-            lambda token, repo, ref: None,
-        )
         mock_update_runtime_api = MagicMock()
-        monkeypatch.setattr(
-            "update_openhands_charts.update_runtime_api_workflow",
-            mock_update_runtime_api,
-        )
-
-        process_updates("token")
-
-        mock_update_runtime_api.assert_not_called()
-        assert "Could not fetch deploy config" in capsys.readouterr().out
-
-    def test_returns_early_when_automation_sha_missing(self, monkeypatch, stub_process_updates_chain, capsys):
-        """When AUTOMATION_SHA is missing, no partial chart updates are attempted."""
-        stub_process_updates_chain()
-        monkeypatch.setattr(
-            "update_openhands_charts.get_deploy_config",
-            lambda token, repo, ref: DeployConfig(runtime_api_sha="runtime-sha", automation_sha=""),
-        )
-        mock_update_runtime_api = MagicMock()
-        mock_update_automation = MagicMock()
-        mock_update_image_loader = MagicMock()
-        mock_update_openhands = MagicMock()
         monkeypatch.setattr("update_openhands_charts.update_runtime_api_workflow", mock_update_runtime_api)
-        monkeypatch.setattr("update_openhands_charts.update_automation_workflow", mock_update_automation)
-        monkeypatch.setattr("update_openhands_charts.update_image_loader_workflow", mock_update_image_loader)
-        monkeypatch.setattr("update_openhands_charts.update_openhands_workflow", mock_update_openhands)
 
         process_updates("token")
 
         mock_update_runtime_api.assert_not_called()
-        mock_update_automation.assert_not_called()
-        mock_update_image_loader.assert_not_called()
-        mock_update_openhands.assert_not_called()
-        assert "AUTOMATION_SHA missing from deploy config" in capsys.readouterr().out
+        assert "Could not fetch runtime image tag" in capsys.readouterr().out
 
     def test_invokes_image_loader_workflow_with_runtime_image_tag(self, monkeypatch, stub_process_updates_chain):
         """When all upstream data is available, the image-loader workflow runs with the sandbox tag.
@@ -2042,15 +1538,7 @@ class TestProcessUpdates:
         """
         stub_process_updates_chain()
         monkeypatch.setattr(
-            "update_openhands_charts.get_deploy_config",
-            lambda token, repo, ref: DeployConfig(runtime_api_sha="runtime-sha", automation_sha="auto-sha"),
-        )
-        monkeypatch.setattr(
             "update_openhands_charts.update_runtime_api_workflow",
-            MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True)),
-        )
-        monkeypatch.setattr(
-            "update_openhands_charts.update_automation_workflow",
             MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=True)),
         )
         monkeypatch.setattr("update_openhands_charts.update_openhands_workflow", MagicMock())
@@ -2061,33 +1549,23 @@ class TestProcessUpdates:
 
         mock_update_image_loader.assert_called_once_with("1.20.0-python", True)
 
-    @pytest.mark.parametrize("runtime_api_changed,automation_changed,expected", [
-        pytest.param(False, False, False, id="no subchart values changed"),
-        pytest.param(True, False, True, id="runtime-api values changed"),
-        pytest.param(False, True, True, id="automation values changed"),
-        pytest.param(True, True, True, id="both subchart values changed"),
+    @pytest.mark.parametrize("runtime_api_changed", [
+        pytest.param(False, id="no subchart values changed"),
+        pytest.param(True, id="runtime-api values changed"),
     ])
     def test_subchart_values_changes_feed_openhands_workflow(
-        self, monkeypatch, stub_process_updates_chain, runtime_api_changed, automation_changed, expected
+        self, monkeypatch, stub_process_updates_chain, runtime_api_changed
     ):
-        """Embedded subchart values results are ORed into subchart_values_changed.
+        """The runtime-api values result feeds subchart_values_changed.
 
-        runtime-api and automation values ship inside the openhands chart, so a
-        change to either alone must reach update_openhands_workflow as
-        subchart_values_changed=True to trigger an openhands version bump.
+        runtime-api values ship inside the openhands chart, so a change there must
+        reach update_openhands_workflow as subchart_values_changed=True to trigger
+        an openhands version bump.
         """
         stub_process_updates_chain()
         monkeypatch.setattr(
-            "update_openhands_charts.get_deploy_config",
-            lambda token, repo, ref: DeployConfig(runtime_api_sha="runtime-sha", automation_sha="auto-sha"),
-        )
-        monkeypatch.setattr(
             "update_openhands_charts.update_runtime_api_workflow",
             MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=runtime_api_changed)),
-        )
-        monkeypatch.setattr(
-            "update_openhands_charts.update_automation_workflow",
-            MagicMock(return_value=update_openhands_charts.UpdateResult(has_changes=automation_changed)),
         )
         monkeypatch.setattr("update_openhands_charts.update_image_loader_workflow", MagicMock())
         mock_update_openhands = MagicMock()
@@ -2095,7 +1573,7 @@ class TestProcessUpdates:
 
         process_updates("token", dry_run=True)
 
-        assert mock_update_openhands.call_args.kwargs["subchart_values_changed"] is expected
+        assert mock_update_openhands.call_args.kwargs["subchart_values_changed"] is runtime_api_changed
 
 
 class TestUpdateRuntimeApiWorkflow:
@@ -2118,84 +1596,28 @@ class TestUpdateRuntimeApiWorkflow:
         values_result = update_openhands_charts.UpdateResult(has_changes=True)
         patched_values_call.return_value = values_result
 
-        result = update_runtime_api_workflow(DeployConfig(runtime_api_sha="abc"), "tag", dry_run=False)
+        result = update_runtime_api_workflow("tag", dry_run=False)
 
         assert result is values_result
 
     def test_values_call_targets_embedded_subchart_values_path(self, patched_values_call):
         """The workflow points the values updater at the embedded subchart's values.yaml."""
-        update_runtime_api_workflow(DeployConfig(runtime_api_sha="abc"), "tag", dry_run=False)
+        update_runtime_api_workflow("tag", dry_run=False)
 
         assert patched_values_call.call_args.args[0] == update_openhands_charts.RUNTIME_API_VALUES_PATH
 
-    def test_values_call_receives_runtime_api_sha_from_deploy_config(self, patched_values_call):
-        """The runtime_api_sha is extracted from deploy_config and passed positionally to values."""
-        update_runtime_api_workflow(DeployConfig(runtime_api_sha="cafef00d"), "tag", dry_run=False)
-
-        # update_runtime_api_values(path, sha, image_tag, dry_run=...) — sha is the 2nd positional arg
-        assert patched_values_call.call_args.args[1] == "cafef00d"
-
     def test_values_call_receives_runtime_image_tag(self, patched_values_call):
-        """The runtime_image_tag is passed through to values as the 3rd positional argument."""
-        update_runtime_api_workflow(DeployConfig(runtime_api_sha="abc"), "image-tag-v9", dry_run=False)
+        """The runtime_image_tag is passed through to values as the 2nd positional argument."""
+        update_runtime_api_workflow("image-tag-v9", dry_run=False)
 
-        assert patched_values_call.call_args.args[2] == "image-tag-v9"
+        assert patched_values_call.call_args.args[1] == "image-tag-v9"
 
     @pytest.mark.parametrize("dry_run", [True, False])
     def test_dry_run_is_propagated_to_values_call(self, patched_values_call, dry_run):
         """The dry_run flag is forwarded to update_runtime_api_values."""
-        update_runtime_api_workflow(DeployConfig(runtime_api_sha="abc"), "tag", dry_run=dry_run)
+        update_runtime_api_workflow("tag", dry_run=dry_run)
 
         assert patched_values_call.call_args.kwargs["dry_run"] is dry_run
-
-
-class TestUpdateAutomationWorkflow:
-    """Tests for update_automation_workflow orchestration.
-
-    automation is an embedded subchart of openhands: no chart version bump
-    happens here — the workflow updates values.yaml and returns the values
-    UpdateResult for process_updates to feed into the openhands chart bump.
-    """
-
-    def test_updates_values_and_returns_values_result(
-        self,
-        monkeypatch,
-        make_temp_yaml_file,
-        sample_automation_values,
-    ):
-        """The automation values file is updated and the values result is returned."""
-        values_path = make_temp_yaml_file(sample_automation_values)
-        monkeypatch.setattr("update_openhands_charts.AUTOMATION_VALUES_PATH", values_path)
-
-        result = update_automation_workflow(
-            DeployConfig(
-                runtime_api_sha="unused",
-                automation_sha="1234567890abcdef1234567890abcdef12345678",
-            ),
-            dry_run=False,
-        )
-
-        assert_file_contains(values_path, "tag: sha-1234567\n")
-        assert result.has_changes is True
-        assert result.has_change_for("automation image tag")
-
-    def test_unchanged_values_return_no_changes(
-        self,
-        monkeypatch,
-        make_temp_yaml_file,
-        sample_automation_values,
-    ):
-        """Reapplying the tag already in the values file reports no changes upward."""
-        values_path = make_temp_yaml_file(sample_automation_values)
-        monkeypatch.setattr("update_openhands_charts.AUTOMATION_VALUES_PATH", values_path)
-
-        result = update_automation_workflow(
-            DeployConfig(runtime_api_sha="unused", automation_sha="c58faa1"),
-            dry_run=False,
-        )
-
-        assert result.has_changes is False
-        assert result.is_unchanged("automation image tag")
 
 
 class TestUpdateImageLoaderWorkflow:

--- a/scripts/update_openhands_charts/test_update_openhands_charts.py
+++ b/scripts/update_openhands_charts/test_update_openhands_charts.py
@@ -944,7 +944,7 @@ class TestUpdateValues:
     - test_reports_error_*: Error handling for missing patterns
 
     TDD Rationale: Tests drive regex-based image tag replacement that must
-    handle three distinct tag locations (enterprise-server, runtime, warmRuntimes).
+    handle two distinct tag locations (enterprise-server, global agent-server).
     Error tests ensure graceful handling when expected patterns are missing,
     preventing silent failures in CI/CD pipelines.
     """
@@ -956,14 +956,13 @@ class TestUpdateValues:
 
     @pytest.mark.parametrize("expected_content", [
         pytest.param("tag: cloud-1.1.0", id="enterprise-server tag"),
-        pytest.param(f"tag: {NEW_RUNTIME_IMAGE_TAG}", id="runtime tag"),
-        pytest.param(f'image: "ghcr.io/openhands/agent-server:{NEW_RUNTIME_IMAGE_TAG}"', id="warmRuntimes tag"),
+        pytest.param(f"tag: {NEW_RUNTIME_IMAGE_TAG}", id="agent-server global tag"),
     ])
     def test_each_image_tag_is_updated(self, temp_values_file, expected_content):
-        """Test that enterprise-server, runtime, and warmRuntimes image tags are each updated.
+        """Test that the enterprise-server and global agent-server image tags are each updated.
 
-        All three tags are written by one call; each parametrize case verifies
-        one tag location in the output file.
+        Both tags are written by one call; each parametrize case verifies one tag
+        location in the output file.
         """
         update_openhands_values(
             temp_values_file,
@@ -999,8 +998,7 @@ class TestUpdateValues:
 
     @pytest.mark.parametrize("unchanged_key", [
         "enterprise-server image tag",
-        "runtime image tag",
-        "warmRuntimes image tag",
+        "agent-server image tag",
     ])
     def test_reapplying_same_values_marks_key_unchanged(self, reapplied_values_result, unchanged_key):
         """Each image-tag key is reported as unchanged when reapplied with the same value."""
@@ -1066,25 +1064,23 @@ runtime-api:
 
         assert result.has_error_containing("Could not find enterprise-server image tag")
 
-    def test_reports_error_when_runtime_tag_missing(self, make_temp_yaml_file):
-        """Test that error is reported when runtime image tag pattern not found.
+    def test_reports_error_when_agent_server_tag_missing(self, make_temp_yaml_file):
+        """Test that error is reported when the global agent-server tag pattern is not found.
 
-        Edge case rationale: The runtime image runs user code in sandboxed containers.
-        Version mismatch between enterprise-server and runtime can cause compatibility
-        issues (API changes, protocol mismatches). Detecting missing runtime patterns
-        ensures both images stay synchronized during updates.
+        Edge case rationale: the agent-server image (the sandbox runtime) now lives
+        once in global.agentServerImage; runtime.image and warmRuntimes fall back to
+        it. If that block is missing, the sandbox runtime version can't be bumped, so
+        the updater must surface it rather than silently leave a stale runtime.
         """
-        # YAML without runtime image section - enterprise-server present but runtime missing
+        # enterprise-server present, but no global.agentServerImage block
         values_content = """\
 image:
   repository: ghcr.io/openhands/enterprise-server
   tag: cloud-1.0.0
 
-runtime-api:
-  warmRuntimes:
-    configs:
-      - name: default
-        image: "ghcr.io/openhands/agent-server:1.0.0-python"
+global:
+  security:
+    allowInsecureImages: true
 """
         temp_file = make_temp_yaml_file(values_content)
 
@@ -1094,40 +1090,7 @@ runtime-api:
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
-        assert result.has_error_containing("Could not find runtime image tag")
-
-    def test_reports_error_when_warm_runtimes_tag_missing(self, make_temp_yaml_file):
-        """Test that error is reported when warmRuntimes image tag pattern not found.
-
-        Edge case rationale: warmRuntimes pre-provisions runtime containers for faster
-        cold starts. If this image isn't updated but runtime is, pre-warmed containers
-        would run stale versions until recycled. This creates inconsistent behavior
-        where some requests use new runtime and others use old pre-warmed instances.
-        """
-        # YAML with warmRuntimes disabled - pattern missing but section exists
-        values_content = """\
-image:
-  repository: ghcr.io/openhands/enterprise-server
-  tag: cloud-1.0.0
-
-runtime:
-  image:
-    repository: ghcr.io/openhands/agent-server
-    tag: 1.0.0-python
-
-runtime-api:
-  warmRuntimes:
-    enabled: false
-"""
-        temp_file = make_temp_yaml_file(values_content)
-
-        result = update_openhands_values(
-            temp_file,
-            openhands_version="cloud-1.1.0",
-            runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
-        )
-
-        assert result.has_error_containing("Could not find warmRuntimes image tag")
+        assert result.has_error_containing("Could not find agent-server image tag")
 
     def test_collects_multiple_errors_when_multiple_patterns_missing(self, make_temp_yaml_file):
         """Test that all missing patterns are reported as errors.
@@ -1151,10 +1114,9 @@ serviceAccount:
             runtime_image_tag=NEW_RUNTIME_IMAGE_TAG,
         )
 
-        assert result.error_count == 3
+        assert result.error_count == 2
         assert result.has_error_containing("enterprise-server")
-        assert result.has_error_containing("runtime image tag")
-        assert result.has_error_containing("warmRuntimes")
+        assert result.has_error_containing("agent-server image tag")
 
 
 
@@ -1775,8 +1737,7 @@ class TestDryRun:
 
         # Assert: changes are tracked even though file wasn't modified
         assert result.has_change_for("enterprise-server image tag")
-        assert result.has_change_for("runtime image tag")
-        assert result.has_change_for("warmRuntimes image tag")
+        assert result.has_change_for("agent-server image tag")
 
     def test_update_chart_without_dry_run_modifies_file(self, temp_chart_file):
         """Test that without dry-run, Chart.yaml is modified."""
@@ -1824,8 +1785,8 @@ class TestUpdateRuntimeApiValues:
 
         assert_file_contains(temp_runtime_api_values_file, "tag: sha-abc1234")
 
-    def test_update_warm_runtimes_image_uses_runtime_image_tag(self, temp_runtime_api_values_file):
-        """Test that warmRuntimes image tag uses value from deploy config."""
+    def test_update_agent_server_image_uses_runtime_image_tag(self, temp_runtime_api_values_file):
+        """Test that the global agent-server image tag uses the value from deploy config."""
         update_runtime_api_values(
             temp_runtime_api_values_file,
             runtime_api_sha="abc1234567890def",
@@ -1833,7 +1794,7 @@ class TestUpdateRuntimeApiValues:
         )
 
         # Should use runtime_image_tag from deploy config
-        assert_file_contains(temp_runtime_api_values_file, f'image: "ghcr.io/openhands/agent-server:{NEW_RUNTIME_IMAGE_TAG}"')
+        assert_file_contains(temp_runtime_api_values_file, f"tag: {NEW_RUNTIME_IMAGE_TAG}")
 
     @pytest.fixture
     def reapplied_runtime_api_values_result(self, temp_runtime_api_values_file):
@@ -1859,7 +1820,7 @@ class TestUpdateRuntimeApiValues:
 
     @pytest.mark.parametrize("unchanged_key", [
         "runtime-api image tag",
-        "runtime-api warmRuntimes image tag",
+        "runtime-api agent-server image tag",
     ])
     def test_reapplying_same_runtime_api_values_marks_key_unchanged(self, reapplied_runtime_api_values_result, unchanged_key):
         """Each runtime-api image-tag key is reported as unchanged when reapplied."""

--- a/scripts/update_openhands_charts/update_openhands_charts.py
+++ b/scripts/update_openhands_charts/update_openhands_charts.py
@@ -7,7 +7,6 @@
 
 import argparse
 import base64
-import io
 import logging
 import os
 import re
@@ -22,10 +21,8 @@ from ruamel.yaml import YAML
 logging.getLogger("github").setLevel(logging.WARNING)
 
 CLOUD_SEMVER_PATTERN = re.compile(r"^cloud-(\d+\.\d+\.\d+)$")
-SHORT_SHA_LENGTH = 7
 OPENHANDS_REPO = "All-Hands-AI/OpenHands"
 OPENHANDS_ENTERPRISE_REPO = "OpenHands/OpenHands"
-DEPLOY_REPO = "OpenHands/deploy"
 SANDBOX_SPEC_PATH = "openhands/app_server/sandbox/sandbox_spec_service.py"
 AGENT_SERVER_IMAGE_PATTERN = re.compile(r"AGENT_SERVER_IMAGE\s*=\s*'[^:]+:([^']+)'")
 SEPARATOR = "=" * 60
@@ -54,9 +51,6 @@ VALUES_PATH = REPO_ROOT / "charts" / "openhands" / "values.yaml"
 RUNTIME_API_VALUES_PATH = (
     REPO_ROOT / "charts" / "openhands" / "charts" / "runtime-api" / "values.yaml"
 )
-AUTOMATION_VALUES_PATH = (
-    REPO_ROOT / "charts" / "openhands" / "charts" / "automation" / "values.yaml"
-)
 IMAGE_LOADER_CHART_PATH = REPO_ROOT / "charts" / "image-loader" / "Chart.yaml"
 IMAGE_LOADER_VALUES_PATH = REPO_ROOT / "charts" / "image-loader" / "values.yaml"
 REPLICATED_CONFIG_PATH = REPO_ROOT / "replicated" / "config.yaml"
@@ -71,12 +65,6 @@ ENTERPRISE_SERVER_TAG_PATTERN = (
 # tag: shape as the enterprise-server pattern.
 GLOBAL_AGENT_SERVER_TAG_PATTERN = (
     r"(agentServerImage:\s*\n\s*repository:\s*ghcr\.io/openhands/agent-server\s*\n\s*tag:\s*)(\S+)"
-)
-RUNTIME_API_TAG_PATTERN = (
-    r'(image:\n\s+repository: ghcr\.io/openhands/runtime-api\n\s+tag: )(sha-[a-f0-9]+)'
-)
-AUTOMATION_TAG_PATTERN = (
-    r'(image:\n\s+repository: ghcr\.io/openhands/automation\n\s+tag: )(sha-[a-f0-9]+)'
 )
 # image-loader's values.yaml has the agent-server image at the top level, so this
 # matches an image: { repository: ghcr.io/openhands/agent-server, tag: ... } block.
@@ -155,11 +143,6 @@ class UpdateResult:
             print(f"Error: {err}")
 
 
-def get_short_sha(sha: str) -> str:
-    """Return the first 7 characters of a SHA hash."""
-    return sha[:SHORT_SHA_LENGTH]
-
-
 def extract_version_from_cloud_tag(cloud_tag: str) -> str | None:
     """Extract version number from cloud-X.Y.Z format."""
     match = CLOUD_SEMVER_PATTERN.match(cloud_tag)
@@ -178,19 +161,6 @@ def get_current_app_version(chart_path: Path) -> str | None:
         return chart_data.get("appVersion")
     except Exception:
         return None
-
-
-def format_sha_tag(sha: str) -> str:
-    """Format a SHA hash into a sha-SHORT_SHA tag format."""
-    return f"sha-{get_short_sha(sha)}"
-
-
-@dataclass
-class DeployConfig:
-    """Configuration values from the deploy workflow."""
-
-    runtime_api_sha: str
-    automation_sha: str = ""
 
 
 def get_latest_cloud_tag(token: str, repo_name: str) -> str | None:
@@ -216,31 +186,6 @@ def cloud_tag_exists(token: str, repo_name: str, tag_name: str) -> bool:
         return True
     except Exception:
         return False
-
-
-def get_deploy_config(token: str, repo_name: str, ref: str | None = None) -> DeployConfig | None:
-    """Fetch deployment config values from deploy.yaml workflow."""
-    headers = {"Authorization": f"Bearer {token}"}
-    url = f"https://api.github.com/repos/{repo_name}/contents/.github/workflows/deploy.yaml"
-    if ref:
-        url += f"?ref={ref}"
-
-    try:
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
-
-        content = base64.b64decode(response.json()["content"]).decode("utf-8")
-        yaml = YAML()
-        workflow = yaml.load(io.StringIO(content))
-
-        env = workflow.get("env", {})
-        return DeployConfig(
-            runtime_api_sha=env.get("RUNTIME_API_SHA", ""),
-            automation_sha=env.get("AUTOMATION_SHA", ""),
-        )
-    except Exception as e:
-        print(f"Error fetching deploy config: {e}")
-        return None
 
 
 def get_runtime_image_tag_from_sandbox_spec(token: str, repo_name: str, ref: str) -> str | None:
@@ -521,19 +466,19 @@ def bump_chart_version(
 
 def update_runtime_api_values(
     values_path: Path,
-    runtime_api_sha: str,
     runtime_image_tag: str,
     dry_run: bool = False,
 ) -> UpdateResult:
-    """Update the runtime-api image tag and global agent-server image tag in runtime-api values.yaml.
+    """Update the global agent-server image tag in runtime-api values.yaml.
 
-    The subchart carries its own global.agentServerImage default so it renders
-    standalone; the umbrella's parent global overrides it at deploy time. Keeping
-    both in sync means a standalone render shows the same agent-server tag.
+    The runtime-api image itself is pinned to a manually-released semver tag, so
+    this only bumps the agent-server tag. The subchart carries its own
+    global.agentServerImage default so it renders standalone; the umbrella's
+    parent global overrides it at deploy time. Keeping both in sync means a
+    standalone render shows the same agent-server tag.
 
     Args:
         values_path: Path to the values.yaml file
-        runtime_api_sha: The runtime-api commit SHA
         runtime_image_tag: The agent-server image tag from sandbox spec (e.g., '1.21.0-python')
         dry_run: If True, don't write changes to file
 
@@ -544,50 +489,9 @@ def update_runtime_api_values(
 
     content = update_tag_in_content(
         content,
-        RUNTIME_API_TAG_PATTERN,
-        format_sha_tag(runtime_api_sha),
-        "runtime-api image tag",
-        result,
-    )
-    content = update_tag_in_content(
-        content,
         GLOBAL_AGENT_SERVER_TAG_PATTERN,
         runtime_image_tag,
         "runtime-api agent-server image tag",
-        result,
-    )
-
-    if not dry_run and result.has_changes:
-        values_path.write_text(content)
-
-    return result
-
-
-def update_automation_values(
-    values_path: Path,
-    automation_sha: str,
-    dry_run: bool = False,
-) -> UpdateResult:
-    """Update image tag in automation values.yaml.
-
-    Args:
-        values_path: Path to the values.yaml file
-        automation_sha: The automation commit SHA from deploy config
-        dry_run: If True, don't write changes to file
-
-    Returns UpdateResult containing changes made.
-    """
-    result = UpdateResult()
-    if not automation_sha:
-        result.errors.append("AUTOMATION_SHA missing from deploy config")
-        return result
-    content = values_path.read_text()
-
-    content = update_tag_in_content(
-        content,
-        AUTOMATION_TAG_PATTERN,
-        format_sha_tag(automation_sha),
-        "automation image tag",
         result,
     )
 
@@ -652,7 +556,6 @@ def resolve_openhands_version(token: str, cloud_tag: str | None) -> str | None:
 
 
 def update_runtime_api_workflow(
-    deploy_config: DeployConfig,
     runtime_image_tag: str,
     dry_run: bool,
 ) -> UpdateResult:
@@ -667,7 +570,6 @@ def update_runtime_api_workflow(
     print("Updating runtime-api values.yaml...")
     values_result = update_runtime_api_values(
         RUNTIME_API_VALUES_PATH,
-        deploy_config.runtime_api_sha,
         runtime_image_tag,
         dry_run=dry_run,
     )
@@ -746,29 +648,6 @@ def update_image_loader_workflow(
     chart_result.print_summary()
 
 
-def update_automation_workflow(
-    deploy_config: DeployConfig,
-    dry_run: bool,
-) -> UpdateResult:
-    """Update automation subchart values. Returns the values UpdateResult.
-
-    automation is an embedded subchart of openhands, so it has no chart
-    version of its own to bump — value changes are released by the openhands
-    chart version bump instead.
-    """
-    print_section_header("Updating automation subchart...")
-
-    print("Updating automation values.yaml...")
-    values_result = update_automation_values(
-        AUTOMATION_VALUES_PATH,
-        deploy_config.automation_sha,
-        dry_run=dry_run,
-    )
-    values_result.print_summary()
-
-    return values_result
-
-
 def process_updates(
     token: str,
     dry_run: bool = False,
@@ -803,25 +682,10 @@ def process_updates(
         print(f"Could not fetch runtime image tag from sandbox spec at {openhands_version}")
         return
 
-    deploy_config = get_deploy_config(token, DEPLOY_REPO, ref=version_number)
-    if not deploy_config:
-        print(f"Could not fetch deploy config from tag {version_number}")
-        return
-    # All charts are released together; abort if any deploy-config SHA is missing.
-    if not deploy_config.automation_sha:
-        print("AUTOMATION_SHA missing from deploy config")
-        return
-
-    print(f"Deploy config (from {version_number}):")
-    print(f"  RUNTIME_API_SHA: {deploy_config.runtime_api_sha}")
-    print(f"  AUTOMATION_SHA: {deploy_config.automation_sha}")
-    print(f"  AGENT_SERVER_IMAGE tag (from sandbox spec): {runtime_image_tag}")
+    print(f"AGENT_SERVER_IMAGE tag (from sandbox spec): {runtime_image_tag}")
 
     print()
-    runtime_api_result = update_runtime_api_workflow(deploy_config, runtime_image_tag, dry_run)
-
-    print()
-    automation_result = update_automation_workflow(deploy_config, dry_run)
+    runtime_api_result = update_runtime_api_workflow(runtime_image_tag, dry_run)
 
     print()
     update_image_loader_workflow(runtime_image_tag, dry_run)
@@ -831,9 +695,7 @@ def process_updates(
         openhands_version,
         runtime_image_tag,
         dry_run,
-        subchart_values_changed=(
-            runtime_api_result.has_changes or automation_result.has_changes
-        ),
+        subchart_values_changed=runtime_api_result.has_changes,
     )
 
 

--- a/scripts/update_openhands_charts/update_openhands_charts.py
+++ b/scripts/update_openhands_charts/update_openhands_charts.py
@@ -66,10 +66,13 @@ REPLICATED_CONFIG_PATH = REPO_ROOT / "replicated" / "config.yaml"
 ENTERPRISE_SERVER_TAG_PATTERN = (
     r"(image:\s*\n\s*repository:\s*ghcr\.io/openhands/enterprise-server\s*\n\s*tag:\s*)(\S+)"
 )
-RUNTIME_TAG_PATTERN = (
-    r"(runtime:\s*\n\s*image:\s*\n\s*repository:\s*ghcr\.io/openhands/agent-server\s*\n\s*tag:\s*)(\S+)"
+# The agent-server image now lives in one place: the openhands chart's
+# global.agentServerImage. runtime.image and warmRuntimes configsByName entries
+# fall back to it, so bumping this single tag moves them all. Same repository:/
+# tag: shape as the enterprise-server pattern.
+GLOBAL_AGENT_SERVER_TAG_PATTERN = (
+    r"(agentServerImage:\s*\n\s*repository:\s*ghcr\.io/openhands/agent-server\s*\n\s*tag:\s*)(\S+)"
 )
-WARM_RUNTIMES_TAG_PATTERN = r'(image:\s*"ghcr\.io/openhands/agent-server:)([^"]+)"'
 RUNTIME_API_TAG_PATTERN = (
     r'(image:\n\s+repository: ghcr\.io/openhands/runtime-api\n\s+tag: )(sha-[a-f0-9]+)'
 )
@@ -98,8 +101,8 @@ REPLICATED_LOCAL_AGENT_SERVER_TAG_PATTERN = (
 REPLICATED_LOCAL_WARM_RUNTIME_IMAGE_PATTERN = (
     r"(image:\s*'\{\{repl LocalRegistryHost \}\}/\{\{repl LocalRegistryNamespace \}\}/agent-server:)([^']+)'"
 )
-# Same shape as RUNTIME_TAG_PATTERN but without the runtime: prefix — image-loader's
-# values.yaml has the agent-server image at the top level.
+# image-loader's values.yaml has the agent-server image at the top level, so this
+# matches an image: { repository: ghcr.io/openhands/agent-server, tag: ... } block.
 IMAGE_LOADER_TAG_PATTERN = (
     r"(image:\s*\n\s*repository:\s*ghcr\.io/openhands/agent-server\s*\n\s*tag:\s*)(\S+)"
 )
@@ -463,18 +466,10 @@ def update_openhands_values(
     )
     content = update_tag_in_content(
         content,
-        RUNTIME_TAG_PATTERN,
+        GLOBAL_AGENT_SERVER_TAG_PATTERN,
         runtime_image_tag,
-        "runtime image tag",
+        "agent-server image tag",
         result,
-    )
-    content = update_tag_in_content(
-        content,
-        WARM_RUNTIMES_TAG_PATTERN,
-        runtime_image_tag,
-        "warmRuntimes image tag",
-        result,
-        replacement_suffix='"',
     )
 
     if not dry_run and result.has_changes:
@@ -635,7 +630,11 @@ def update_runtime_api_values(
     runtime_image_tag: str,
     dry_run: bool = False,
 ) -> UpdateResult:
-    """Update image tag and warmRuntimes default config image in runtime-api values.yaml.
+    """Update the runtime-api image tag and global agent-server image tag in runtime-api values.yaml.
+
+    The subchart carries its own global.agentServerImage default so it renders
+    standalone; the umbrella's parent global overrides it at deploy time. Keeping
+    both in sync means a standalone render shows the same agent-server tag.
 
     Args:
         values_path: Path to the values.yaml file
@@ -657,11 +656,10 @@ def update_runtime_api_values(
     )
     content = update_tag_in_content(
         content,
-        WARM_RUNTIMES_TAG_PATTERN,
+        GLOBAL_AGENT_SERVER_TAG_PATTERN,
         runtime_image_tag,
-        "runtime-api warmRuntimes image tag",
+        "runtime-api agent-server image tag",
         result,
-        replacement_suffix='"',
     )
 
     if not dry_run and result.has_changes:

--- a/scripts/update_openhands_charts/update_openhands_charts.py
+++ b/scripts/update_openhands_charts/update_openhands_charts.py
@@ -59,7 +59,6 @@ AUTOMATION_VALUES_PATH = (
 )
 IMAGE_LOADER_CHART_PATH = REPO_ROOT / "charts" / "image-loader" / "Chart.yaml"
 IMAGE_LOADER_VALUES_PATH = REPO_ROOT / "charts" / "image-loader" / "values.yaml"
-REPLICATED_OPENHANDS_PATH = REPO_ROOT / "replicated" / "openhands.yaml"
 REPLICATED_CONFIG_PATH = REPO_ROOT / "replicated" / "config.yaml"
 
 # Regex patterns for values.yaml image tag updates
@@ -78,28 +77,6 @@ RUNTIME_API_TAG_PATTERN = (
 )
 AUTOMATION_TAG_PATTERN = (
     r'(image:\n\s+repository: ghcr\.io/openhands/automation\n\s+tag: )(sha-[a-f0-9]+)'
-)
-# The proxy-style refs wrap the agent-server image in the custom_sandbox_image_enabled
-# KOTS conditional ({{repl if ...}}...{{repl else}}<proxy image>{{repl end}}), so the
-# proxy URL/tag no longer sits flush against the opening quote. Anchor on the
-# ghcr.io/openhands/agent-server marker (a single-quoted scalar never contains an inner
-# single quote, so [^']* stays within the value) and capture the version with [^'{]+ so
-# it stops before the trailing {{repl end}} or closing quote — both of which are then
-# left untouched (no replacement_suffix needed). The patterns also match the unwrapped
-# form, where [^']* and the optional groups collapse to empty.
-REPLICATED_PROXY_AGENT_SERVER_TAG_PATTERN = (
-    r"(repository:\s*'[^']*ghcr\.io/openhands/agent-server(?:\{\{repl end\}\})?'\s*\n"
-    r"(?:\s*#[^\n]*\n)*"
-    r"\s*tag:\s*'(?:[^']*\{\{repl else\}\})?)([^'{]+)"
-)
-REPLICATED_PROXY_WARM_RUNTIME_IMAGE_PATTERN = (
-    r"(image:\s*'[^']*ghcr\.io/openhands/agent-server:)([^'{]+)"
-)
-REPLICATED_LOCAL_AGENT_SERVER_TAG_PATTERN = (
-    r"(repository:\s*'\{\{repl LocalRegistryHost \}\}/\{\{repl LocalRegistryNamespace \}\}/agent-server'\s*\n\s*tag:\s*')([^']+)'"
-)
-REPLICATED_LOCAL_WARM_RUNTIME_IMAGE_PATTERN = (
-    r"(image:\s*'\{\{repl LocalRegistryHost \}\}/\{\{repl LocalRegistryNamespace \}\}/agent-server:)([^']+)'"
 )
 # image-loader's values.yaml has the agent-server image at the top level, so this
 # matches an image: { repository: ghcr.io/openhands/agent-server, tag: ... } block.
@@ -336,36 +313,6 @@ def update_tag_in_content(
     return content
 
 
-def update_all_tags_in_content(
-    content: str,
-    pattern: str,
-    new_tag: str,
-    tag_name: str,
-    result: UpdateResult,
-    replacement_suffix: str = "",
-    error_if_missing: bool = True,
-) -> str:
-    """Update all regex-matched tags in content and track grouped results."""
-    matches = list(re.finditer(pattern, content))
-    if not matches:
-        if error_if_missing:
-            result.errors.append(f"Could not find {tag_name} in values.yaml")
-        return content
-
-    old_tags = [match.group(2) for match in matches]
-    if all(old_tag == new_tag for old_tag in old_tags):
-        result.unchanged.append((tag_name, new_tag))
-        return content
-
-    replacement = rf"\g<1>{new_tag}{replacement_suffix}"
-    content = re.sub(pattern, replacement, content)
-    changed_old_tags = sorted({old_tag for old_tag in old_tags if old_tag != new_tag})
-    old_value_summary = ", ".join(changed_old_tags)
-    result.changes.append((tag_name, old_value_summary, new_tag))
-    result.has_changes = True
-    return content
-
-
 def bump_patch_version(version: str) -> str:
     """Bump the patch version of a semantic version string.
 
@@ -470,58 +417,6 @@ def update_openhands_values(
         runtime_image_tag,
         "agent-server image tag",
         result,
-    )
-
-    if not dry_run and result.has_changes:
-        values_path.write_text(content)
-
-    return result
-
-
-def update_replicated_openhands_values(
-    values_path: Path,
-    runtime_image_tag: str,
-    dry_run: bool = False,
-) -> UpdateResult:
-    """Update agent-server image tags in the replicated/openhands.yaml KOTS wrapper.
-
-    The wrapper carries its own copy of the agent-server tag in four locations:
-    proxy-style and LocalRegistry-style image refs, each in both the chart-level
-    image block and the warmRuntimes default config. The chart-values updater
-    cannot reach these because the templating only renders inside the KOTS wrapper.
-    """
-    content = values_path.read_text()
-    result = UpdateResult()
-
-    content = update_all_tags_in_content(
-        content,
-        REPLICATED_PROXY_AGENT_SERVER_TAG_PATTERN,
-        runtime_image_tag,
-        "replicated runtime image tag",
-        result,
-    )
-    content = update_tag_in_content(
-        content,
-        REPLICATED_PROXY_WARM_RUNTIME_IMAGE_PATTERN,
-        runtime_image_tag,
-        "replicated warmRuntimes image tag",
-        result,
-    )
-    content = update_all_tags_in_content(
-        content,
-        REPLICATED_LOCAL_AGENT_SERVER_TAG_PATTERN,
-        runtime_image_tag,
-        "replicated local registry runtime image tag",
-        result,
-        replacement_suffix="'",
-    )
-    content = update_tag_in_content(
-        content,
-        REPLICATED_LOCAL_WARM_RUNTIME_IMAGE_PATTERN,
-        runtime_image_tag,
-        "replicated local registry warmRuntimes image tag",
-        result,
-        replacement_suffix="'",
     )
 
     if not dry_run and result.has_changes:
@@ -804,15 +699,6 @@ def update_openhands_workflow(
         dry_run=dry_run,
     )
     values_result.print_summary()
-
-    print()
-    print("Updating replicated/openhands.yaml...")
-    replicated_result = update_replicated_openhands_values(
-        REPLICATED_OPENHANDS_PATH,
-        runtime_image_tag,
-        dry_run=dry_run,
-    )
-    replicated_result.print_summary()
 
     print()
     print("Updating replicated/config.yaml...")


### PR DESCRIPTION
## Description

The warm runtime config in the runtime-api chart was a list (`warmRuntimes.configs`). Helm can't merge lists across value layers, so a consumer who wanted to change one field of one entry had to re-declare the whole list. This converts it to a map (`warmRuntimes.configsByName`) keyed by each entry's `name`, which merges cleanly layer to layer.

The list form still works and takes precedence when it's set, so existing consumers keep working untouched.

It also adds `global.agentServerImage` as the single source for the agent-server image. `runtime.image` and any `configsByName` entry that omits its own `image` both fall back to it, so the proxy / custom-sandbox / local-registry variants only override the repository (and the tag, for the admin-supplied custom image). The replicated wrapper now uses both the map form and the global, which collapses a large block of duplicated warm config.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (umbrella `openhands` 0.7.80 -> 0.7.81; runtime-api is an inert embedded `0.0.0`)
- [ ] I have tested the chart upgrade path from the previous version (see notes - I verified render-equivalence, not a live `helm upgrade`)
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (there are none - `global.agentServerImage` ships with defaults, nothing new is required)

## Additional Notes

A few things worth a reviewer's attention:

- **Backwards compatibility.** `configsByName` is the new canonical form, but `configs` still renders and wins when it's non-empty. I confirmed with `helm template` that an existing list-based config renders byte-identical to before.

- **Incidental fix for local-registry installs.** The replicated wrapper's local-registry warm override used to sit at `runtime.warmRuntimes`, a key the chart never reads (warm config lives under `runtime-api`). So local-registry / airgapped installs' warm pods silently fell back to the proxy image path. Routing the warm image through `global.agentServerImage`, which the local-registry block does override, fixes that.

- **The tag now lives only in the chart default.** The replicated wrapper sets the agent-server repository and inherits the tag from `global.agentServerImage.tag` via map-merge. That continues the direction of #758, and it let me delete the whole `update_replicated_openhands_values()` image-bump path (function, 4 regexes, and its tests) since the wrapper no longer carries a literal agent-server tag.

- **Two pre-existing test failures, left as-is.** `test_every_runtime_api_ref_in_real_embedded_values_is_matched` and `test_automation_ref_in_real_embedded_values_is_matched` are red from earlier sha-vs-version tag drift (#758 / #759), unrelated to this change. Everything else passes (248).
