### PR TITLE
feat(sysbox): default sandbox isolation on the embedded cluster

### DIFF
--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -29,16 +29,24 @@ application chart runs.
   `crdCheck.enabled: true` and is used by the trust-manager release to wait
   for cert-manager CRDs to reach the `Established` condition before
   applying trust-manager's webhook resources.
+- `templates/sysbox-installer.yaml` renders, only when `sysbox.enabled: true`,
+  a privileged DaemonSet plus a `sysbox` RuntimeClass. The DaemonSet runs
+  `files/install-sysbox.sh` on each host (via `nsenter --target 1`) to install
+  Sysbox and register the `sysbox` containerd runtime through a k0s
+  containerd drop-in. It targets Embedded Cluster (k0s) and discovers the
+  containerd config path at runtime, so it works regardless of the EC
+  `--data-dir`. Requires a Debian/Ubuntu host with internet access.
 
 ## Releases
 
-Two Replicated HelmChart manifests reference this chart with different
+Three Replicated HelmChart manifests reference this chart with different
 toggles:
 
-| Manifest                              | `cert-manager.enabled` | `trust-manager.enabled` | `crdCheck.enabled` | KOTS weight |
-|---------------------------------------|------------------------|-------------------------|--------------------|-------------|
-| `replicated/infra-cert-manager.yaml`  | `true`                 | `false`                 | `false`            | 5           |
-| `replicated/infra-trust-manager.yaml` | `false`                | `true`                  | `true`             | 6           |
+| Manifest                              | `cert-manager.enabled` | `trust-manager.enabled` | `crdCheck.enabled` | `sysbox.enabled`              | KOTS weight |
+|---------------------------------------|------------------------|-------------------------|--------------------|-------------------------------|-------------|
+| `replicated/infra-cert-manager.yaml`  | `true`                 | `false`                 | `false`            | `false`                       | 5           |
+| `replicated/infra-trust-manager.yaml` | `false`                | `true`                  | `true`             | `false`                       | 6           |
+| `replicated/infra-sysbox.yaml`        | `false`                | `false`                 | `false`            | `true` when Sandbox Isolation = Sysbox | 7           |
 
 The trust-manager release runs the CRD check before applying its own
 resources, because `helm install --wait` only waits for pods to become

