### PR TITLE
feat(charts): build OH_AGENT_SERVER_ENV from a mergeable map

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -642,25 +642,40 @@
 */}}
 {{- define "openhands.env" }}
 {{- $defaults := include "openhands.env.defaults" . | fromYamlArray }}
+{{- /*
+    Effective env-var overrides. Start from .Values.env, then fold the
+    structured .Values.agentServerEnv map into OH_AGENT_SERVER_ENV: the map is
+    merged on top of any JSON string already present at
+    .Values.env.OH_AGENT_SERVER_ENV and re-serialised to JSON. This lets callers
+    (e.g. replicated/openhands.yaml) assemble OH_AGENT_SERVER_ENV from a
+    recursively-merged map of individual keys instead of repeating a hand-written
+    JSON blob in every optionalValues block. When agentServerEnv is empty,
+    .Values.env passes through unchanged, so existing callers are unaffected.
+   */}}
+{{- $envOverrides := .Values.env | default dict }}
+{{- if .Values.agentServerEnv }}
+{{- $envOverrides = deepCopy $envOverrides }}
+{{- $base := dict }}
+{{- with (get $envOverrides "OH_AGENT_SERVER_ENV") }}
+{{- $base = mustFromJson (. | toString) }}
+{{- end }}
+{{- $_ := set $envOverrides "OH_AGENT_SERVER_ENV" (mustToJson (mergeOverwrite $base (deepCopy .Values.agentServerEnv))) }}
+{{- end }}
 {{- /* Build a lookup dict of override keys for O(1) membership checks */}}
 {{- $overrideKeys := dict }}
-{{- if .Values.env }}
-{{- range $key, $_ := .Values.env }}
+{{- range $key, $_ := $envOverrides }}
 {{- $_ := set $overrideKeys $key true }}
 {{- end }}
-{{- end }}
-{{- /* Keep only default entries that are NOT overridden by .Values.env */}}
+{{- /* Keep only default entries that are NOT overridden by the effective overrides */}}
 {{- $filtered := list }}
 {{- range $entry := $defaults }}
 {{- if not (hasKey $overrideKeys (get $entry "name")) }}
 {{- $filtered = append $filtered $entry }}
 {{- end }}
 {{- end }}
-{{- /* Append user overrides from .Values.env (these take precedence) */}}
-{{- if .Values.env }}
-{{- range $key, $value := .Values.env }}
+{{- /* Append overrides (these take precedence) */}}
+{{- range $key, $value := $envOverrides }}
 {{- $filtered = append $filtered (dict "name" $key "value" ($value | toString)) }}
