### PR TITLE
fix(postgres): gate PVC-migration restore on the final server, not Bitnami's temp init server

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.41.0
-version: 0.9.1
+version: 0.9.0
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: cloud-1.41.0
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - name: keycloak
     version: 24.7.5

--- a/charts/openhands/templates/postgres-pvc-migration.yaml
+++ b/charts/openhands/templates/postgres-pvc-migration.yaml
@@ -214,6 +214,19 @@ data:
     /opt/bitnami/scripts/postgresql/entrypoint.sh /opt/bitnami/scripts/postgresql/run.sh >/tmp/local-pg.log 2>&1 &
     SERVER_PID=$!
 
+    # Bitnami setup runs a TEMPORARY server (stopped when setup ends) that also
+    # passes pg_isready; restoring into it loses the data mid-stream. Gate on
+    # run.sh's final-server marker before probing readiness.
+    log "Waiting for Bitnami setup to finish (final server start)..."
+    for _ in $(seq 1 120); do
+      if grep -qF '** Starting PostgreSQL **' /tmp/local-pg.log 2>/dev/null; then break; fi
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        log "Local server exited early:"; cat /tmp/local-pg.log || true; exit 1
+      fi
+      sleep 2
+    done
+    grep -qF '** Starting PostgreSQL **' /tmp/local-pg.log
+
     log "Waiting for the local server to accept connections..."
     for _ in $(seq 1 60); do
       if pg_isready -h 127.0.0.1 -p "$PORT" -U postgres >/dev/null 2>&1; then break; fi


### PR DESCRIPTION
## Problem

The `openhands-postgres-migration` pre-upgrade hook (#766) can fail with:

```
UPGRADE FAILED: pre-upgrade hooks failed: resource not ready, name: openhands-postgres-migration, kind: Job, status: Failed
```

A customer hit this on every attempt while upgrading to 0.7.85; diagnosed from their support bundle.

**Root cause — a startup race in `seed.sh`:** on first boot, the Bitnami entrypoint's setup phase starts a **temporary** background server (`postgresql_start_bg`, listening on 127.0.0.1:5432) to set the superuser password, then `setup.sh`'s `trap "postgresql_stop" EXIT` stops it before `run.sh` starts the real server. The seed script's `pg_isready` loop can pass against that temp server, so `pg_dumpall | psql` streams into it and gets killed mid-restore when setup finishes:

- attempt 1: `FATAL: terminating connection due to administrator command` (fast shutdown mid-restore), pg_dumpall broken pipe, integrity check caught `source=6 restored=1` → abort
- attempts 2–3: `FATAL: the database system is starting up` (real server still booting)

The abort path worked as designed — no cutover, old database left intact — but the upgrade is blocked.

## Fix

Before the readiness probe, wait for `run.sh`'s `** Starting PostgreSQL **` marker in the entrypoint log. The marker string is exact-matched (`grep -F`); the temp server's log line is `Starting PostgreSQL in background...` and cannot match it.

## Verification

Against the exact seeder image (`bitnamilegacy/postgresql:16.4.0-debian-12-r14`), instrumented run:

```
first pg_isready OK at: 1.1s (postmaster pid 122)   <- TEMP server: what the old loop latched onto
final-server marker at: 2.2s
postmaster pid after marker: 7, 5s later: 7, test rows: 1
GATED_PATH_STABLE
RACE_DEMONSTRATED: first-ready pid (122) was the TEMP server; final server pid is 7
```

Also: `helm template` renders, extracted `seed.sh` passes `bash -n`. The hook remains retry-safe (partial PGDATA is cleared per attempt; marker configmap only written after cutover).


Refs FDE-94
