### PR TITLE
feat: Expose Laminar v1 API ingress for self-hosted analytics

### DIFF
--- a/charts/openhands/templates/ingress-laminar-api.yaml
+++ b/charts/openhands/templates/ingress-laminar-api.yaml
@@ -1,0 +1,33 @@
+{{- $apiIngress := .Values.laminar.apiIngress | default dict -}}
+{{- $tls := $apiIngress.tls | default dict -}}
+{{- if and .Values.laminar.enabled $apiIngress.enabled $apiIngress.hostname }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: laminar-api-ingress
+  {{ with $apiIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $apiIngress.className }}
+  ingressClassName: {{ $apiIngress.className }}
+  {{- end }}
+  {{- if $tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $apiIngress.hostname }}
+      secretName: {{ $tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ $apiIngress.hostname }}
+      http:
+        paths:
+          - path: {{ $apiIngress.path | default "/v1" }}
+            pathType: {{ $apiIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: laminar-app-server-service
+                port:
+                  number: 8000
+{{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -498,6 +498,20 @@ laminar:
         clusterIssuer: ""
       annotations: {}
 
+  # OpenHands-managed ingress that exposes only Laminar's public ingestion API
+  # paths on the analytics hostname. This avoids exposing the full app-server
+  # surface through the upstream Laminar appServer.ingress, which routes "/".
+  apiIngress:
+    enabled: false
+    hostname: ""
+    className: ""
+    path: /v1
+    pathType: Prefix
+    tls:
+      enabled: false
+      secretName: "laminar-frontend-tls"
+    annotations: {}
+
   appServer:
     # loadBalancer creates an L4 Network Load Balancer Service for the app-server (OTLP trace ingestion).
     # Use this on AWS (NLB) where runtimes send traces directly over TCP.

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -59,6 +59,7 @@ spec:
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/service/laminar-rabbitmq-headless{{repl end}}'
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/service/laminar-rabbitmq-service{{repl end}}'
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/service/laminar-redis-service{{repl end}}'
+    - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/ingress/laminar-api-ingress{{repl end}}'
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/ingress/laminar-frontend-ingress{{repl end}}'
 
     # postgres

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -999,6 +999,13 @@ spec:
             env:
               nextauthUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
               nextPublicUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+          apiIngress:
+            enabled: true
+            hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+            className: "traefik"
+            tls:
+              enabled: true
+              secretName: "openhands-tls"
           postgres:
             persistence:
               storageClass: "openebs-hostpath"

--- a/scripts/test_laminar_api_ingress.py
+++ b/scripts/test_laminar_api_ingress.py
@@ -1,0 +1,41 @@
+"""Tests for the self-hosted Laminar API ingress contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAMINAR_API_INGRESS = (
+    REPO_ROOT / "charts" / "openhands" / "templates" / "ingress-laminar-api.yaml"
+)
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+REPLICATED_APPLICATION = REPO_ROOT / "replicated" / "application.yaml"
+
+
+def test_laminar_api_ingress_exposes_only_v1_prefix() -> None:
+    template = LAMINAR_API_INGRESS.read_text(encoding="utf-8")
+
+    assert 'name: laminar-api-ingress' in template
+    assert 'path: {{ $apiIngress.path | default "/v1" }}' in template
+    assert 'pathType: {{ $apiIngress.pathType | default "Prefix" }}' in template
+    assert "name: laminar-app-server-service" in template
+    assert "number: 8000" in template
+    assert "path: /" not in template
+
+
+def test_replicated_enables_laminar_api_ingress_on_analytics_host() -> None:
+    values = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
+
+    assert "apiIngress:" in values
+    assert "enabled: true" in values
+    assert "analytics.app.{{repl ConfigOption \"base_domain\"}}" in values
+    assert "{{repl ConfigOption \"analytics_hostname\"}}" in values
+    assert "appServer:\n            loadBalancer:\n              enabled: false" in values
+    assert "appServer:\n            loadBalancer:\n              enabled: false\n            ingress:" not in values
+
+
+def test_replicated_application_expects_laminar_api_ingress() -> None:
+    application = REPLICATED_APPLICATION.read_text(encoding="utf-8")
+
+    assert "openhands/ingress/laminar-api-ingress" in application


### PR DESCRIPTION
## Summary
- add an OpenHands-managed Laminar API ingress that exposes only `/v1` on the analytics hostname
- enable that ingress for self-hosted analytics in Replicated values
- include the ingress in Replicated expected resources and add regression tests

## Testing
- `uvx pytest scripts/test_laminar_api_ingress.py scripts/test_keycloak_realm_template.py`

## Why

Exposing /v1/ paths was suggested by Din from laminar see https://openhands-ai.slack.com/archives/C06U8UTKSAD/p1782941063706259?thread_ts=1782843637.758159&cid=C06U8UTKSAD

The concern is in the same thread, by Aarushi, currently we are not allowing api server access and it's needed to process laminar traces externally.