### PR TITLE
feat(infra): add coordinator to relax sandbox PDBs for k0s upgrades

### DIFF
--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -10,18 +10,30 @@ eviction API, which the PDB rejects, and the upgrade stalls on a cordoned node.
 Rather than drop the PDB, this controller removes the *pods* ahead of the drain
 so there is nothing for the PDB to protect, then brings them back afterwards.
 
-Why a Deployment and not a Helm hook: embedded-cluster upgrades k0s BEFORE it
-upgrades the application Helm charts (operator Upgrade(): upgradeK0s → addons →
-extensions). A chart pre-upgrade hook would therefore fire only AFTER the node
-roll already happened — too late. This controller runs continuously and reacts
-to the embedded-cluster `Installation` state, which flips to a drain state at
-the very start of the k0s upgrade (controllers roll before workers, so there is
-ample lead time before the first worker drain).
+Why it reacts continuously and not via a Helm hook: embedded-cluster upgrades
+k0s BEFORE it upgrades the application Helm charts (operator Upgrade():
+upgradeK0s → addons → extensions). A chart pre-upgrade hook would therefore fire
+only AFTER the node roll already happened — too late. This controller runs
+continuously and reacts to the embedded-cluster `Installation` state, which
+flips to a drain state at the very start of the k0s upgrade.
+
+Why a DaemonSet and not a Deployment: the upgrade drains the node, and most
+installs are single-node, so a Deployment's pod would be evicted along with
+everything else and never be around to scale the sandboxes down — deadlock,
+because the sandbox PDBs then block the very drain that would let the node
+upgrade. `kubectl drain` and k0s autopilot both pass IgnoreAllDaemonSets, so a
+DaemonSet pod is NOT evicted by the drain. It stays running on the draining node
+and removes the sandbox pods, which unblocks the drain. After the node reboots
+into the new k0s, the DaemonSet pod is recreated and restores the sandboxes.
 
 Safety: the PDB stays as a hard interlock. If this controller is down or slow,
 the worst case is the upgrade stalls on a cordoned node (autopilot's drain
 retries every 120s, never force-deleting past the PDB) — a sandbox is never
 killed without its workspace first being released by scaling to zero.
+
+On multi-node clusters a pod runs per node; all reconcile the same cluster-wide
+sandboxes, which is redundant but idempotent (scale state is tracked per
+deployment via an annotation, so duplicate or concurrent actions converge).
 
 Disabled by default. Enable only on embedded-cluster installs, where the
 `installations.embeddedcluster.replicated.com` CRD exists. On any other cluster
@@ -178,7 +190,10 @@ data:
     done
 ---
 apiVersion: apps/v1
-kind: Deployment
+# DaemonSet, not Deployment: drains pass IgnoreAllDaemonSets, so this pod is not
+# evicted by the node drain it must survive to scale the sandboxes down. See the
+# header comment.
+kind: DaemonSet
 metadata:
   name: {{ $name }}
   namespace: {{ $ns }}