-{{- end }}
 {{- end }}
 {{- $filtered | toYaml }}
 {{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -81,6 +81,16 @@ env:
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
+# Structured source for the OH_AGENT_SERVER_ENV environment variable, which the
+# enterprise-server passes through to every agent-server (sandbox) runtime it
+# spawns. Rather than hand-writing that JSON blob, list the runtime's env vars
+# as a map here and the chart serialises it to JSON (see the "openhands.env"
+# helper). The map is merged on top of any OH_AGENT_SERVER_ENV string set
+# directly in .Values.env, so callers that layer values — e.g. KOTS
+# optionalValues with recursiveMerge — can add keys without repeating the whole
+# blob in every block. Empty by default, which emits no OH_AGENT_SERVER_ENV.
+agentServerEnv: {}
+
 filestore:
   ephemeral: false
   bucket: openhands-sessions

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -51,7 +51,8 @@ spec:
       # unconditionally (not gated on analytics_enabled) so the Keycloak realm
       # redirect URIs stay on the analytics domain either way.
       LAMINAR_WEB_HOST: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
-      OH_AGENT_SERVER_ENV: '{"SSL_CERT_FILE": "/etc/openhands/ca-bundle/ca-bundle.crt", "REQUESTS_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "GIT_SSL_CAINFO": "/etc/openhands/ca-bundle/ca-bundle.crt", "CURL_CA_BUNDLE": "/etc/openhands/ca-bundle/ca-bundle.crt", "NODE_EXTRA_CA_CERTS": "/etc/openhands/ca-bundle/ca-bundle.crt"}'
+      # OH_AGENT_SERVER_ENV is assembled by the chart from spec.values.agentServerEnv
+      # (see the map below), not hand-written here.
       OPENHANDS_DEFAULT_ORG_ENABLED: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
       OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS: 'repl{{ ConfigOptionEquals "default_openhands_org_auto_add_users" "1" }}'
       # Hiding personal workspaces needs both forms: the structured flag drives
@@ -69,6 +70,18 @@ spec:
       # Enterprise reads the FEATURE_FLAGS-prefixed name; bare name kept for OSS.
       OH_WEB_CLIENT_FEATURE_FLAGS_ALLOW_USER_LLM_CONFIGURATION: 'repl{{ ConfigOptionEquals "allow_user_llm_configuration" "1" }}'
       OH_ALLOW_USER_LLM_CONFIGURATION: 'repl{{ ConfigOptionEquals "allow_user_llm_configuration" "1" }}'
+
+    # Runtime (agent-server sandbox) env vars. The chart serialises this map into
+    # OH_AGENT_SERVER_ENV (see the openhands.env helper). These CA-bundle
+    # defaults apply to every provider; the provider optionalValues blocks below
+    # recursively-merge their own keys on top, so the bundle vars live here once
+    # instead of being repeated in each block.
+    agentServerEnv:
+      SSL_CERT_FILE: /etc/openhands/ca-bundle/ca-bundle.crt
+      REQUESTS_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
+      GIT_SSL_CAINFO: /etc/openhands/ca-bundle/ca-bundle.crt
+      CURL_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
+      NODE_EXTRA_CA_CERTS: /etc/openhands/ca-bundle/ca-bundle.crt
 
     ingress:
       enabled: true
@@ -691,7 +704,14 @@ spec:
           HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
           NO_PROXY: '{{repl $computedNoProxy}}'
           SSL_VERIFY: '{{repl if ConfigOptionEquals "ssl_verify" "1"}}True{{repl else}}False{{repl end}}'
-          OH_AGENT_SERVER_ENV: '{{repl printf "{\"HTTP_PROXY\": \"%s\", \"HTTPS_PROXY\": \"%s\", \"NO_PROXY\": \"%s\", \"SSL_VERIFY\": \"%s\", \"GIT_SSL_NO_VERIFY\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOption "http_proxy") (ConfigOption "https_proxy") $computedNoProxy (ConfigOptionEquals "ssl_verify" "1" | ternary "True" "False") (ConfigOptionEquals "ssl_verify" "1" | ternary "False" "True") }}'
+        # Runtime proxy vars, recursively-merged onto the base agentServerEnv
+        # (CA-bundle) map, so only the proxy-specific keys need to appear here.
+        agentServerEnv:
+          HTTP_PROXY: '{{repl ConfigOption "http_proxy"}}'
+          HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
+          NO_PROXY: '{{repl $computedNoProxy}}'
+          SSL_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "True" "False"}}'
+          GIT_SSL_NO_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "False" "True"}}'
         keycloak:
           extraEnvVars:
             # Existing KC env vars (must be repeated because recursiveMerge replaces arrays)
@@ -728,7 +748,12 @@ spec:
           # textarea's first line from the legacy azure_deployment_name value,
           # so this stays byte-identical to today's azure-<deployment> default.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/azure-repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "azure_deployments" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
-          OH_AGENT_SERVER_ENV: '{{repl printf "{\"AZURE_API_KEY\": \"%s\", \"AZURE_API_BASE\": \"%s\", \"AZURE_API_VERSION\": \"%s\"}" (ConfigOption "azure_api_key") (ConfigOption "azure_endpoint") (ConfigOption "azure_api_version") }}'
+        # Azure runtime creds, recursively-merged onto the base agentServerEnv
+        # (CA-bundle) map.
+        agentServerEnv:
+          AZURE_API_KEY: '{{repl ConfigOption "azure_api_key"}}'
+          AZURE_API_BASE: '{{repl ConfigOption "azure_endpoint"}}'
+          AZURE_API_VERSION: '{{repl ConfigOption "azure_api_version"}}'
         litellm-helm:
           proxy_config:
             # One azure-<name> -> azure/<name> entry per non-empty line of the
@@ -770,7 +795,11 @@ spec:
           # served via the hidden alias in the model_list below, so existing
           # user/org settings keep working.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "custom_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = splitList "/" $m | last }}repl{{ end }}repl{{ end }}repl{{ $first }}'
-          OH_AGENT_SERVER_ENV: '{{repl printf "{\"CUSTOM_API_KEY\": \"%s\", \"CUSTOM_API_BASE\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOption "custom_api_key") (ConfigOption "custom_base_url") }}'
+        # Custom-endpoint runtime creds, recursively-merged onto the base
+        # agentServerEnv (CA-bundle) map.
+        agentServerEnv:
+          CUSTOM_API_KEY: '{{repl ConfigOption "custom_api_key"}}'
+          CUSTOM_API_BASE: '{{repl ConfigOption "custom_base_url"}}'
         litellm-helm:
           proxy_config:
             # One entry per non-empty line of the "Custom LLM Models" KOTS
@@ -797,7 +826,16 @@ spec:
           # falling back to gemini-2.5-flash — today's hardcoded default and
           # the textarea's prefilled line — if it resolves empty.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "vertex_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first | default "gemini-2.5-flash" }}'