--- a/charts/infra/files/install-sysbox.sh
+++ b/charts/infra/files/install-sysbox.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# install-sysbox.sh — runs on each node, installed by the infra chart's sysbox
+# DaemonSet. The DaemonSet stages the image-baked Sysbox artifacts onto the host
+# under $SYSBOX_ARTIFACTS_DIR, then execs this script on the HOST via
+# `nsenter --target 1`, so systemctl and the containerd drop-in all act on the
+# node itself.
+#
+# It installs Sysbox from those staged artifacts (no download, no apt/dpkg) and
+# registers the sysbox containerd runtime through a k0s containerd drop-in, so
+# pods with runtimeClassName: sysbox-runc get VM-like (user-namespace) isolation.
+# Idempotent: safe to re-run on every pod restart.
+#
+# Because the binaries are portable Go builds and k0s ships its own containerd,
+# this works on any systemd host with kernel >= 6.3 — not just Debian/Ubuntu.
+# (Kernel >= 6.3 is enforced by the openhands chart's Sysbox preflight.)
+#
+# Order matters: Sysbox is installed BEFORE the containerd drop-in is written.
+# That way, when k0s reloads containerd to pick up the drop-in, containerd's
+# first registration of the sysbox runtime queries the binary's `features`
+# subcommand and reports userns support to kubelet — no second containerd bounce.
+
+set -euo pipefail
+
+SYSBOX_VERSION="${SYSBOX_VERSION:-0.7.0}"
+SYSBOX_ARTIFACTS_DIR="${SYSBOX_ARTIFACTS_DIR:-/run/sysbox-install}"
+READY_FILE=/run/sysbox-installer.ready
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+log() { echo "==> $*"; }
+
+# Re-gate readiness until this run finishes configuring the node.
+rm -f "$READY_FILE"
+
+# --- Discover the k0s-managed containerd config + binary --------------------
+# Embedded Cluster runs k0s with a custom --data-dir, so don't assume /etc/k0s.
+# Find containerd's actual --config and binary from the running process.
+conf_from_pid() {
+  local pid="$1" args
+  args="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+  # Trailing `|| true` is load-bearing: under `set -e`, a bare
+  # VAR="$(conf_from_pid ...)" assignment aborts the whole script if this
+  # pipeline exits non-zero — which it does when containerd was launched without
+  # --config (k0s often runs it bare: cmdline is just "/usr/bin/containerd"), as
+  # grep then matches nothing. Returning success emits an empty string and lets
+  # discovery fall through to the k0s default path below instead of dying
+  # silently with exit 1.
+  echo "$args" | grep -oE -- '--config[ =][^ ]+' | head -1 | sed -E 's/--config[ =]//' || true
+}
+
+CONTAINERD_CONF=""
+CONTAINERD_BIN=""
+for _ in $(seq 1 30); do
+  pid="$(pgrep -x containerd 2>/dev/null | head -1 || true)"
+  if [ -n "$pid" ]; then
+    CONTAINERD_CONF="$(conf_from_pid "$pid")"
+    CONTAINERD_BIN="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+    # containerd is up. Its config path is either parsed from the cmdline above
+    # or, when it was launched without --config, the k0s default set just below.
+    # Either way there is nothing more to wait for, so stop once the process is
+    # found — don't keep looping (and stalling ~60s) just because the cmdline
+    # carried no --config.
+    break
+  fi
+  sleep 2
+done
+[ -n "$CONTAINERD_CONF" ] || CONTAINERD_CONF=/etc/k0s/containerd.toml
+[ -f "$CONTAINERD_CONF" ] || err "containerd config not found at $CONTAINERD_CONF"
+grep -q '^# k0s_managed=true' "$CONTAINERD_CONF" \
+  || err "$CONTAINERD_CONF is not k0s-managed; refusing to modify it"
+
+DROPIN_DIR="$(dirname "$CONTAINERD_CONF")/containerd.d"
+DROPIN="$DROPIN_DIR/sysbox.toml"
+
+log "containerd config: $CONTAINERD_CONF"
+log "containerd binary: ${CONTAINERD_BIN:-<unresolved>}"
+log "drop-in:           $DROPIN"
+
+# --- 1. Install Sysbox from the staged, image-baked artifacts ----------------
+# The DaemonSet copied the Sysbox binaries and systemd units out of the nestybox
+# image into $SYSBOX_ARTIFACTS_DIR (bin/ + systemd/). We install them the same
+# way nestybox's own installer does for a containerd node, minus the CRI-O,
+# shiftfs and apt steps: shiftfs is unneeded for kernel >= 6.3, and the binaries
+# have no package dependencies for our validated Docker-in-Docker path.
+#
+# We deliberately do NOT touch /etc/subuid or /etc/subgid. nestybox's installer
+# only configures those on its CRI-O path; on containerd with `hostUsers: false`
+# (which runtime-api sets for sysbox sandboxes) the kubelet owns user-namespace
+# ID allocation, so a "containers" subid range is never consulted — and blindly
+# appending one would overlap the host's default user range.
+SYSBOX_BIN_DIR="$SYSBOX_ARTIFACTS_DIR/bin"
+SYSBOX_UNIT_DIR="$SYSBOX_ARTIFACTS_DIR/systemd"
+[ -f "$SYSBOX_BIN_DIR/sysbox-runc" ] \
+  || err "staged sysbox binaries not found in $SYSBOX_BIN_DIR (did the DaemonSet stage them?)"
+
+need_install=true
+if command -v sysbox-runc >/dev/null 2>&1; then
+  cur="$(sysbox-runc --version 2>/dev/null | awk '/^[[:space:]]*version:/ {print $2}')"
+  if [ "$cur" = "$SYSBOX_VERSION" ] \
+     && systemctl is-active --quiet sysbox-mgr \
+     && systemctl is-active --quiet sysbox-fs; then
+    log "sysbox-runc $SYSBOX_VERSION already installed and active; skipping reinstall"
+    need_install=false
+  else
+    log "sysbox-runc ${cur:-unknown} present; (re)installing $SYSBOX_VERSION"
+  fi
+fi
+
+if $need_install; then
+  # Stop Sysbox (if running) so the binaries can be replaced without a
+  # "text file busy". mgr/fs are PartOf sysbox.service, so this stops all three;
+  # tolerate absence on first install.
+  systemctl stop sysbox 2>/dev/null || true
+
+  log "installing sysbox binaries into /usr/bin"
+  install -m 0755 "$SYSBOX_BIN_DIR/sysbox-mgr"  /usr/bin/sysbox-mgr
+  install -m 0755 "$SYSBOX_BIN_DIR/sysbox-fs"   /usr/bin/sysbox-fs
+  install -m 0755 "$SYSBOX_BIN_DIR/sysbox-runc" /usr/bin/sysbox-runc
+
+  # Kernel sysctls + modules Sysbox needs. `sysctl -e` ignores keys absent on
+  # this kernel (e.g. kernel.unprivileged_userns_clone on non-Debian kernels),
+  # so a single missing key can't abort the install.
+  log "applying sysbox sysctls and kernel modules"
+  install -D -m 0644 "$SYSBOX_UNIT_DIR/99-sysbox-sysctl.conf" /etc/sysctl.d/99-sysbox-sysctl.conf
+  install -D -m 0644 "$SYSBOX_UNIT_DIR/50-sysbox-mod.conf"    /etc/modules-load.d/50-sysbox-mod.conf
+  sysctl -e -p /etc/sysctl.d/99-sysbox-sysctl.conf || true
+  modprobe configfs 2>/dev/null || true
+
+  log "installing sysbox systemd units"
+  install -m 0644 "$SYSBOX_UNIT_DIR/sysbox.service"     /etc/systemd/system/sysbox.service
+  install -m 0644 "$SYSBOX_UNIT_DIR/sysbox-mgr.service" /etc/systemd/system/sysbox-mgr.service
+  install -m 0644 "$SYSBOX_UNIT_DIR/sysbox-fs.service"  /etc/systemd/system/sysbox-fs.service
+  systemctl daemon-reload
+  systemctl enable sysbox.service sysbox-mgr.service sysbox-fs.service
+
+  log "starting sysbox"
+  systemctl restart sysbox
+fi
+
+# --- 2. Verify Sysbox services ----------------------------------------------
+log "verifying sysbox systemd units"
+systemctl is-active --quiet sysbox     || systemctl restart sysbox
+systemctl is-active --quiet sysbox-mgr || err "sysbox-mgr not active"
+systemctl is-active --quiet sysbox-fs  || err "sysbox-fs not active"
+
+# --- 3. containerd drop-in (write only when changed) -------------------------
+# k0s's main containerd.toml imports this dir directly (imports =
+# ["<dir>/containerd.d/*.toml"]) and watches it, restarting containerd to load
+# changes. So there is NO separate merged-CRI file to grep, and writing only on
+# change avoids bouncing containerd every time the DaemonSet pod restarts.
+# k0s requires version = 3 (the containerd v2 plugin path), despite the public
+# docs example showing version = 2.
+log "ensuring $DROPIN"
+mkdir -p "$DROPIN_DIR"
+NEW_DROPIN="$(mktemp)"
+cat > "$NEW_DROPIN" <<'EOF'
+version = 3
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
+  runtime_type = "io.containerd.runc.v2"
+  pod_annotations = ["nestybox.sysbox-runtime"]
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
+  BinaryName = "/usr/bin/sysbox-runc"
+  SystemdCgroup = false
+EOF
+if cmp -s "$NEW_DROPIN" "$DROPIN" 2>/dev/null; then
+  log "drop-in already current"
+  rm -f "$NEW_DROPIN"
+else
+  mv "$NEW_DROPIN" "$DROPIN"
+  log "drop-in written; k0s will reload containerd"
+fi
+
+# --- 4. Verify the sysbox runtime drop-in is in place ------------------------
+# Confirm the drop-in that registers the runtime is present and names it. We do
+# NOT read it back from `containerd config dump`: run as a one-off command it
+# does not expand the main config's `imports`, so it never shows the drop-in even
+# though the running containerd has loaded it (verified in practice — sysbox
+# sandboxes run). The k0s-managed containerd binary is also not reliably
+# executable from the host mount namespace (k0s launches it from a path that need
+# not exist on the host fs, e.g. cmdline "/usr/bin/containerd" with no such file).
+# k0s watches $DROPIN_DIR and reloads containerd to apply changes, so a correct
+# drop-in file is what makes the runtime live.
+log "verifying sysbox runtime drop-in"
+grep -q 'runtimes\.sysbox-runc' "$DROPIN" \
+  || err "sysbox runtime drop-in missing or malformed at $DROPIN"
+
+log "sysbox runtime ready on $(hostname)"
+: > "$READY_FILE"
+
+# Hold the pod open; a re-run on restart keeps the node configured.
+exec sleep infinity

