### PR TITLE
fix: Use Laminar values for API ingress backend

### DIFF
--- a/charts/openhands/templates/ingress-laminar-api.yaml
+++ b/charts/openhands/templates/ingress-laminar-api.yaml
@@ -1,5 +1,9 @@
 {{- $apiIngress := .Values.laminar.apiIngress | default dict -}}
 {{- $tls := $apiIngress.tls | default dict -}}
+{{- $env := .Values.env | default dict -}}
+{{- $laminarBaseUrl := get $env "LMNR_BASE_URL" | default "" -}}
+{{- $laminarBaseHost := (urlParse $laminarBaseUrl).host | default "" -}}
+{{- $laminarServiceName := (splitList ":" $laminarBaseHost | first) | default "laminar-app-server-service" -}}
 {{- if and .Values.laminar.enabled $apiIngress.enabled $apiIngress.hostname }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -27,7 +31,7 @@ spec:
             pathType: {{ $apiIngress.pathType | default "Prefix" }}
             backend:
               service:
-                name: laminar-app-server-service
+                name: {{ $laminarServiceName }}
                 port:
-                  number: 8000
+                  number: {{ .Values.laminar.httpPort | default 8000 }}
 {{- end }}

--- a/scripts/test_laminar_api_ingress.py
+++ b/scripts/test_laminar_api_ingress.py
@@ -19,8 +19,9 @@ def test_laminar_api_ingress_exposes_only_v1_prefix() -> None:
     assert 'name: laminar-api-ingress' in template
     assert 'path: {{ $apiIngress.path | default "/v1" }}' in template
     assert 'pathType: {{ $apiIngress.pathType | default "Prefix" }}' in template
-    assert "name: laminar-app-server-service" in template
-    assert "number: 8000" in template
+    assert '{{- $laminarBaseUrl := get $env "LMNR_BASE_URL" | default "" -}}' in template
+    assert "name: {{ $laminarServiceName }}" in template
+    assert "number: {{ .Values.laminar.httpPort | default 8000 }}" in template
     assert "path: /" not in template
 
 


### PR DESCRIPTION
## Summary
- derive the Laminar API ingress backend service from `env.LMNR_BASE_URL`
- use `laminar.httpPort` for the backend port instead of hardcoding `8000`
- update the Laminar API ingress regression test for the value-driven backend

## Testing
- `uvx pytest scripts/test_laminar_api_ingress.py scripts/test_keycloak_realm_template.py -q`
- temporary Helm v3.15.4 render of `charts/openhands` with Laminar API ingress enabled

Follow-up to #774 for Aivong’s review comments.