### PR TITLE
chore: Add automation to builder so it shows up on release image list

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -1101,3 +1101,5 @@ spec:
       enabled: true
     runtime-api:
       enabled: true
+    automation:
+      enabled: true


### PR DESCRIPTION
## Description
Add automation to builder so it shows up on release image list. I want the automation image to show up when we click "view release image list" in the replicated UI. So it's easier to create release notes and understand the bumps.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->