-          OH_AGENT_SERVER_ENV: '{{repl printf "{\"VERTEXAI_CREDENTIALS\": %s, \"VERTEXAI_PROJECT\": \"%s\", \"VERTEXAI_LOCATION\": \"%s\", \"SSL_CERT_FILE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"REQUESTS_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"GIT_SSL_CAINFO\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"CURL_CA_BUNDLE\": \"/etc/openhands/ca-bundle/ca-bundle.crt\", \"NODE_EXTRA_CA_CERTS\": \"/etc/openhands/ca-bundle/ca-bundle.crt\"}" (ConfigOptionData "google_vertex_credentials" | toJson) (ConfigOption "google_vertex_project_id") (ConfigOption "google_vertex_location") }}'
+        # Vertex runtime creds, recursively-merged onto the base agentServerEnv
+        # (CA-bundle) map. ConfigOptionData returns the decoded (possibly
+        # multi-line) service-account JSON; `default "{}" | mustFromJson |
+        # mustToJson` minifies it to a single-line JSON string so it stays a
+        # valid YAML scalar, and the chart then JSON-encodes that string as the
+        # env value — matching the previous `... | toJson` handling.
+        agentServerEnv:
+          VERTEXAI_CREDENTIALS: '{{repl ConfigOptionData "google_vertex_credentials" | default "{}" | mustFromJson | mustToJson }}'
+          VERTEXAI_PROJECT: '{{repl ConfigOption "google_vertex_project_id"}}'
+          VERTEXAI_LOCATION: '{{repl ConfigOption "google_vertex_location"}}'
         litellm-helm:
           # volumes / volumeMounts are arrays — recursiveMerge replaces them,
           # so the ca-bundle entry from spec.values.litellm-helm above must
@@ -852,7 +890,12 @@ spec:
           # alias in the model_list below, so existing user/org settings keep
           # working.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "bedrock_model_ids" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
-          OH_AGENT_SERVER_ENV: '{{repl printf "{\"AWS_ACCESS_KEY_ID\": \"%s\", \"AWS_SECRET_ACCESS_KEY\": \"%s\", \"AWS_REGION_NAME\": \"%s\"}" (ConfigOption "aws_access_key_id") (ConfigOption "aws_secret_access_key") (ConfigOption "aws_region_name") }}'
+        # Bedrock runtime creds, recursively-merged onto the base agentServerEnv
+        # (CA-bundle) map.
+        agentServerEnv:
+          AWS_ACCESS_KEY_ID: '{{repl ConfigOption "aws_access_key_id"}}'
+          AWS_SECRET_ACCESS_KEY: '{{repl ConfigOption "aws_secret_access_key"}}'
+          AWS_REGION_NAME: '{{repl ConfigOption "aws_region_name"}}'
         litellm-helm:
           proxy_config:
             # One <id> -> bedrock/<id> entry per non-empty line of the


### PR DESCRIPTION
## Description

Closes https://linear.app/all-hands-ai/issue/PLTF-2032/set-agent-server-env-as-a-values-entry-with-helper

`OH_AGENT_SERVER_ENV` is a JSON string that the enterprise-server passes to every agent-server (sandbox) runtime. In `replicated/openhands.yaml` it was hand-written as a JSON blob per provider, and every block re-listed the same five CA-bundle vars. Because the value was a single scalar, KOTS `recursiveMerge` replaced it wholesale, so each provider block had to repeat the shared vars to keep them.

This makes the chart assemble `OH_AGENT_SERVER_ENV` from a structured `agentServerEnv` map instead. The CA-bundle vars now live once in a base map, and each provider's optionalValues block adds only its own keys via recursive merge. Adding a runtime env var is now a one-line map entry.


## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Backwards compatible by design. `agentServerEnv` defaults to `{}`, which the helper treats as a no-op, so charts that don't set it render exactly as before. It's not a new required value. If a caller still sets a raw `OH_AGENT_SERVER_ENV` string in `.Values.env`, that keeps working; when both are present the map merges on top.

One behavior change worth calling out: azure and bedrock runtimes now also inherit the CA-bundle vars from the base map. They didn't before, because their scalar string replaced the base entirely. This also fixes a latent bug where enabling a proxy together with a provider like azure dropped one block's vars (last matching block won the scalar). The CA-bundle mount is unconditional (`caBundle.enabled: true`), so pointing every provider's runtime at it is safe.

The vertex service-account JSON goes through `default "{}" | mustFromJson | mustToJson` so the (possibly multi-line) file collapses to a single-line YAML scalar before the chart JSON-encodes it. That's functionally equivalent to the previous `| toJson` handling.