### PR TITLE
chore: move image values to top of values files

### DIFF
--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -67,13 +67,13 @@ trust-manager:
 # and supply the CRD list to wait on.
 crdCheck:
   enabled: false
-  timeout: 120s
-  backoffLimit: 6
-  crds: []
   image:
     repository: docker.io/rancher/kubectl
     tag: v1.33.0
     pullPolicy: IfNotPresent
+  timeout: 120s
+  backoffLimit: 6
+  crds: []
   imagePullSecrets: []
   resources:
     requests:
@@ -95,6 +95,10 @@ crdCheck:
 # Disabled by default; on other clusters the controller would just idle.
 sandboxUpgradeCoordinator:
   enabled: false
+  image:
+    repository: docker.io/alpine/k8s
+    tag: "1.30.0"
+    pullPolicy: IfNotPresent
   # Namespace where runtime-api creates sandbox pods and their PDBs (its
   # K8S_NAMESPACE). In the openhands chart this is the openhands release namespace.
   runtimeNamespace: openhands
@@ -111,11 +115,6 @@ sandboxUpgradeCoordinator:
     - Installing
   # Seconds between Installation-state polls.
   pollIntervalSeconds: 10
-  # Needs a shell AND kubectl. Do NOT use rancher/kubectl (FROM scratch, no shell).
-  image:
-    repository: docker.io/alpine/k8s
-    tag: "1.30.0"
-    pullPolicy: IfNotPresent
   imagePullSecrets: []
   resources:
     requests:

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -186,6 +186,8 @@ env: {}
 # Service name will be "{release-name}-postgresql", secret name also "{release-name}-postgresql"
 postgresql:
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     username: postgres
     database: automations
@@ -197,8 +199,6 @@ postgresql:
   service:
     ports:
       postgresql: 5432
-  image:
-    repository: bitnamilegacy/postgresql
 
 global:
   security:

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -175,6 +175,8 @@ env: {}
 # Service name will be "{release-name}-postgresql", secret name also "{release-name}-postgresql"
 postgresql:
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     username: postgres
     database: integrations_hub
@@ -186,8 +188,6 @@ postgresql:
   service:
     ports:
       postgresql: 5432
-  image:
-    repository: bitnamilegacy/postgresql
 
 global:
   security:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -1,3 +1,10 @@
+image:
+  repository: ghcr.io/openhands/runtime-api
+  # You must use a stable, semver tag. Do not use sha-based tags.
+  # If you are hotfixing, you MUST create a patch release and use the semver tag.
+  tag: 0.2.0
+  pullPolicy: Always
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -7,13 +14,6 @@ databaseMigrations:
   waitForDatabase: true
   createDatabases: false
   migrate: true
-
-image:
-  repository: ghcr.io/openhands/runtime-api
-  # You must use a stable, semver tag. Do not use sha-based tags.
-  # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: 0.2.0
-  pullPolicy: Always
 
 imagePullSecrets:
   - name: ghcr-login-secret
@@ -117,12 +117,12 @@ securityContext: {}
 # other device plugins; the sandbox pods do not.
 kvm:
   enabled: false
-  resourceName: smarter-devices/kvm
-  maxDevices: 20
   image:
     repository: ghcr.io/smarter-project/smarter-device-manager
     tag: v1.20.11
     pullPolicy: IfNotPresent
+  resourceName: smarter-devices/kvm
+  maxDevices: 20
   # The device plugin advertises /dev/kvm but the node's default 0660 root:kvm
   # perms still block the non-root sandbox UID from opening it. An init container
   # relaxes /dev/kvm to 0666 so unprivileged sandboxes can use it. Disable only if
@@ -148,6 +148,8 @@ affinity: {}
 
 postgresql:
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
   isFeatureDeploy: false
   primary:
     persistence:
@@ -160,8 +162,6 @@ postgresql:
     password: "" # This should be set externally for security reasons
     existingSecret: postgres-password
     database: runtime_api_db
-  image:
-    repository: bitnamilegacy/postgresql
 
 externalDatabase:
   enabled: false
@@ -352,13 +352,13 @@ replicated:
   enabled: false
 
 global:
-  security:
-    # This allows using the bitnamilegacy image repo.
-    # See: https://github.com/bitnami/containers/issues/83267
-    allowInsecureImages: true
   # Canonical agent-server image. Defaults any warm-runtime configsByName entry
   # that omits its own `image`. In the openhands umbrella the parent chart's
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
     tag: 1.29.0-python
+  security:
+    # This allows using the bitnamilegacy image repo.
+    # See: https://github.com/bitnami/containers/issues/83267
+    allowInsecureImages: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -8,6 +8,12 @@ allowedUsers: null
 # them without the OpenHands app itself.
 enabled: true
 
+image:
+  repository: ghcr.io/openhands/enterprise-server
+  # You must use a stable, semver tag. Do not use sha-based tags.
+  # If you are hotfixing, you MUST create a patch release and use the semver tag.
+  tag: cloud-1.40.0
+
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -188,12 +194,6 @@ gitlabWebhookInstallation:
       memory: 512Mi
       cpu: 200m
 
-image:
-  repository: ghcr.io/openhands/enterprise-server
-  # You must use a stable, semver tag. Do not use sha-based tags.
-  # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.40.0
-
 ingress:
   enabled: false
   # REQUIRED: Update to a hostname in a DNS domain you own
@@ -350,6 +350,8 @@ uvicorn:
 
 keycloak:
   enabled: false
+  image:
+    repository: bitnamilegacy/keycloak
   # Parent-chart flag (not consumed by the Keycloak subchart): run the
   # realm-config init container that creates the OpenHands realm, its OIDC
   # client, and identity providers if missing, and updates them otherwise.