@@ -186,10 +201,6 @@ metadata:
     app.kubernetes.io/name: sandbox-upgrade-coordinator
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 1
-  # One coordinator at a time — there is no leader election in the script.
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: sandbox-upgrade-coordinator
@@ -201,6 +212,11 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ $name }}
+      # Run on every node — including tainted control-plane nodes — so the pod is
+      # present on whichever node the upgrade drains (the single node, in the
+      # common case).
+      tolerations:
+        - operator: Exists
       {{- with $c.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -1,39 +1,51 @@
 {{- /*
-sandbox-upgrade-coordinator — keeps the per-sandbox PodDisruptionBudgets in
-place across a Kubernetes (k0s) upgrade by scaling sandbox deployments to zero
-while the upgrade rolls nodes, then restoring them when it finishes.
+sandbox-upgrade-coordinator — lets a Kubernetes (k0s) upgrade drain the node
+without giving up the per-sandbox PodDisruptionBudgets that protect sandboxes
+from involuntary eviction the rest of the time.
 
 Why this exists: runtime-api gives every sandbox a PDB with maxUnavailable=0,
-so the pod is never voluntarily evicted. That same PDB blocks the node drains
-that embedded-cluster's k0s upgrade (autopilot) performs — the drain uses the
-eviction API, which the PDB rejects, and the upgrade stalls on a cordoned node.
-Rather than drop the PDB, this controller removes the *pods* ahead of the drain
-so there is nothing for the PDB to protect, then brings them back afterwards.
+so the sandbox pod is never voluntarily evicted. That same PDB blocks the node
+drains that embedded-cluster's k0s upgrade (autopilot) performs — the drain uses
+the eviction API, which a maxUnavailable=0 PDB always rejects, so the upgrade
+stalls on a cordoned node.
+
+What it does: while an upgrade is rolling nodes, it relaxes the sandbox PDBs to
+maxUnavailable=100% so the drain can evict the pods, then sets them back to
+maxUnavailable=0 when the upgrade finishes. It does NOT touch the sandbox
+Deployments — those stay at replicas=1, so Kubernetes recreates each pod as soon
+as the node uncordons, and the node-local workspace PVC survives the reboot.
+Sandboxes come back on their own with their workspace intact; the interruption
+is the pod being killed and rescheduled.
+
+Why it relaxes the PDB instead of scaling the Deployment: the Deployments are
+owned and reconciled by runtime-api, which owns spec.replicas and the runtime
+lifecycle state in its database. An external scale-to-0 fights that owner and
+bypasses runtime-api's own pause/stop bookkeeping. The PDB is just an obstacle to
+the drain, so relaxing it is the minimal, ownership-respecting way to let the
+node roll.
 
 Why it reacts continuously and not via a Helm hook: embedded-cluster upgrades
 k0s BEFORE it upgrades the application Helm charts (operator Upgrade():
-upgradeK0s → addons → extensions). A chart pre-upgrade hook would therefore fire
-only AFTER the node roll already happened — too late. This controller runs
+upgradeK0s → addons → extensions). A chart pre-upgrade hook would fire only
+AFTER the node roll already happened — too late. This controller runs
 continuously and reacts to the embedded-cluster `Installation` state, which
 flips to a drain state at the very start of the k0s upgrade.
 
 Why a DaemonSet and not a Deployment: the upgrade drains the node, and most
 installs are single-node, so a Deployment's pod would be evicted along with
-everything else and never be around to scale the sandboxes down — deadlock,
-because the sandbox PDBs then block the very drain that would let the node
-upgrade. `kubectl drain` and k0s autopilot both pass IgnoreAllDaemonSets, so a
-DaemonSet pod is NOT evicted by the drain. It stays running on the draining node
-and removes the sandbox pods, which unblocks the drain. After the node reboots
-into the new k0s, the DaemonSet pod is recreated and restores the sandboxes.
+everything else and never be around to relax the PDBs. `kubectl drain` and k0s
+autopilot both pass IgnoreAllDaemonSets, so a DaemonSet pod is NOT evicted by the
+drain. It stays running on the draining node, relaxes the PDBs so the drain
+proceeds, and after the node reboots into the new k0s it restores them.
 
-Safety: the PDB stays as a hard interlock. If this controller is down or slow,
-the worst case is the upgrade stalls on a cordoned node (autopilot's drain
-retries every 120s, never force-deleting past the PDB) — a sandbox is never
-killed without its workspace first being released by scaling to zero.
+Safety: the relax is idempotent and only widens a PDB during a detected upgrade;
+the moment the Installation leaves a drain state the PDBs go back to
+maxUnavailable=0. If this controller is down, the worst case is the upgrade
+stalls on a cordoned node (autopilot's drain retries every 120s) — PDB
+protection is never silently lost.
 
-On multi-node clusters a pod runs per node; all reconcile the same cluster-wide
-sandboxes, which is redundant but idempotent (scale state is tracked per
-deployment via an annotation, so duplicate or concurrent actions converge).
+On multi-node clusters a pod runs per node; all reconcile the same sandbox PDBs,
+which is redundant but idempotent.
 
 Disabled by default. Enable only on embedded-cluster installs, where the
 `installations.embeddedcluster.replicated.com` CRD exists. On any other cluster
@@ -57,11 +69,11 @@ imagePullSecrets:
 {{- end }}
 ---
 # Cluster-scoped read of the embedded-cluster Installation (the upgrade signal),
-# plus deployment get/list/watch/patch/update so the controller can scale
-# sandboxes. This is a ClusterRole (not a namespaced Role) because the
-# controller runs in the infra release namespace but scales sandbox deployments
-# in the openhands namespace, which the openhands chart creates later and which
-# may not exist when this chart installs.
+# plus poddisruptionbudgets get/list/watch/patch so the controller can relax and
+# restore the sandbox PDBs. This is a ClusterRole (not a namespaced Role) because
+# the controller runs in the infra release namespace but acts on PDBs in the
+# openhands namespace, which the openhands chart creates later and which may not
+# exist when this chart installs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -73,9 +85,9 @@ rules:
   - apiGroups: ["embeddedcluster.replicated.com"]
     resources: ["installations"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -109,18 +121,18 @@ data:
     set -u
 
     # Namespace runtime-api drops sandboxes into (its K8S_NAMESPACE), which in
-    # the openhands chart is the openhands release namespace.
+    # the openhands chart is the openhands release namespace. The sandbox PDBs
+    # live here and carry the sandbox label.
     NS='{{ $c.runtimeNamespace }}'
     SELECTOR='{{ $c.sandboxSelector }}'
     INTERVAL='{{ $c.pollIntervalSeconds }}'
     DRAIN_STATES='{{ join " " $c.drainStates }}'
-    ANNOTATION='infra.openhands.dev/pre-upgrade-replicas'
 
     log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [sandbox-upgrade-coordinator] $*"; }
 
     # Print each Installation's status.state, one per line. Exits non-zero if
     # the CRD is absent or the API is unreachable, which the caller treats as
-    # "unknown" and leaves sandboxes untouched.
+    # "unknown" and leaves the PDBs untouched.
     read_states() {
       kubectl get installations.embeddedcluster.replicated.com \
         -o jsonpath='{range .items[*]}{.status.state}{"\n"}{end}'
@@ -137,38 +149,38 @@ data:
       return 1
     }
 
-    # Scale every running sandbox to zero, recording its prior replica count in
-    # an annotation so the exact count can be restored. Idempotent: a sandbox
-    # that already carries the annotation, or is already at zero, is skipped.
-    scale_down() {
-      kubectl get deploy -n "$NS" -l "$SELECTOR" \
-        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.replicas}{"\n"}{end}' 2>/dev/null \
-      | while read -r name replicas; do
-          [ -z "$name" ] && continue
-          saved=$(kubectl get deploy -n "$NS" "$name" \
-            -o "jsonpath={.metadata.annotations['$ANNOTATION']}" 2>/dev/null || true)
-          if [ -z "$saved" ] && [ "${replicas:-0}" -gt 0 ]; then
-            log "scaling $name down (was $replicas) for the upgrade"
-            kubectl annotate deploy -n "$NS" "$name" "$ANNOTATION=$replicas" --overwrite >/dev/null 2>&1 || true
-            kubectl scale deploy -n "$NS" "$name" --replicas=0 >/dev/null 2>&1 || true
-          fi
-        done
+    # Names of the sandbox PDBs. runtime-api labels each sandbox PDB with the
+    # sandbox selector (e.g. runtime_id), so this matches only sandboxes and not
+    # the app's own PDBs (keycloak/postgres/redis).
+    list_pdbs() {
+      kubectl get pdb -n "$NS" -l "$SELECTOR" \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null
     }
 
-    # Restore every sandbox this controller scaled down, then drop the marker
-    # annotation. Sandboxes without the annotation are left alone, so a sandbox
-    # that was intentionally paused (at zero) before the upgrade stays paused.
-    scale_up() {
-      for name in $(kubectl get deploy -n "$NS" -l "$SELECTOR" \
-        -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-          saved=$(kubectl get deploy -n "$NS" "$name" \
-            -o "jsonpath={.metadata.annotations['$ANNOTATION']}" 2>/dev/null || true)
-          if [ -n "$saved" ]; then
-            log "restoring $name to $saved replica(s)"
-            kubectl scale deploy -n "$NS" "$name" --replicas="$saved" >/dev/null 2>&1 || true
-            kubectl annotate deploy -n "$NS" "$name" "${ANNOTATION}-" >/dev/null 2>&1 || true
-          fi
-        done
+    # spec.maxUnavailable of one PDB as a plain string ("0" or "100%"). Empty if
+    # the PDB is gone or expresses its budget with minAvailable instead.
+    current_max_unavailable() {
+      kubectl get pdb -n "$NS" "$1" -o jsonpath='{.spec.maxUnavailable}' 2>/dev/null
+    }
+
+    # Set spec.maxUnavailable on every sandbox PDB to the desired value, patching
+    # only the ones that differ so steady state is a no-op (no writes, no log
+    # spam) and runtime-api creating fresh PDBs at 0 is left alone.
+    #   $1 = value as it appears in jsonpath output ("0" or "100%")
+    #   $2 = the same value as a JSON literal (0 or "100%")
+    set_pdbs() {
+      want_str="$1"
+      want_json="$2"
+      list_pdbs | while read -r name; do
+        [ -z "$name" ] && continue
+        cur=$(current_max_unavailable "$name")
+        if [ "$cur" != "$want_str" ]; then
+          log "PDB $name maxUnavailable ${cur:-none} -> $want_str"
+          kubectl patch pdb -n "$NS" "$name" --type=merge \
+            -p "{\"spec\":{\"maxUnavailable\":$want_json}}" >/dev/null 2>&1 \
+            || log "WARN: failed to patch PDB $name"
+        fi
+      done
     }
 
     log "starting; namespace=$NS selector='$SELECTOR' drainStates='$DRAIN_STATES' interval=${INTERVAL}s"
@@ -176,16 +188,16 @@ data:
     while true; do
       if states=$(read_states 2>/dev/null); then
         if is_draining "$states"; then
-          [ "$PHASE" != "draining" ] && log "k0s upgrade in progress; scaling sandboxes down"
+          [ "$PHASE" != "draining" ] && log "k0s upgrade in progress; relaxing sandbox PDBs (maxUnavailable=100%) so the node can drain"
           PHASE="draining"
-          scale_down
+          set_pdbs '100%' '"100%"'
         else
-          [ "$PHASE" = "draining" ] && log "k0s upgrade finished; restoring sandboxes"
+          [ "$PHASE" = "draining" ] && log "k0s upgrade finished; restoring sandbox PDBs (maxUnavailable=0)"
           PHASE="idle"
-          scale_up
+          set_pdbs '0' '0'
         fi
       else
-        [ "$PHASE" != "unknown" ] && log "WARN: cannot read Installation state (CRD missing or API error); leaving sandboxes unchanged"
+        [ "$PHASE" != "unknown" ] && log "WARN: cannot read Installation state (CRD missing or API error); leaving PDBs unchanged"
         PHASE="unknown"
       fi
       sleep "$INTERVAL"
@@ -193,7 +205,7 @@ data:
 ---
 apiVersion: apps/v1
 # DaemonSet, not Deployment: drains pass IgnoreAllDaemonSets, so this pod is not
-# evicted by the node drain it must survive to scale the sandboxes down. See the
+# evicted by the node drain it must survive to relax the sandbox PDBs. See the
 # header comment.
 kind: DaemonSet
 metadata:

--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -1,0 +1,244 @@
+{{- /*
+sandbox-upgrade-coordinator — keeps the per-sandbox PodDisruptionBudgets in
+place across a Kubernetes (k0s) upgrade by scaling sandbox deployments to zero
+while the upgrade rolls nodes, then restoring them when it finishes.
+
+Why this exists: runtime-api gives every sandbox a PDB with maxUnavailable=0,
+so the pod is never voluntarily evicted. That same PDB blocks the node drains
+that embedded-cluster's k0s upgrade (autopilot) performs — the drain uses the
+eviction API, which the PDB rejects, and the upgrade stalls on a cordoned node.
+Rather than drop the PDB, this controller removes the *pods* ahead of the drain
+so there is nothing for the PDB to protect, then brings them back afterwards.
+
+Why a Deployment and not a Helm hook: embedded-cluster upgrades k0s BEFORE it
+upgrades the application Helm charts (operator Upgrade(): upgradeK0s → addons →
+extensions). A chart pre-upgrade hook would therefore fire only AFTER the node
+roll already happened — too late. This controller runs continuously and reacts
+to the embedded-cluster `Installation` state, which flips to a drain state at
+the very start of the k0s upgrade (controllers roll before workers, so there is
+ample lead time before the first worker drain).
+
+Safety: the PDB stays as a hard interlock. If this controller is down or slow,
+the worst case is the upgrade stalls on a cordoned node (autopilot's drain
+retries every 120s, never force-deleting past the PDB) — a sandbox is never
+killed without its workspace first being released by scaling to zero.
+
+Disabled by default. Enable only on embedded-cluster installs, where the
+`installations.embeddedcluster.replicated.com` CRD exists. On any other cluster
+the controller idles harmlessly (it cannot read the CRD, so it changes nothing).
+*/ -}}
+{{- if .Values.sandboxUpgradeCoordinator.enabled }}
+{{- $c := .Values.sandboxUpgradeCoordinator }}
+{{- $name := printf "%s-sandbox-upgrade-coordinator" .Release.Name }}
+{{- $ns := .Release.Namespace }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: sandbox-upgrade-coordinator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with $c.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+# Cluster-scoped read of the embedded-cluster Installation (the upgrade signal),
+# plus deployment get/list/watch/patch so the controller can scale sandboxes.
+# Deployment access is cluster-wide because the runtime namespace is created
+# lazily by runtime-api and may not exist when this chart installs; the script
+# only ever touches `runtimeNamespace`. Narrow this to a namespaced Role if you
+# can guarantee the namespace exists first.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    app.kubernetes.io/name: sandbox-upgrade-coordinator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups: ["embeddedcluster.replicated.com"]
+    resources: ["installations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    app.kubernetes.io/name: sandbox-upgrade-coordinator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: sandbox-upgrade-coordinator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  coordinator.sh: |
+    #!/bin/sh
+    # POSIX sh — alpine/k8s ships a shell and kubectl. Do NOT swap in
+    # rancher/kubectl here: it is FROM scratch and has no shell.
+    set -u
+
+    NS='{{ $c.runtimeNamespace }}'
+    SELECTOR='{{ $c.sandboxSelector }}'
+    INTERVAL='{{ $c.pollIntervalSeconds }}'
+    DRAIN_STATES='{{ join " " $c.drainStates }}'
+    ANNOTATION='infra.openhands.dev/pre-upgrade-replicas'
+
+    log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [sandbox-upgrade-coordinator] $*"; }
+
+    # Print each Installation's status.state, one per line. Exits non-zero if
+    # the CRD is absent or the API is unreachable, which the caller treats as
+    # "unknown" and leaves sandboxes untouched.
+    read_states() {
+      kubectl get installations.embeddedcluster.replicated.com \
+        -o jsonpath='{range .items[*]}{.status.state}{"\n"}{end}'
+    }
+
+    # True when any Installation is in a drain state (a k0s upgrade is rolling
+    # nodes). Argument is the newline list from read_states.
+    is_draining() {
+      for s in $1; do
+        for d in $DRAIN_STATES; do
+          [ "$s" = "$d" ] && return 0
+        done
+      done
+      return 1
+    }
+
+    # Scale every running sandbox to zero, recording its prior replica count in
+    # an annotation so the exact count can be restored. Idempotent: a sandbox
+    # that already carries the annotation, or is already at zero, is skipped.
+    scale_down() {
+      kubectl get deploy -n "$NS" -l "$SELECTOR" \
+        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.replicas}{"\n"}{end}' 2>/dev/null \
+      | while read -r name replicas; do
+          [ -z "$name" ] && continue
+          saved=$(kubectl get deploy -n "$NS" "$name" \
+            -o "jsonpath={.metadata.annotations['$ANNOTATION']}" 2>/dev/null || true)
+          if [ -z "$saved" ] && [ "${replicas:-0}" -gt 0 ]; then
+            log "scaling $name down (was $replicas) for the upgrade"
+            kubectl annotate deploy -n "$NS" "$name" "$ANNOTATION=$replicas" --overwrite >/dev/null 2>&1 || true
+            kubectl scale deploy -n "$NS" "$name" --replicas=0 >/dev/null 2>&1 || true
+          fi
+        done
+    }
+
+    # Restore every sandbox this controller scaled down, then drop the marker
+    # annotation. Sandboxes without the annotation are left alone, so a sandbox
+    # that was intentionally paused (at zero) before the upgrade stays paused.
+    scale_up() {
+      for name in $(kubectl get deploy -n "$NS" -l "$SELECTOR" \
+        -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+          saved=$(kubectl get deploy -n "$NS" "$name" \
+            -o "jsonpath={.metadata.annotations['$ANNOTATION']}" 2>/dev/null || true)
+          if [ -n "$saved" ]; then
+            log "restoring $name to $saved replica(s)"
+            kubectl scale deploy -n "$NS" "$name" --replicas="$saved" >/dev/null 2>&1 || true
+            kubectl annotate deploy -n "$NS" "$name" "${ANNOTATION}-" >/dev/null 2>&1 || true
+          fi
+        done
+    }
+
+    log "starting; namespace=$NS selector='$SELECTOR' drainStates='$DRAIN_STATES' interval=${INTERVAL}s"
+    PHASE=""
+    while true; do
+      if states=$(read_states 2>/dev/null); then
+        if is_draining "$states"; then
+          [ "$PHASE" != "draining" ] && log "k0s upgrade in progress; scaling sandboxes down"
+          PHASE="draining"
+          scale_down
+        else
+          [ "$PHASE" = "draining" ] && log "k0s upgrade finished; restoring sandboxes"
+          PHASE="idle"
+          scale_up
+        fi
+      else
+        [ "$PHASE" != "unknown" ] && log "WARN: cannot read Installation state (CRD missing or API error); leaving sandboxes unchanged"
+        PHASE="unknown"
+      fi
+      sleep "$INTERVAL"
+    done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: sandbox-upgrade-coordinator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  # One coordinator at a time — there is no leader election in the script.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sandbox-upgrade-coordinator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sandbox-upgrade-coordinator
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ $name }}
+      {{- with $c.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: coordinator
+          image: "{{ $c.image.repository }}:{{ $c.image.tag }}"
+          imagePullPolicy: {{ $c.image.pullPolicy | default "IfNotPresent" }}
+          command: ["/bin/sh", "/scripts/coordinator.sh"]
+          env:
+            # kubectl writes its discovery cache under $HOME; give it a writable one.
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml $c.resources | nindent 12 }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ $name }}
+            defaultMode: 0555
+            items:
+              - key: coordinator.sh
+                path: coordinator.sh
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -57,11 +57,11 @@ imagePullSecrets:
 {{- end }}
 ---
 # Cluster-scoped read of the embedded-cluster Installation (the upgrade signal),
-# plus deployment get/list/watch/patch so the controller can scale sandboxes.
-# Deployment access is cluster-wide because the runtime namespace is created
-# lazily by runtime-api and may not exist when this chart installs; the script
-# only ever touches `runtimeNamespace`. Narrow this to a namespaced Role if you
-# can guarantee the namespace exists first.
+# plus deployment get/list/watch/patch/update so the controller can scale
+# sandboxes. This is a ClusterRole (not a namespaced Role) because the
+# controller runs in the infra release namespace but scales sandbox deployments
+# in the openhands namespace, which the openhands chart creates later and which
+# may not exist when this chart installs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -108,6 +108,8 @@ data:
     # rancher/kubectl here: it is FROM scratch and has no shell.
     set -u
 
+    # Namespace runtime-api drops sandboxes into (its K8S_NAMESPACE), which in
+    # the openhands chart is the openhands release namespace.
     NS='{{ $c.runtimeNamespace }}'
     SELECTOR='{{ $c.sandboxSelector }}'
     INTERVAL='{{ $c.pollIntervalSeconds }}'

--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -119,7 +119,19 @@ data:
     # POSIX sh — alpine/k8s ships a shell and kubectl. Do NOT swap in
     # rancher/kubectl here: it is FROM scratch and has no shell.
     set -u
-
+    # Sandbox upgrade coordinator — keeps sandbox PDBs out of the way during
+    # k0s upgrades, then locks them back down. Control loop:
+    #
+    #   1. Every INTERVAL seconds, read status.state of all Installation CRDs.
+    #   2. If any is in a drain state (upgrade rolling nodes) → relax every
+    #      sandbox PDB to maxUnavailable=100% so the node can drain.
+    #   3. Otherwise (idle) → restore every sandbox PDB to maxUnavailable=0
+    #      to protect running sandboxes.
+    #   4. If state is unreadable (CRD missing / API error) → leave PDBs as-is.
+    #
+    # Only PDBs matching the sandbox selector are touched, and only when the
+    # value actually differs — steady state writes nothing and logs nothing.
+    # 
     # Namespace runtime-api drops sandboxes into (its K8S_NAMESPACE), which in
     # the openhands chart is the openhands release namespace. The sandbox PDBs
     # live here and carry the sandbox label.

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -92,8 +92,9 @@ crdCheck:
 # Disabled by default; on other clusters the controller would just idle.
 sandboxUpgradeCoordinator:
   enabled: false
-  # Namespace where runtime-api creates sandbox pods (its K8S_NAMESPACE).
-  runtimeNamespace: runtime-pods
+  # Namespace where runtime-api creates sandbox pods (its K8S_NAMESPACE). In the
+  # openhands chart this is the openhands release namespace.
+  runtimeNamespace: openhands
   # Label selector identifying sandbox deployments (runtime-api labels each
   # sandbox with runtime_id).
   sandboxSelector: runtime_id

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -81,3 +81,40 @@ crdCheck:
       memory: 64Mi
     limits:
       memory: 128Mi
+
+# Keeps the per-sandbox PodDisruptionBudgets in place across a Kubernetes (k0s)
+# upgrade. A small controller watches the embedded-cluster `Installation` state
+# and, while a k0s upgrade is rolling nodes, scales sandbox deployments to zero
+# so nothing blocks autopilot's node drains; it restores them when the upgrade
+# finishes. See templates/sandbox-upgrade-coordinator.yaml for the full design.
+#
+# Enable ONLY on embedded-cluster installs (where the Installation CRD exists).
+# Disabled by default; on other clusters the controller would just idle.
+sandboxUpgradeCoordinator:
+  enabled: false
+  # Namespace where runtime-api creates sandbox pods (its K8S_NAMESPACE).
+  runtimeNamespace: runtime-pods
+  # Label selector identifying sandbox deployments (runtime-api labels each
+  # sandbox with runtime_id).
+  sandboxSelector: runtime_id
+  # Installation states that mean a k0s node roll is underway. While any
+  # Installation reports one of these, sandboxes are held at zero replicas.
+  # "Enqueued" and "Installing" are the states embedded-cluster sets around the
+  # autopilot plan; widen for more lead time or narrow to reduce false starts.
+  drainStates:
+    - Enqueued
+    - Installing
+  # Seconds between Installation-state polls.
+  pollIntervalSeconds: 10
+  # Needs a shell AND kubectl. Do NOT use rancher/kubectl (FROM scratch, no shell).
+  image:
+    repository: docker.io/alpine/k8s
+    tag: "1.30.0"
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      memory: 64Mi

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -82,26 +82,30 @@ crdCheck:
     limits:
       memory: 128Mi
 
-# Keeps the per-sandbox PodDisruptionBudgets in place across a Kubernetes (k0s)
-# upgrade. A small controller watches the embedded-cluster `Installation` state
-# and, while a k0s upgrade is rolling nodes, scales sandbox deployments to zero
-# so nothing blocks autopilot's node drains; it restores them when the upgrade
-# finishes. See templates/sandbox-upgrade-coordinator.yaml for the full design.
+# Lets a Kubernetes (k0s) upgrade drain nodes without dropping the per-sandbox
+# PodDisruptionBudgets that protect sandboxes the rest of the time. A small
+# controller watches the embedded-cluster `Installation` state and, while a k0s
+# upgrade is rolling nodes, relaxes the sandbox PDBs (maxUnavailable=100%) so
+# autopilot's node drains can evict the pods; it sets them back to
+# maxUnavailable=0 when the upgrade finishes. The Deployments are left at
+# replicas=1, so pods return on their own once the node uncordons. See
+# templates/sandbox-upgrade-coordinator.yaml for the full design.
 #
 # Enable ONLY on embedded-cluster installs (where the Installation CRD exists).
 # Disabled by default; on other clusters the controller would just idle.
 sandboxUpgradeCoordinator:
   enabled: false
-  # Namespace where runtime-api creates sandbox pods (its K8S_NAMESPACE). In the
-  # openhands chart this is the openhands release namespace.
+  # Namespace where runtime-api creates sandbox pods and their PDBs (its
+  # K8S_NAMESPACE). In the openhands chart this is the openhands release namespace.
   runtimeNamespace: openhands
-  # Label selector identifying sandbox deployments (runtime-api labels each
-  # sandbox with runtime_id).
+  # Label selector identifying sandbox PDBs (runtime-api labels each sandbox and
+  # its PDB with runtime_id).
   sandboxSelector: runtime_id
   # Installation states that mean a k0s node roll is underway. While any
-  # Installation reports one of these, sandboxes are held at zero replicas.
-  # "Enqueued" and "Installing" are the states embedded-cluster sets around the
-  # autopilot plan; widen for more lead time or narrow to reduce false starts.
+  # Installation reports one of these, the sandbox PDBs are relaxed so the node
+  # can drain. "Enqueued" and "Installing" are the states embedded-cluster sets
+  # around the autopilot plan; widen for more lead time or narrow to reduce false
+  # starts.
   drainStates:
     - Enqueued
     - Installing

--- a/replicated/infra-cert-manager.yaml
+++ b/replicated/infra-cert-manager.yaml
@@ -15,6 +15,17 @@ spec:
   values:
     trust-manager:
       enabled: false
+    # Sandbox upgrade coordinator: scales sandboxes to zero during a k0s node
+    # roll so their PodDisruptionBudgets don't block the drain, then restores
+    # them. Enabled here (one of the two infra releases) so it ships with the
+    # embedded-cluster installer. Runs as a DaemonSet so it survives the drain.
+    # See charts/infra/templates/sandbox-upgrade-coordinator.yaml.
+    sandboxUpgradeCoordinator:
+      enabled: true
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/alpine/k8s'
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
     cert-manager:
       enabled: true
       global:

--- a/replicated/infra-cert-manager.yaml
+++ b/replicated/infra-cert-manager.yaml
@@ -15,10 +15,11 @@ spec:
   values:
     trust-manager:
       enabled: false
-    # Sandbox upgrade coordinator: scales sandboxes to zero during a k0s node
-    # roll so their PodDisruptionBudgets don't block the drain, then restores
-    # them. Enabled here (one of the two infra releases) so it ships with the
-    # embedded-cluster installer. Runs as a DaemonSet so it survives the drain.
+    # Sandbox upgrade coordinator: during a k0s node roll it relaxes the sandbox
+    # PodDisruptionBudgets (maxUnavailable=100%) so the drain can evict the pods,
+    # then sets them back to maxUnavailable=0. Enabled here (one of the two infra
+    # releases) so it ships with the embedded-cluster installer. Runs as a
+    # DaemonSet so it survives the drain.
     # See charts/infra/templates/sandbox-upgrade-coordinator.yaml.
     sandboxUpgradeCoordinator:
       enabled: true

--- a/replicated/infra-cert-manager.yaml
+++ b/replicated/infra-cert-manager.yaml
@@ -22,6 +22,8 @@ spec:
     # See charts/infra/templates/sandbox-upgrade-coordinator.yaml.
     sandboxUpgradeCoordinator:
       enabled: true
+      # runtime-api's K8S_NAMESPACE in the openhands chart.
+      runtimeNamespace: openhands
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/alpine/k8s'
       imagePullSecrets:


### PR DESCRIPTION
## Description

runtime-api gives every sandbox a PodDisruptionBudget with `maxUnavailable=0`, so a sandbox pod is never voluntarily evicted. On embedded-cluster installs that protection has a side effect: it also blocks the node drains the k0s upgrade performs. Autopilot drains nodes through the eviction API, and a `maxUnavailable=0` PDB rejects every eviction, so a k8s version upgrade stalls on a cordoned node and never finishes.

This adds a small controller, the sandbox-upgrade-coordinator, so the upgrade can drain the node without giving up that PDB protection the rest of the time. While a k0s upgrade is rolling nodes, it relaxes the sandbox PDBs to `maxUnavailable=100%` so the drain can evict the pods, then sets them back to `maxUnavailable=0` once the upgrade finishes.

It's baked into the infra chart, disabled by default, and enabled for embedded-cluster installs - where the upgrade happens and the `Installation` CRD it watches exists. The sandbox Deployments stay at `replicas=1`, so each pod reschedules on its own once the node uncordons, and the node-local workspace PVC survives the reboot. The interruption is the pod being killed and recreated.

## Approach

A few choices worth flagging:

- **It acts on the PDB.** The PDB is the only thing blocking the drain. The obvious alternative - scaling the sandbox Deployment to zero - would fight runtime-api, which owns `spec.replicas` and the sandbox lifecycle state in its database, and it would bypass runtime-api's own pause/stop bookkeeping. Relaxing the PDB is the minimal change that respects that ownership.
- **It runs as a DaemonSet.** k0s autopilot and `kubectl drain` pass `IgnoreAllDaemonSets`, so this pod survives the very drain it has to act during. A Deployment's pod would get evicted with everything else and wouldn't be around to restore the PDBs afterward.
- **It's a standalone controller that reacts to `Installation` state.** A chart pre-upgrade hook would fire too late: embedded-cluster upgrades k0s before the application charts, so the node roll has already stalled by the time a hook runs. The controller watches the `Installation` state and reacts at the start of the k0s upgrade.

The selector only matches PDBs labeled `runtime_id`, so the app's own PDBs (keycloak, postgres, redis) are left alone. The relax is idempotent and only widens a PDB during a detected upgrade. If the controller is down, the worst case is the upgrade stalls on a cordoned node - autopilot retries the drain every 120s - so the PDB protection is never silently dropped.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart (infra `0.1.2` -> `0.1.3`)
- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

The new `sandboxUpgradeCoordinator` values are additive and default to `enabled: false`, so existing `values.yaml` configs are unaffected. There are no breaking changes and no new required values, so the README doesn't need an update.

## Additional Notes

Validated on an embedded-cluster install:

- The coordinator deploys and runs as a DaemonSet.
- Against a real sandbox PDB (a warm-pool runtime), the scoping is right: it targets only the `runtime_id` PDB and leaves keycloak/postgres/redis alone.
- At steady state it issues zero patches and logs nothing, so there's no flapping.
- The k0s upgrade path is tested end-to-end: with a sandbox present, the upgrade drains the node and completes instead of stalling on the sandbox PDB.