--- a/charts/infra/templates/sysbox-installer.yaml
+++ b/charts/infra/templates/sysbox-installer.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.sysbox.enabled }}
+# RuntimeClass that maps pods (runtimeClassName: sysbox-runc) to the sysbox
+# containerd runtime the DaemonSet below registers on each node. Cluster-scoped,
+# so it is created once regardless of the release namespace.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: {{ .Values.sysbox.runtimeClassName }}
+  labels:
+    app.kubernetes.io/name: sysbox-installer
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+handler: {{ .Values.sysbox.runtimeClassName }}
+---
+# Privileged DaemonSet that installs Sysbox onto every node and wires up the
+# sysbox containerd runtime via a k0s drop-in. The Sysbox binaries + systemd
+# units ship inside the nestybox image (/opt/sysbox); an init container using
+# that image stages them onto the host under /run/sysbox-install, then the
+# installer container (a modern image, for a working nsenter) enters the host's
+# namespaces and runs the installer from those staged artifacts (see
+# files/install-sysbox.sh). Two images are needed because the nestybox image is
+# centos:7-based and its nsenter (util-linux 2.23.2) cannot enter PID 1's
+# namespaces on recent kernels.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysbox-installer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: sysbox-installer
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sysbox-installer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sysbox-installer
+    spec:
+      # hostPID lets `nsenter --target 1` reach the host's init namespaces.
+      hostPID: true
+      {{- with .Values.sysbox.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sysbox.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sysbox.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Stage the image-baked Sysbox artifacts onto the host. The binaries live
+      # in the nestybox image's filesystem (/opt/sysbox), so they are copied to
+      # the host-shared staging dir here; the installer container below then
+      # enters the host mount namespace (where /opt/sysbox is not visible) and
+      # reads them back from $SYSBOX_ARTIFACTS_DIR. This is the ONLY use of the
+      # nestybox image — its ancient nsenter is never invoked.
+      initContainers:
+        - name: stage-artifacts
+          image: "{{ .Values.sysbox.image.repository }}:{{ .Values.sysbox.image.tag }}"
+          imagePullPolicy: {{ .Values.sysbox.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          env:
+            - name: SYSBOX_ARTIFACTS_DIR
+              value: /run/sysbox-install
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "==> staging Sysbox artifacts from image to host ${SYSBOX_ARTIFACTS_DIR}"
+              mkdir -p /host-staging/bin /host-staging/systemd
+              cp -a /opt/sysbox/bin/generic/. /host-staging/bin/
+              cp -a /opt/sysbox/systemd/. /host-staging/systemd/
+          volumeMounts:
+            # Maps to host $SYSBOX_ARTIFACTS_DIR; the init container writes the
+            # staged binaries/units here, the host-side installer reads them back.
+            - name: sysbox-staging
+              mountPath: /host-staging
+      containers:
+        - name: installer
+          # Modern util-linux (nsenter >= 2.38) as the runner: it enters the host
+          # namespaces and runs the installer from the artifacts the init
+          # container staged under $SYSBOX_ARTIFACTS_DIR on the host. Not the
+          # nestybox image, whose centos:7 nsenter (2.23.2) fails on kernel 6.x.
+          image: "{{ .Values.sysbox.runnerImage.repository }}:{{ .Values.sysbox.runnerImage.tag }}"
+          imagePullPolicy: {{ .Values.sysbox.runnerImage.pullPolicy }}
+          securityContext:
+            privileged: true
+          env:
+            - name: SYSBOX_VERSION
+              value: {{ .Values.sysbox.version | quote }}
+            # Host path (in the host mount namespace) where the init container
+            # staged the image-baked Sysbox artifacts for the installer to read.
+            - name: SYSBOX_ARTIFACTS_DIR
+              value: /run/sysbox-install
+            - name: INSTALL_SCRIPT
+              value: |
+{{ .Files.Get "files/install-sysbox.sh" | indent 16 }}
+          # `nsenter --mount` enters the host mount namespace (where the staged
+          # artifacts live at $SYSBOX_ARTIFACTS_DIR) and the host's bash runs the
+          # installer. The container bash expands $INSTALL_SCRIPT and hands the
+          # text to the host's bash.
+          command:
+            - /bin/bash
+            - -c
+            - exec nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/bash -c "$INSTALL_SCRIPT"
+          # Ready only once the host has been fully configured (sentinel on host).
+          readinessProbe:
+            exec:
+              command: ["nsenter", "--target", "1", "--mount", "--", "test", "-f", "/run/sysbox-installer.ready"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          resources:
+            {{- toYaml .Values.sysbox.resources | nindent 12 }}
+      volumes:
+        # Staging area on the host for the image-baked Sysbox artifacts. Lives
+        # on tmpfs (/run); re-created on every pod (re)start, which is fine since
+        # the installer is idempotent and re-stages each run.
+        - name: sysbox-staging
+          hostPath:
+            path: /run/sysbox-install
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -122,3 +122,57 @@ sandboxUpgradeCoordinator:
       memory: 32Mi
     limits:
       memory: 64Mi
+
+# Sysbox installer. When enabled, a privileged DaemonSet installs the Sysbox
+# container runtime on every node and registers the sysbox RuntimeClass,
+# giving pods with runtimeClassName: sysbox-runc VM-like (user-namespace)
+# isolation. Disabled by default; the Replicated "Sandbox Isolation" config
+# option turns it on.
+#
+# The Sysbox binaries and systemd units are baked into the image below (the
+# official nestybox/sysbox-deploy-k8s image), so the install needs no internet
+# access (fixes air-gap) and is not tied to Debian/Ubuntu: the binaries are
+# portable Go builds and k0s ships its own containerd, so any systemd host with
+# kernel >= 6.3 works. Kernel >= 6.3 is enforced by the openhands chart's Sysbox
+# preflight.
+sysbox:
+  enabled: false
+  # Sysbox CE version, used for the on-host idempotency/version check and for
+  # logging. Must match the Sysbox version encoded in image.tag below.
+  version: "0.7.0"
+  # Name of the RuntimeClass + handler. Must stay in sync with the containerd
+  # runtime name in files/install-sysbox.sh and the runtime-api RUNTIME_CLASS
+  # value (replicated/openhands.yaml).
+  runtimeClassName: sysbox-runc
+  image:
+    # Official nestybox image that ships the Sysbox binaries under
+    # /opt/sysbox/bin/generic and the systemd units under /opt/sysbox/systemd.
+    # Used ONLY by the init container to stage those artifacts onto the host: it
+    # is centos:7-based (util-linux 2.23.2), whose nsenter cannot enter PID 1's
+    # namespaces on recent kernels, so it must NOT run the installer itself. The
+    # tag encodes the Sysbox version as v<version>-0; keep it in sync with
+    # .version above.
+    repository: ghcr.io/nestybox/sysbox-deploy-k8s
+    tag: v0.7.0-0
+    pullPolicy: IfNotPresent
+  # Runner image for the installer container. Its only job is to provide a modern
+  # nsenter (util-linux >= 2.38) that can enter the host namespaces to run
+  # files/install-sysbox.sh; it is never installed on the host, so this stays
+  # distro-agnostic for the node. Split out from image above because the nestybox
+  # image's ancient nsenter fails on kernel 6.x (exits 1 before the script runs).
+  runnerImage:
+    repository: docker.io/library/debian
+    tag: bookworm-slim
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # Run on every Linux node, tolerating all taints (incl. control-plane).
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - operator: Exists
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      memory: 512Mi

--- a/charts/openhands/templates/troubleshoot/_sysbox.tpl
+++ b/charts/openhands/templates/troubleshoot/_sysbox.tpl
@@ -1,0 +1,61 @@
+{{/*
+Sysbox precondition preflight: when "Sandbox Isolation" is set to Sysbox, verify
+the host can actually run Sysbox sandboxes before install. Sysbox sandboxes run
+with hostUsers: false (native Kubernetes user namespaces), which requires a
+recent kernel. If the kernel is too old the deploy would come up broken
+(sandboxes can't mount sysfs), so the kernel analyzer fails and tells the
+operator to switch Sandbox Isolation to "runc".
+
+The Sysbox runtime is installed on every node from binaries baked into the
+installer image (no download, and not tied to Debian/Ubuntu), so there is no
+egress or package-manager precondition to check — the kernel floor is the only
+hard gate.
+
+Preconditions checked (kernel requirement is from the Kubernetes user-namespaces
+docs: kernel 6.3 is where tmpfs gained idmap-mount support; containerd 2.0+ ships
+with this embedded-cluster's k8s 1.36, so it is not re-checked here):
+  - Node kernel >= 6.3 ...... required for hostUsers: false userns        (fail)
+  - Node OS is Debian/Ubuntu  the only combination validated end-to-end   (warn)
+
+Both are read from the default clusterResources collector's
+cluster-resources/nodes.json via textAnalyze (no pod, no hostPath -> Pod Security
+Standards safe). textAnalyze matches if ANY node satisfies the check; on the
+single-node (or homogeneous multi-node) embedded-cluster installs this feature
+targets that is exact.
+
+Gated in preflights.yaml on Sysbox being the selected isolation (runtime-api's
+RUNTIME_CLASS == "sysbox-runc", set from the config option in replicated/openhands.yaml).
+*/}}
+
+{{- define "troubleshoot.sysbox.vars" -}}
+{{- $rtApiEnv := (index .Values "runtime-api" | default dict).env | default dict -}}
+selected: {{ eq ($rtApiEnv.RUNTIME_CLASS | toString) "sysbox-runc" }}
+{{- end -}}
+
+{{- define "troubleshoot.analyzers.sysbox" -}}
+- textAnalyze:
+    checkName: "Sysbox: node kernel is 6.3 or newer"
+    fileName: cluster-resources/nodes.json
+    # Matches kernelVersion >= 6.3: "6." with minor >= 3 (6.3-6.9 or two-digit
+    # 6.10+), or any major >= 7. Anchored to the value so a 5.15 kernel's "15"
+    # can't masquerade as a major version.
+    regex: '"kernelVersion":\s*"(6\.([3-9]|[1-9][0-9]+)|([7-9]|[1-9][0-9]+)\.)'
+    outcomes:
+      - pass:
+          when: "true"
+          message: "Kernel is 6.3 or newer."
+      - fail:
+          when: "false"
+          message: "Sysbox requires Linux kernel 6.3+ (e.g. Ubuntu 24.04). Upgrade the kernel, or set Sandbox Isolation to runc."
+- textAnalyze:
+    checkName: "Sysbox: node OS is Debian/Ubuntu"
+    fileName: cluster-resources/nodes.json
+    regex: '"osImage":\s*"(Ubuntu|Debian)'
+    outcomes:
+      - pass:
+          when: "true"
+          message: "Node OS is Debian/Ubuntu."
+      - warn:
+          when: "false"
+          message: "Sysbox is validated only on Debian/Ubuntu. If sandboxes fail to start, set Sandbox Isolation to runc."
+{{- end -}}

--- a/charts/openhands/templates/troubleshoot/preflights.yaml
+++ b/charts/openhands/templates/troubleshoot/preflights.yaml
@@ -1,5 +1,6 @@
 {{- define "troubleshoot.preflights" -}}
 {{- $tls := include "troubleshoot.tlsHostname.vars" . | fromYaml -}}
+{{- $sysbox := include "troubleshoot.sysbox.vars" . | fromYaml -}}
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
@@ -12,6 +13,9 @@ spec:
     {{- end }}
   analyzers:
     {{- include "troubleshoot.analyzers.shared" . | nindent 4 }}
+    {{- if $sysbox.selected }}
+    {{- include "troubleshoot.analyzers.sysbox" . | nindent 4 }}
+    {{- end }}
     {{- if $tls.cert }}
     {{- include "troubleshoot.analyzers.tlsHostname" . | nindent 4 }}
     {{- end }}

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -13,6 +13,9 @@ spec:
   additionalNamespaces:
     - openhands
     - cert-manager
+    # The Sysbox installer DaemonSet runs in kube-system (privileged, host
+    # namespaces), so KOTS must provision the image pull secret there too.
+    - kube-system
 
   statusInformers:
     # openhands

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -878,6 +878,18 @@ spec:
       title: Sandbox Configuration
       description: OpenHands conversations run in isolated sandboxes. Configure sandbox resources and lifecycle settings here. Adjust these settings based on your expected workload and the size of your cluster.
       items:
+        - name: sandbox_isolation
+          title: Sandbox Isolation
+          help_text: |
+            The container runtime used to isolate each sandbox.
+            Sysbox (default) provides stronger isolation between sandboxes and enables Docker-in-Docker. It requires Linux kernel 6.3+ (e.g. Ubuntu 24.04).
+          type: select_one
+          default: "sysbox"
+          items:
+            - name: "sysbox"
+              title: "Sysbox (stronger isolation, default)"
+            - name: "runc"
+              title: "runc (standard)"
         - name: runtime_routing_mode
           title: Sandbox Routing Mode
           help_text: |

--- a/replicated/infra-sysbox.yaml
+++ b/replicated/infra-sysbox.yaml
@@ -1,0 +1,58 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: infra-sysbox
+spec:
+  chart:
+    name: infra
+  releaseName: infra-sysbox
+  # kube-system already permits the privileged, host-namespace pods the Sysbox
+  # installer needs, and is where node-level DaemonSets conventionally live.
+  namespace: kube-system
+  # Weight 7 runs after cert-manager (5) and trust-manager (6) and before the
+  # openhands app (10), so Sysbox is installed on the node before any runtime
+  # pod that requests runtimeClassName: sysbox-runc can be scheduled.
+  weight: 7
+  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
+  values:
+    # This release only carries the Sysbox installer; cert-manager and
+    # trust-manager are installed by their own releases.
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    sysbox:
+      # Off by default. The "Sandbox Isolation" config option flips it on below.
+      enabled: false
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/nestybox/sysbox-deploy-k8s'
+      runnerImage:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/debian'
+
+  optionalValues:
+    # Install Sysbox only when the operator selects the Sysbox isolation level.
+    - when: '{{repl ConfigOptionEquals "sandbox_isolation" "sysbox" }}'
+      recursiveMerge: true
+      values:
+        sysbox:
+          enabled: true
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        sysbox:
+          image:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/sysbox-deploy-k8s'
+          runnerImage:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/debian'
+
+  builder:
+    # Render only the sysbox installer so `replicated release` discovers its
+    # image; cert-manager/trust-manager images come from their own releases.
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    sysbox:
+      enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -314,7 +314,22 @@ spec:
         RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_server") "") (ne (ConfigOption "custom_sandbox_image_registry_username") "") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"
-        RUNTIME_CLASS: ""
+        RUNTIME_CLASS: '{{repl if ConfigOptionEquals "sandbox_isolation" "sysbox"}}sysbox-runc{{repl else}}{{repl end}}'
+        # The embedded-cluster node carries no sysbox-install label or
+        # sysbox-runtime taint, so clear the scheduling defaults the runtime-api
+        # injects for the sysbox-runc class (node selector sysbox-install=yes +
+        # the sysbox-runtime toleration). Empty JSON collections mean "no node
+        # selector / no tolerations", keeping sandboxes schedulable on the single
+        # node. Scheduling is independent from the userns/hostUsers config
+        # (SET_HOST_USERS below). (runtime-api env vars from OpenHands/runtime-api#631.)
+        RUNTIME_TOLERATIONS: "[]"
+        RUNTIME_NODE_SELECTOR: "{}"
+        # Make the runtime-api set hostUsers: false on sysbox-runc sandboxes
+        # (native K8s user namespace). Required on k0s/containerd: without it the
+        # runtime-api uses a CRI-O-only userns annotation that is a no-op here, and
+        # sysbox-runc then can't mount sysfs into the sandbox ("operation not
+        # permitted"). Harmless for runc (only the sysbox-runc path reads it).
+        SET_HOST_USERS: "true"
         RUNTIME_DISABLE_SSL: "false"
         PERSISTENT_STORAGE_SIZE: 'repl{{ ConfigOption "sandbox_storage_size" }}'
         MEMORY_REQUEST: 'repl{{ ConfigOption "sandbox_memory_request" }}'


### PR DESCRIPTION
## Description

This adds sysbox as a sandbox isolation runtime for the embedded cluster. A privileged DaemonSet installs the sysbox runtime on every node and registers a `sysbox-runc` RuntimeClass. Runtime sandboxes then run under that class with user-namespace isolation, so they get stronger isolatio and can run Docker-in-Docker with no privileged or host access.

On the embedded cluster sysbox is the default isolation, with runc still selectable for hosts that can't meet its kernel requirement. A preflight blocks the install when sysbox is selected on a kernel older than 6.3.

## Helm Chart Checklist

- [x] I have updated the `version` field in `Chart.yaml` for each modified chart
- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

A few things worth a reviewer's attention:

- **How sysbox gets installed.** The runtime binaries and systemd units ship baked into the `sysbox-deploy-k8s` image. An init container copies them onto the host, then the installer container enters the host namespaces with `nsenter --target 1` and runs a host-side script that installs the binaries and registers the runtime through a k0s containerd drop-in. Nothing is downloaded at install time and there's no apt/dpkg, so it works on any systemd host with kernel 6.3+, and the image comes through the Replicated proxy like every other image.

- **Two images in the DaemonSet.** The init container uses the nestybox `sysbox-deploy-k8s` image purely as a source of the baked binaries. The installer container uses a debian image for the actual host entry, because the nestybox image is centos:7-based and its nsenter (util-linux 2.23.2) can't enter PID 1's namespaces on recent kernels.

- **k8s 1.36 is a prerequisite.** The containerd drop-in uses the containerd 2.x plugin path (`io.containerd.cri.v1.runtime`), which only exists on the containerd that k0s 1.36 ships. That's why this also bumps the embedded cluster to `2.19.1+k8s-1.36`.

- **runtime-api scheduling and userns wiring.** The runtime-api image is pinned to `0.3.0`, which adds `RUNTIME_TOLERATIONS` / `RUNTIME_NODE_SELECTOR` (OpenHands/runtime-api#631). Both are set empty in the Replicated values, so sandboxes drop the cloud sysbox node selector and toleration and stay schedulable on the single EC node. `SET_HOST_USERS=true` makes the runtime-api set `hostUsers: false` on sysbox-runc sandboxes, which is required on k0s/containerd - the CRI-O userns annotation it falls back to otherwise is a no-op there, and sysbox can't mount sysfs into the sandbox without it.

- **Preflight gate.** With sysbox selected, a preflight reads the node kernel from the cluster-resources collector. A kernel older than 6.3 fails the check; a non-Debian/Ubuntu OS warns, since that's the only combination validated end-to-end.
