### PR TITLE
chore(charts): bump OpenHands image to cloud-1.43.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.41.0
+appVersion: cloud-1.43.0
 version: 0.11.0
 dependencies:
   - name: keycloak

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.42.0
+  tag: cloud-1.43.0
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Description

Updates the openhands chart `appVersion` and image tag to `cloud-1.43.0`.

This change updates:
- `charts/openhands/Chart.yaml`: `appVersion: cloud-1.41.0` → `cloud-1.43.0`
- `charts/openhands/values.yaml`: `tag: cloud-1.42.0` → `cloud-1.43.0`

The `values.yaml` image tag was already one step ahead of `Chart.yaml` (it had been bumped to `cloud-1.42.0` via the automated `bump-image-tag.yml` workflow, which does not touch `Chart.yaml`). This PR brings both files back in sync at `cloud-1.43.0`, matching the manual-bump pattern used for previous OpenHands image updates.

The chart `version` in `Chart.yaml` (currently `0.11.0`) is owned by release-please and is intentionally not changed here.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Verified locally:
- `helm lint charts/openhands` passes (1 chart(s) linted, 0 chart(s) failed)
- `helm template charts/openhands` renders `ghcr.io/openhands/enterprise-server:cloud-1.43.0` in every Deployment/Job/StatefulSet that references the main image
- No stale `cloud-1.41.x` or `cloud-1.42.x` references remain in the repo

---
_This PR was created by an AI agent (OpenHands) on behalf of a user._
