### PR TITLE
fix(replicated): default deletion time to 10 days for self-hosted

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -889,7 +889,7 @@ spec:
           title: Deletion Time (seconds)
           help_text: How long (in seconds) before paused conversations are permanently deleted. Once deleted, the conversation's storage is freed and it can no longer be accessed.
           type: text
-          default: "259200"
+          default: "864000"
           validation:
             regex:
               pattern: ^[1-9][0-9]*$


### PR DESCRIPTION
## Summary

This PR updates the Replicated `sandbox_dead_seconds` default to 10 days (864000s) for self-hosted installations.

The previous default of 3 days (PR #803) was chosen as a balance between storage management and user convenience. However, feedback suggests that many operators prefer a longer retention window to accommodate weekly workflows and reduce the risk of losing work during extended weekends or short vacations.

10 days provides:
- Coverage for a full work week plus weekends
- Buffer for typical vacation periods
- Better balance between storage cost and user experience for self-hosted installations

Operators who need shorter or longer retention can still configure this value in the config screen to match their specific requirements.

**Change:** 259200 (3 days) → 864000 (10 days)

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b1c772cf-b07c-41f5-8234-5861abc25418)