### PR TITLE
feat: upgrade embedded cluster to 2.19.2+k8s-1.35

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -3,7 +3,7 @@ kind: Config
 metadata:
   name: embedded-cluster-config
 spec:
-  version: "2.19.2+k8s-1.34"
+  version: "2.19.2+k8s-1.35"
   domains:
     proxyRegistryDomain: "images.r9.all-hands.dev"
     replicatedAppDomain: "updates.r9.all-hands.dev"


### PR DESCRIPTION
## Description

Next step in the stacked k8s version bumps. This moves the Replicated embedded cluster from `2.19.2+k8s-1.34` to `2.19.2+k8s-1.35`, taking the bundled kubernetes version to 1.35. The embedded cluster version itself (2.19.2) is unchanged.

This is stacked on #821 and targets that branch, so the diff here is just the one-line k8s bump. It'll rebase onto `main` automatically once #821 merges.

## Helm Chart Checklist

<!-- Not applicable - this PR changes the embedded cluster installer config, not a helm chart. -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

`2.19.2+k8s-1.35` is a published GA embedded cluster release.