### PR TITLE
fix(replicated): default deletion time to 3 days for self-hosted

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -889,7 +889,7 @@ spec:
           title: Deletion Time (seconds)
           help_text: How long (in seconds) before paused conversations are permanently deleted. Once deleted, the conversation's storage is freed and it can no longer be accessed.
           type: text
-          default: "86400"
+          default: "259200"
           validation:
             regex:
               pattern: ^[1-9][0-9]*$

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -889,7 +889,7 @@ spec:
           title: Deletion Time (seconds)
           help_text: How long (in seconds) before paused conversations are permanently deleted. Once deleted, the conversation's storage is freed and it can no longer be accessed.
           type: text
-          default: "5184000"
+          default: "1209600"
           validation:
             regex:
               pattern: ^[1-9][0-9]*$

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -889,7 +889,7 @@ spec:
           title: Deletion Time (seconds)
           help_text: How long (in seconds) before paused conversations are permanently deleted. Once deleted, the conversation's storage is freed and it can no longer be accessed.
           type: text
-          default: "1209600"
+          default: "86400"
           validation:
             regex:
               pattern: ^[1-9][0-9]*$


### PR DESCRIPTION
## Summary

PR #752 raised the Replicated `sandbox_dead_seconds` default from 1 day to 60 days (5184000s) to match the production SaaS retention window, which was itself a stopgap until workspace archiving ships.

That 60-day default doesn't make sense for self-hosted installs. A self-hosted operator running on their own storage doesn't want paused conversations pinning PVCs for two months by default.

The original default was 1 day, but feedback is that most operators end up bumping that to 3. This sets the default to 3 days (259200s) so it fits how people actually run it.

Operators who want longer retention can still set it to whatever they like in the config screen.