@@ -413,8 +415,6 @@ keycloak:
     # this is evaluated in the Keycloak subchart context at render time.
     - name: KC_DB_URL_PROPERTIES
       value: 'sslmode={{ .Values.externalDatabase.sslMode | default "prefer" }}'
-  image:
-    repository: bitnamilegacy/keycloak
   waitForDb:
     image: "bitnamilegacy/postgresql:latest"
   initContainers:
@@ -538,9 +538,6 @@ litellm-helm:
   # and because it is the most extensively tested scenario. Our automation uses an admin key
   # to do user management for the LiteLLM instance.
   enabled: false
-  masterkeySecretName: lite-llm-api-key
-  masterkeySecretKey: lite-llm-api-key
-  environmentSecrets: [litellm-env-secrets]
   # Pin the litellm image tag. The litellm-helm chart's default tag is its
   # appVersion (currently v1.80.8-nightly), which predates the
   # --use_v2_migration_resolver arg passed via the Replicated values and so
@@ -548,6 +545,9 @@ litellm-helm:
   # format BerriAI uses for 1.84.x+ stable images).
   image:
     tag: "1.84.1"
+  masterkeySecretName: lite-llm-api-key
+  masterkeySecretKey: lite-llm-api-key
+  environmentSecrets: [litellm-env-secrets]
   # Migrations run automatically when litellm starts. This disables running them separately as a job.
   migrationJob:
     enabled: false
@@ -630,6 +630,8 @@ minio:
 
 postgresql:
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     username: postgres
     existingSecret: postgres-password
@@ -644,8 +646,6 @@ postgresql:
     # Add the following if using Karpenter with persistence
     # podAnnotations:
     #   karpenter.sh/do-not-evict: "true"
-  image:
-    repository: bitnamilegacy/postgresql
 
 # One-time migration of embedded PostgreSQL data from an emptyDir volume to a
 # PVC. Renders pre-upgrade Helm hooks ONLY and is disabled by default; the
@@ -657,6 +657,19 @@ postgresql:
 # See templates/postgres-pvc-migration.yaml.
 postgresMigration:
   enabled: false
+  images:
+    # Orchestrator image — needs a shell AND kubectl. Do NOT use rancher/kubectl
+    # (it ships no shell, so `sh -c` fails).
+    kubectl:
+      repository: docker.io/alpine/k8s
+      tag: "1.30.0"
+      pullPolicy: IfNotPresent
+    # Seeder image — reuse the SAME pinned image as the postgresql subchart so
+    # the seeded PGDATA matches the version the recreated StatefulSet runs.
+    postgresql:
+      repository: docker.io/bitnami/postgresql
+      tag: 16.4.0-debian-12-r14
+      pullPolicy: IfNotPresent
   # PVC size / storageClass. These MUST match postgresql.primary.persistence so
   # the recreated StatefulSet adopts (rather than re-creates) the seeded PVC.
   # An empty storageClass falls back to the cluster default StorageClass.
@@ -676,19 +689,6 @@ postgresMigration:
     limits:
       memory: 1Gi
   imagePullSecrets: []
-  images:
-    # Orchestrator image — needs a shell AND kubectl. Do NOT use rancher/kubectl
-    # (it ships no shell, so `sh -c` fails).
-    kubectl:
-      repository: docker.io/alpine/k8s
-      tag: "1.30.0"
-      pullPolicy: IfNotPresent
-    # Seeder image — reuse the SAME pinned image as the postgresql subchart so
-    # the seeded PGDATA matches the version the recreated StatefulSet runs.
-    postgresql:
-      repository: docker.io/bitnami/postgresql
-      tag: 16.4.0-debian-12-r14
-      pullPolicy: IfNotPresent
 
 externalDatabase:
   enabled: false
@@ -698,6 +698,8 @@ externalDatabase:
 
 redis:
   enabled: true
+  image:
+    repository: bitnamilegacy/redis
   architecture: standalone
   auth:
     enabled: true
@@ -714,8 +716,6 @@ redis:
     limits:
       memory: 512Mi
       cpu: 100m
-  image:
-    repository: bitnamilegacy/redis
 
 maintenanceTasks:
   enabled: true
@@ -1073,16 +1073,16 @@ replicated:
   postgresDatabase: ""
 
 global:
-  security:
-    # This allows using the bitnamilegacy image repo.
-    # See: https://github.com/bitnami/containers/issues/83267
-    allowInsecureImages: true
   # Canonical agent-server image. Defaults the runtime image (runtime.image) and
   # any warm-runtime configsByName entry that omits its own `image`. Override
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
     tag: 1.29.0-python
+  security:
+    # This allows using the bitnamilegacy image repo.
+    # See: https://github.com/bitnami/containers/issues/83267
+    allowInsecureImages: true
 
 vertexAI:
   enabled: false
@@ -1131,13 +1131,13 @@ caBundle:
 # wait on. The Replicated layer enables this and supplies the list.
 crdCheck:
   enabled: false
-  timeout: 120s
-  backoffLimit: 6
-  crds: []
   image:
     repository: docker.io/rancher/kubectl
     tag: v1.33.0
     pullPolicy: IfNotPresent
+  timeout: 120s
+  backoffLimit: 6
+  crds: []
   imagePullSecrets: []
   resources:
     requests:


### PR DESCRIPTION
## Description

Move image/tag keys to the top of each maintained chart's `values.yaml` and to the first position within nested subchart blocks. Values are reordered only; no values change.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

YAML mapping key order is semantically irrelevant; rendered output is unchanged. Verified each modified file parses and is structurally equal to its pre-change version.

_This PR was created by an AI agent (OpenHands) on behalf of the user._