### PR TITLE
chore: PLTF-3185 Bump agent-server image tag to 1.34.0

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.31.1-python
+  tag: 1.34.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -357,7 +357,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.31.1-python
+    tag: 1.34.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1102,7 +1102,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.31.1-python
+    tag: 1.34.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -976,9 +976,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.31.1-python
+          help_text: Image tag, e.g. 1.34.0-python
           type: text
-          default: "1.31.1-python"
+          default: "1.34.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Why
The agent-server defaults were still pinned to `1.31.1-python` while this release should use `1.34.0-python`. This updates only the agent-server image tag in the Helm defaults, the image-loader pre-pull image, and the Replicated custom sandbox option so those runtime defaults stay aligned.

## Validation
- Scoped tag search found no remaining `1.31.1` references under `charts`, `replicated`, or `scripts/update_openhands_charts`; the expected `1.34.0-python` references are present in the four bumped defaults.

_This PR was drafted by an AI agent on behalf of the user._