### PR TITLE
Configure sandbox spec agent-server image

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -1,3 +1,44 @@
+{{- define "openhands.agentServerImage" -}}
+{{- printf "%s:%s" (.Values.runtime.image.repository | default .Values.global.agentServerImage.repository) (.Values.runtime.image.tag | default .Values.global.agentServerImage.tag) -}}
+{{- end -}}
+
+{{- define "openhands.defaultWarmRuntimeConfig" -}}
+{{- $runtimeApi := index .Values "runtime-api" | default dict -}}
+{{- $warmRuntimes := get $runtimeApi "warmRuntimes" | default dict -}}
+{{- $configsByName := get $warmRuntimes "configsByName" | default dict -}}
+{{- get $configsByName "default" | default dict | toYaml -}}
+{{- end -}}
+
+{{- define "openhands.defaultSandboxSpecCommand" -}}
+{{- $config := include "openhands.defaultWarmRuntimeConfig" . | fromYaml -}}
+{{- get $config "command" | default (list "/usr/local/bin/openhands-agent-server" "--port" "60000") | toYaml -}}
+{{- end -}}
+
+{{- define "openhands.defaultSandboxSpecWorkingDir" -}}
+{{- $config := include "openhands.defaultWarmRuntimeConfig" . | fromYaml -}}
+{{- get $config "working_dir" | default "/workspace/project" -}}
+{{- end -}}
+
+{{- define "openhands.defaultSandboxSpecInitialEnv" -}}
+{{- $config := include "openhands.defaultWarmRuntimeConfig" . | fromYaml -}}
+{{- $initialEnv := deepCopy (get $config "environment" | default dict) -}}
+{{- $envOverrides := .Values.env | default dict -}}
+{{- $agentServerEnv := dict -}}
+{{- with (get $envOverrides "OH_AGENT_SERVER_ENV") -}}
+{{- $agentServerEnv = mustFromJson (. | toString) -}}
+{{- end -}}
+{{- if .Values.agentServerEnv -}}
+{{- $agentServerEnv = mergeOverwrite $agentServerEnv (deepCopy .Values.agentServerEnv) -}}
+{{- end -}}
+{{- $initialEnv = mergeOverwrite $initialEnv $agentServerEnv -}}
+{{- range $key, $value := $envOverrides -}}
+{{- if or (hasPrefix "LLM_" $key) (hasPrefix "LMNR_" $key) -}}
+{{- $_ := set $initialEnv $key ($value | toString) -}}
+{{- end -}}
+{{- end -}}
+{{- mustToJson $initialEnv -}}
+{{- end -}}
+
 {{- define "openhands.env.defaults" }}
 - name: RUNTIME
   value: remote
@@ -112,6 +153,19 @@
 {{- end }}
 - name: NO_SETUP
   value: 'true'
+- name: OH_SANDBOX_SPEC_KIND
+  value: RemoteSandboxSpecServiceInjector
+- name: OH_SANDBOX_SPEC_SPECS_0_ID
+  value: {{ include "openhands.agentServerImage" . | quote }}
+{{- $sandboxSpecCommand := include "openhands.defaultSandboxSpecCommand" . | fromYamlArray }}
+{{- range $index, $part := $sandboxSpecCommand }}
+- name: OH_SANDBOX_SPEC_SPECS_0_COMMAND_{{ $index }}
+  value: {{ $part | quote }}
+{{- end }}
+- name: OH_SANDBOX_SPEC_SPECS_0_INITIAL_ENV
+  value: {{ include "openhands.defaultSandboxSpecInitialEnv" . | quote }}
+- name: OH_SANDBOX_SPEC_SPECS_0_WORKING_DIR
+  value: {{ include "openhands.defaultSandboxSpecWorkingDir" . | quote }}
 - name: AGENT_SERVER_IMAGE_REPOSITORY
   value: "{{ .Values.runtime.image.repository | default .Values.global.agentServerImage.repository }}"
 - name: AGENT_SERVER_IMAGE_TAG


### PR DESCRIPTION
## Summary

- Configure the default remote sandbox spec from the chart-rendered agent-server image values.
- Carry the default warm runtime command, working directory, and initial environment into the static sandbox spec.
- Keep the existing `AGENT_SERVER_IMAGE_*` env vars for compatibility with older OpenHands app images.

## Context

Companion for OpenHands/OpenHands#15168. That PR stops reading `AGENT_SERVER_IMAGE_REPOSITORY` and `AGENT_SERVER_IMAGE_TAG`, so OHE needs to provide the image through `OH_SANDBOX_SPEC_*` instead.

## Validation

- `helm dependency build charts/openhands`
- `helm lint charts/openhands`
- `helm template oh-main charts/openhands`
- `helm template oh-main charts/openhands --set-string global.agentServerImage.repository=local.registry/ns/agent-server --set-string global.agentServerImage.tag=9.9.9-python --set-string agentServerEnv.REQUESTS_CA_BUNDLE=/etc/test-ca.pem --set-string env.LLM_TIMEOUT=3600`
- `git diff --check`