### PR TITLE
chore(release): OHE cloud-1.40.1 — backport JDC fixes + Jira timeouts (laminar-safe patch off 1.40.0)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.40.0
-version: 0.7.84
+appVersion: cloud-1.40.1
+version: 0.7.85
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.40.0
+  tag: cloud-1.40.1
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What
Cuts the **OHE `cloud-1.40.1`** patch: pins `enterprise-server` to the `cloud-1.40.1` tag and bumps the openhands chart `0.7.84 → 0.7.85`.

`cloud-1.40.1` = `cloud-1.40.0` + five back-ported fixes (no other 1.41.0 changes):
- **#15012** — Jira Cloud/DC HTTP timeouts configurable + consistent (helps 1finity's slow Jira DC)
- **#15034** — more forgiving repo + picker-mention resolution for Jira DC
- **#15036** — don't org-gate a personal-workspace Jira DC integration
- **#15040** — integration panel scoped by role (members get guidance, not the admin setup form) + email-mode agent hint
- **#14900** — don't switch LLM profile before the conversation UUID exists (avoids 422)

## Why a 1.40.x patch (not 1.41.0)
1.41.0 bumps the SDK to 1.30.0, which has a deterministic **laminar + streaming** bug (`software-agent-sdk#3972`): with `LMNR_PROJECT_API_KEY` set + forced streaming (#15021), every conversation fails. This patch stays on **SDK 1.29.0 / agent-server `1.29.0-python`**, delivering the fixes on a laminar-safe base while 1.41.0 waits on the SDK fix.

## Testing
Validated on replicated-02: in-place deploy of `cloud-1.40.1`, clean **no-op migration** (alembic head 126), all pods healthy, JDC panel/mention/hint + Jira timeout config confirmed present, app 200.

## After merge
Promote the resulting Replicated sequence to **Stable** (human-gated). Customers on 1.40.0 upgrade with a clean forward no-op migration.
