### PR TITLE
feat: PLTF-3125 expose Replicated CORS origins config

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -66,6 +66,21 @@ spec:
           type: text
           default: "runtime.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+        - name: additional_cors_origins
+          title: Additional Permitted CORS Origins
+          help_text: >-
+            Optional. Comma-separated list of extra origins allowed to make
+            cross-origin browser requests to OpenHands. Each origin must include
+            the scheme and host (e.g. https://example.com) and may include
+            a port (e.g. https://example.com:8443 or http://localhost:8000);
+            it must NOT include a path or a trailing slash. The application's own
+            origin is always permitted automatically.
+          type: text
+          default: ""
+          validation:
+            regex:
+              pattern: '^\s*(https?://(\[[0-9A-Fa-f:.]+\]|[^:/\s,?#]+)(:[0-9]+)?(\s*,\s*https?://(\[[0-9A-Fa-f:.]+\]|[^:/\s,?#]+)(:[0-9]+)?)*)?\s*$'
+              message: 'Must be blank or a comma-separated list of origins like https://example.com or http://localhost:8000, with no paths or trailing slashes.'
 
     - name: tls_configuration
       title: Certificate Configuration

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -462,6 +462,11 @@ spec:
         {{repl ConfigOptionData "tls_ca_certificate" | nindent 8 }}
 
   optionalValues:
+    - when: '{{repl ne (ConfigOption "additional_cors_origins" | trim) "" }}'
+      recursiveMerge: true
+      values:
+        env:
+          PERMITTED_CORS_ORIGINS: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}},{{repl ConfigOption "additional_cors_origins" | trim }}'
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
       recursiveMerge: true
       values:


### PR DESCRIPTION
## Why

Self-hosted OpenHands Enterprise operators using Replicated/KOTS could not configure app-server CORS origins for external browser UIs such as Agent Canvas. The app server already reads `PERMITTED_CORS_ORIGINS`, and raw Helm installs could already set it through `.Values.env`, but installer-based operators had no first-class config field. This PR exposes that setting in KOTS and automatically includes the deployment's own app origin before any operator-supplied origins.

## Validation

- Raw Helm passthrough sanity check: `helm template openhands charts/openhands --set-string 'env.PERMITTED_CORS_ORIGINS=https://app.example.com\,https://canvas.example.com' | rg -n "PERMITTED_CORS_ORIGINS|https://app.example.com" -C 2` confirmed `.Values.env.PERMITTED_CORS_ORIGINS` renders into the OpenHands app-server env. This validates the existing chart path that the KOTS `optionalValues` block targets.
- Reproduced the CORS failure on an older Replicated build: real Agent Canvas from `localhost:8000` hit `OPTIONS /oauth/device/authorize` -> `400` with no `Access-Control-Allow-Origin`, blocking device authorization.
  - Validated with an upgrade to a release built on this PR branch with **Additional Permitted CORS Origins** set to `http://localhost:8000`: KOTS templated `PERMITTED_CORS_ORIGINS=https://<app-origin>,http://localhost:8000`.
  - Confirmed allowlist behavior after the fix: preflight from `localhost:8000` returned `200`, while a non-listed origin still returned `400`.
  - Confirmed real Agent Canvas success after upgrade: backend add, device-auth login, and conversation creation succeeded without CORS errors; server logs showed all preflights returned `200`.
