### PR TITLE
feat: Add warm runtime selection env vars

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -1,6 +1,10 @@
 {{- define "openhands.env.defaults" }}
 - name: RUNTIME
   value: remote
+- name: OH_SANDBOX_SPEC_KIND
+  value: openhands.app_server.sandbox.dynamic_remote_sandbox_spec_service.DynamicRemoteSandboxSpecServiceInjector
+- name: OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME
+  value: v1_current
 - name: OPENHANDS_CONFIG_CLS
   value: {{ .Values.appConfig.OPENHANDS_CONFIG_CLS }}
 - name: OPENHANDS_GITHUB_SERVICE_CLS


### PR DESCRIPTION
## Description

Adds two always-emitted environment variables to the OpenHands chart, next to the existing `RUNTIME=remote` entry in `openhands.env.defaults`:

- `OH_SANDBOX_SPEC_KIND=openhands.app_server.sandbox.dynamic_remote_sandbox_spec_service.DynamicRemoteSandboxSpecServiceInjector`
- `OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME=v1_current`

These are emitted unconditionally (no `{{- if ... }}` guard), matching the pattern used by `RUNTIME=remote`. They can still be overridden via the `.Values.env` map because they flow through the existing `openhands.env` wrapper that deduplicates defaults against user overrides.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

- Verified locally with `helm template`: both vars appear in the rendered env list, and `env.OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME: <override>` correctly wins over the default (deduplication logic at the bottom of `_env.yaml`).
- No new required values are introduced; the defaults are hard-coded into the chart, identical to how `RUNTIME=remote` is treated.

_This PR was created by an AI agent (OpenHands) on behalf of the user._