### PR TITLE
fix(release): give each release-please line its own labels

### DIFF
--- a/release-please-config.crd-check.json
+++ b/release-please-config.crd-check.json
@@ -3,6 +3,8 @@
   "bump-minor-pre-major": true,
   "include-commit-authors": true,
   "bootstrap-sha": "9a1529f375680a2b928375ad25d13d00c1a9dbfd",
+  "label": "autorelease: crd-check pending",
+  "release-label": "autorelease: crd-check tagged",
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },

--- a/release-please-config.image-loader.json
+++ b/release-please-config.image-loader.json
@@ -3,6 +3,8 @@
   "bump-minor-pre-major": true,
   "include-commit-authors": true,
   "bootstrap-sha": "9a1529f375680a2b928375ad25d13d00c1a9dbfd",
+  "label": "autorelease: image-loader pending",
+  "release-label": "autorelease: image-loader tagged",
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },

--- a/release-please-config.openhands-secrets.json
+++ b/release-please-config.openhands-secrets.json
@@ -3,6 +3,8 @@
   "bump-minor-pre-major": true,
   "include-commit-authors": true,
   "bootstrap-sha": "9a1529f375680a2b928375ad25d13d00c1a9dbfd",
+  "label": "autorelease: openhands-secrets pending",
+  "release-label": "autorelease: openhands-secrets tagged",
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },

--- a/release-please-config.openhands.json
+++ b/release-please-config.openhands.json
@@ -3,6 +3,8 @@
   "bump-minor-pre-major": true,
   "include-commit-authors": true,
   "bootstrap-sha": "9a1529f375680a2b928375ad25d13d00c1a9dbfd",
+  "label": "autorelease: openhands pending",
+  "release-label": "autorelease: openhands tagged",
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
## Description

The four release lines (openhands, image-loader, crd-check, openhands-secrets) run as independent release-please manifests but shared one label namespace: the default `autorelease: pending` / `autorelease: tagged`. release-please matches merged release PRs purely by that label, so every line latched onto whichever release PR merged.

That caused two problems on each openhands release:

- The sibling lines cut spurious tags and releases off openhands's PR (e.g. `image-loader/0.8.1` and `crd-check/0.8.1` pointing at openhands commits).
- All four jobs raced to remove the single shared `pending` label. The winner removed it; the losers got a 404 and the job crashed, which is why the last release run failed and had to be retried.

This gives each line its own `label` / `release-label` pair, so a manifest only ever matches and relabels its own release PR. release-please reads these keys per config and the label prefix still starts with `autorelease:`, so the downstream back-labeling step is unaffected.

## Helm Chart Checklist

N/A - no charts modified, only release-please config.

## Additional Notes

One migration step outside this PR: the in-flight image-loader release PR #769 still carries the old shared `autorelease: pending` label. Once this lands, no release line matches that label, so #769 gets orphaned. It needs the new `autorelease: image-loader pending` label so the image-loader line recognizes it as its own when it merges and cuts the 0.1.10 release. Simplest is to add that label to #769, or just merge #769 before this PR.