### PR TITLE
PLTF-3196: Configure OpenHands resolver label for Replicated

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -718,6 +718,15 @@ spec:
           type: file
           when: 'repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}'
           required: true
+        - name: github_resolver_label
+          title: OpenHands Resolver Label
+          help_text: >-
+            The GitHub label that triggers the OpenHands resolver on issues and
+            pull requests. Defaults to "openhands". Set a custom value so this
+            instance only responds to that label and ignores the default.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}'
+          default: "openhands"
 
     - name: gitlab_authentication
       title: GitLab Authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -550,6 +550,7 @@ spec:
       values:
         env:
           ENABLE_V1_GITHUB_RESOLVER: "true"
+          OH_RESOLVER_LABEL: '{{repl ConfigOption "github_resolver_label"}}'
         githubApp:
           enabled: true
           appId: '{{repl ConfigOption "github_app_id"}}'

--- a/scripts/test_replicated_github_resolver_label.py
+++ b/scripts/test_replicated_github_resolver_label.py
@@ -1,0 +1,62 @@
+"""Tests for Replicated GitHub resolver label configuration."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+
+
+def extract_named_config_item(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^        - name: {re.escape(name)}\n.*?(?=^        - name: |\n\n    - name: |\Z)",
+        text,
+    )
+    assert match, f"{name} config item not found"
+    return match.group(0)
+
+
+def extract_optional_values_block(text: str, when: str) -> str:
+    match = re.search(
+        rf"(?ms)^    - when: {re.escape(when)}\n.*?(?=^    - when: |\Z)",
+        text,
+    )
+    assert match, f"optionalValues block not found for {when}"
+    return match.group(0)
+
+
+def test_installer_exposes_optional_github_resolver_label_with_github_auth() -> None:
+    config = REPLICATED_CONFIG.read_text(encoding="utf-8")
+    resolver_label = extract_named_config_item(config, "github_resolver_label")
+
+    assert "title: OpenHands Resolver Label" in resolver_label
+    assert "type: text" in resolver_label
+    assert 'default: "openhands"' in resolver_label
+    assert 'when: \'repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}\'' in resolver_label
+    assert "required:" not in resolver_label
+    assert 'Defaults to "openhands"' in resolver_label
+    assert "custom value" in resolver_label
+
+    private_key_position = config.index("        - name: github_app_private_key")
+    resolver_label_position = config.index("        - name: github_resolver_label")
+    assert private_key_position < resolver_label_position
+
+
+def test_github_auth_optional_values_map_resolver_label_to_openhands_env() -> None:
+    openhands_values = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
+    github_auth = extract_optional_values_block(
+        openhands_values,
+        "'{{repl ConfigOptionEquals \"github_auth_enabled\" \"1\" }}'",
+    )
+
+    assert "recursiveMerge: true" in github_auth
+    assert "env:" in github_auth
+    assert 'ENABLE_V1_GITHUB_RESOLVER: "true"' in github_auth
+    assert (
+        "OH_RESOLVER_LABEL: '{{repl ConfigOption \"github_resolver_label\"}}'"
+        in github_auth
+    )


### PR DESCRIPTION
## Summary
- Adds a Replicated GitHub auth config option for the OpenHands resolver label, defaulting to openhands for existing installs.
- Maps the option to OH_RESOLVER_LABEL in the OpenHands optional values block.
- Adds focused manifest tests for the config option and env mapping.

## Tests
- uv run --with pytest pytest scripts/test_replicated_github_resolver_label.py
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' replicated/config.yaml replicated/openhands.yaml
- make lint