### PR TITLE
chore(charts): bump OpenHands image to cloud-1.41.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.40.0
+appVersion: cloud-1.41.0
 version: 0.8.0
 dependencies:
   - name: keycloak

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.40.0
+  tag: cloud-1.41.0
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Description

Bump the OpenHands image tag from `cloud-1.40.0` to `cloud-1.41.0` to pick up the latest release.

- `charts/openhands/Chart.yaml`: `appVersion` updated to `cloud-1.41.0`
- `charts/openhands/values.yaml`: `image.tag` updated to `cloud-1.41.0`

This PR was created by an AI agent (OpenHands) on behalf of the user.

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Image-only change; the chart's own version (`0.8.0`) is unchanged and will be managed by release-please.
