### PR TITLE
docs: PLTF-2960 fix chart_file paths in image-bump docs

### DIFF
--- a/docs/automated-image-tag-bumps.md
+++ b/docs/automated-image-tag-bumps.md
@@ -83,7 +83,7 @@ jobs:
     secrets: inherit
     with:
       component: runtime-api
-      chart_file: charts/runtime-api/values.yaml
+      chart_file: charts/openhands/charts/runtime-api/values.yaml
       image_tag_path: .image.tag          # optional — this is the default
       tag: ${{ needs.prepare-tag.outputs.tag }}
 ```
@@ -100,7 +100,7 @@ A ready-to-copy version is in
     secrets: inherit
     with:
       component: automation
-      chart_file: charts/automation/values.yaml
+      chart_file: charts/openhands/charts/automation/values.yaml
       tag: ${{ needs.prepare-tag.outputs.tag }}
 ```
 
@@ -140,7 +140,7 @@ current and no PR was needed).
 ```bash
 # Dry run against a real chart file (prints old -> new, writes nothing):
 uv run scripts/bump_image_tag/bump_image_tag.py \
-  --file charts/runtime-api/values.yaml --path .image.tag --tag sha-1234567 --dry-run
+  --file charts/openhands/charts/runtime-api/values.yaml --path .image.tag --tag sha-1234567 --dry-run
 
 # Unit tests:
 uv run scripts/bump_image_tag/test_bump_image_tag.py

--- a/docs/examples/component-release-bump.yml
+++ b/docs/examples/component-release-bump.yml
@@ -42,6 +42,6 @@ jobs:
     secrets: inherit
     with:
       component: runtime-api
-      chart_file: charts/runtime-api/values.yaml
+      chart_file: charts/openhands/charts/runtime-api/values.yaml
       image_tag_path: .image.tag          # optional — this is the default
       tag: ${{ needs.prepare-tag.outputs.tag }}


### PR DESCRIPTION
## Why
The caller examples in `docs/automated-image-tag-bumps.md` and `docs/examples/component-release-bump.yml` point `chart_file` at `charts/<component>/values.yaml`, but the component subcharts actually live under `charts/openhands/charts/<component>/values.yaml` — copy-pasting the snippet makes the bump script fail on a missing file. This corrects the four occurrences ahead of wiring up the `automation` caller (PLTF-2960).

## Validation
- `ls charts/openhands/charts/{automation,runtime-api}/values.yaml` — both corrected paths exist; the old `charts/automation` / `charts/runtime-api` paths do not.

_This PR was drafted by an AI agent on behalf of the user._