### PR TITLE
docs: drop manual Chart.yaml version bump from PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,6 @@
 
 <!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->
 
-- [ ] I have updated the `version` field in `Chart.yaml` for each modified chart
 - [ ] I have tested the chart upgrade path from the previous version
 - [ ] I have verified backwards compatibility with existing values.yaml configurations
 - [ ] I have updated the chart's README.md if there are any breaking changes or new required values


### PR DESCRIPTION
## Summary

The Helm chart checklist told authors to bump the `version` field in `Chart.yaml` for each modified chart. That item was added in #132.

It's no longer required. Since #768 we use release-please to version the charts, so the bump happens automatically as part of that process. Asking authors to do it by hand is now redundant and can conflict with what release-please manages.

This drops that one checklist line. The rest of the checklist stays.