### PR TITLE
feat: PLTF-2960 sync metadata with image tag bumps

### DIFF
--- a/.github/workflows/bump-image-tag.yml
+++ b/.github/workflows/bump-image-tag.yml
@@ -4,11 +4,12 @@ name: Bump chart image tag
 # from its own release workflow to open a PR in the chart repo that points a
 # chart's image tag at the newly released image.
 #
-# It updates ONLY the tag scalar - it deliberately does not bump the chart
-# `version` in Chart.yaml. The PR is titled `feat(<component>): …` so release-please
-# folds it into that chart's release PR under Features; the chart `version` is then
-# bumped automatically when the release PR is merged (a minor bump, since feats
-# move the minor for these pre-1.0 charts).
+# It updates the image tag and can optionally update a related chart metadata
+# scalar to the same value. It deliberately does not bump the chart `version` in
+# Chart.yaml. The PR is titled `feat(<component>): …` so release-please folds it
+# into that chart's release PR under Features; the chart `version` is then bumped
+# automatically when the release PR is merged (a minor bump, since feats move the
+# minor for these pre-1.0 charts).
 #
 # See docs/automated-image-tag-bumps.md for caller setup and the auth model.
 
@@ -31,6 +32,16 @@ on:
         description: 'yq-style path to the image tag scalar within chart_file.'
         required: false
         default: '.image.tag'
+        type: string
+      metadata_file:
+        description: 'Optional YAML file containing a metadata scalar that should track tag (for example, a Chart.yaml).'
+        required: false
+        default: ''
+        type: string
+      metadata_path:
+        description: 'yq-style path to the optional metadata scalar within metadata_file.'
+        required: false
+        default: '.appVersion'
         type: string
       base_branch:
         description: 'Branch to open the PR against.'
@@ -138,13 +149,27 @@ jobs:
             --path "$IMAGE_TAG_PATH" \
             --tag "$NEW_TAG"
 
+      - name: Bump related metadata
+        if: ${{ inputs.metadata_file != '' }}
+        env:
+          METADATA_FILE: ${{ inputs.metadata_file }}
+          METADATA_PATH: ${{ inputs.metadata_path }}
+          NEW_TAG: ${{ inputs.tag }}
+        run: |
+          uv run scripts/bump_image_tag/bump_image_tag.py \
+            --file "$METADATA_FILE" \
+            --path "$METADATA_PATH" \
+            --tag "$NEW_TAG"
+
       - name: Create or update pull request
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          # Commit only the file we edited — never anything else the runner touched.
-          add-paths: ${{ inputs.chart_file }}
+          # Commit only the files we edited — never anything else the runner touched.
+          add-paths: |
+            ${{ inputs.chart_file }}
+            ${{ inputs.metadata_file }}
           base: ${{ inputs.base_branch }}
           branch: ${{ inputs.pr_branch != '' && inputs.pr_branch || format('bump-image-tag/{0}', inputs.component) }}
           delete-branch: true

--- a/docs/automated-image-tag-bumps.md
+++ b/docs/automated-image-tag-bumps.md
@@ -10,13 +10,18 @@ their own release workflow:
 - Workflow: [`.github/workflows/bump-image-tag.yml`](../.github/workflows/bump-image-tag.yml)
 - Edit script: [`scripts/bump_image_tag/bump_image_tag.py`](../scripts/bump_image_tag/bump_image_tag.py)
 
-The caller passes just three things: which **file** to edit, the **path** to the
-tag inside it, and the new **tag**.
+The caller passes a **file** to edit, the **path** to the image tag inside it,
+and the new **tag**. It can also opt into updating a metadata scalar in another
+YAML file to that same tag.
 
 ## What it changes (and what it deliberately doesn't)
 
-The PR changes **only the image tag scalar** — a single line. It does **not**
-bump the chart `version` in `Chart.yaml` and does nothing else.
+The PR changes the image tag scalar. When the caller supplies `metadata_file`,
+it also changes the scalar at `metadata_path` to the same tag. This supports
+charts whose `appVersion` should mirror their default image tag.
+
+It never bumps the chart `version` in `Chart.yaml`; that remains owned by
+release-please.
 
 The PR is titled `feat(<component>): bump image tag to <tag>`, so release-please
 categorizes it under Features and folds it into the chart's open release PR. The
@@ -104,6 +109,25 @@ A ready-to-copy version is in
       tag: ${{ needs.prepare-tag.outputs.tag }}
 ```
 
+### The `openhands` component
+
+The OpenHands chart's `appVersion` is intended to track its default image tag.
+Opt into the paired update explicitly so other components retain their existing
+single-file behavior:
+
+```yaml
+  bump-chart:
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    secrets: inherit
+    with:
+      component: openhands
+      chart_file: charts/openhands/values.yaml
+      image_tag_path: .image.tag
+      metadata_file: charts/openhands/Chart.yaml
+      metadata_path: .appVersion
+      tag: ${{ github.ref_name }}
+```
+
 ## Inputs
 
 | Input | Required | Default | Description |
@@ -112,6 +136,8 @@ A ready-to-copy version is in
 | `chart_file` | yes | — | YAML file to edit, relative to the chart repo root. |
 | `tag` | yes | — | New image tag to set. Must match the tag you pushed. |
 | `image_tag_path` | no | `.image.tag` | yq-style path to the tag scalar. Supports nested keys and list indices, e.g. `.warmRuntimes.configs[0].image`. |
+| `metadata_file` | no | empty | Optional YAML file containing a scalar that should track `tag`, such as a chart's `Chart.yaml`. |
+| `metadata_path` | no | `.appVersion` | yq-style path to the optional scalar in `metadata_file`. |
 | `base_branch` | no | `main` | Branch to open the PR against. |
 | `chart_repo` | no | `OpenHands/OpenHands-Cloud` | Repo to update, `owner/name`. |
 | `pr_branch` | no | `bump-image-tag/<component>` | Head branch. The default rolls a single open PR per component, advancing it to the latest tag. Set something tag-specific (e.g. `bump-image-tag/runtime-api/${{ needs.prepare-tag.outputs.tag }}`) to get one PR per release. |
@@ -127,8 +153,9 @@ current and no PR was needed).
 
 ## Behavior notes
 
-- **Idempotent:** if the tag already matches, the script makes no change and no PR
-  is opened.
+- **Idempotent:** if the image tag and optional metadata scalar already match, the
+  scripts make no change and no PR is opened. If the image tag is current but the
+  metadata scalar is stale, the workflow repairs the metadata in its own PR.
 - **One rolling PR per component (default):** a second release before the first PR
   merges updates the same PR to the newer tag. After a PR merges and its branch is
   deleted, the next release opens a fresh PR.
@@ -144,4 +171,7 @@ uv run scripts/bump_image_tag/bump_image_tag.py \
 
 # Unit tests:
 uv run scripts/bump_image_tag/test_bump_image_tag.py
+
+# Reusable-workflow contract tests:
+uv run --with pytest python -m pytest scripts/test_chart_image_bump_contract.py -q
 ```

--- a/scripts/test_chart_image_bump_contract.py
+++ b/scripts/test_chart_image_bump_contract.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pytest"]
+# ///
+"""Behavior checks for the reusable chart image-bump workflow."""
+
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW = Path(".github/workflows/bump-image-tag.yml")
+
+
+def _section(text: str, start: str, end: str) -> str:
+    start_index = text.index(start)
+    end_index = text.index(end, start_index)
+    return text[start_index:end_index]
+
+
+def test_callers_can_opt_into_updating_a_metadata_scalar_with_the_image_tag():
+    workflow = WORKFLOW.read_text()
+    inputs = _section(workflow, "    inputs:\n", "    secrets:\n")
+
+    assert "      metadata_file:\n" in inputs
+    assert "        default: ''\n" in inputs
+    assert "      metadata_path:\n" in inputs
+    assert "        default: '.appVersion'\n" in inputs
+
+    metadata_step = _section(
+        workflow,
+        "      - name: Bump related metadata\n",
+        "      - name: Create or update pull request\n",
+    )
+    assert "if: ${{ inputs.metadata_file != '' }}" in metadata_step
+    assert "METADATA_FILE: ${{ inputs.metadata_file }}" in metadata_step
+    assert "METADATA_PATH: ${{ inputs.metadata_path }}" in metadata_step
+    assert "NEW_TAG: ${{ inputs.tag }}" in metadata_step
+    assert '--file "$METADATA_FILE"' in metadata_step
+    assert '--path "$METADATA_PATH"' in metadata_step
+    assert '--tag "$NEW_TAG"' in metadata_step
+
+
+def test_metadata_updates_are_staged_with_the_primary_image_tag_update():
+    workflow = WORKFLOW.read_text()
+    create_pr_step = _section(
+        workflow,
+        "      - name: Create or update pull request\n",
+        "      - name: Summary\n",
+    )
+
+    assert "add-paths: |" in create_pr_step
+    assert "${{ inputs.chart_file }}" in create_pr_step
+    assert "${{ inputs.metadata_file }}" in create_pr_step
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

When the OpenHands image tag changes, the chart's `appVersion` can be left at the old version. This lets a caller update both values in one PR. Callers that do not opt in keep their current behavior, and Release Please still controls the chart package version.

## Validation

The focused workflow contract test checks the three links needed for a correct metadata update in the same PR:

`Caller opts in → workflow updates Chart.yaml → generated PR includes both files`

We deliberately changed the workflow in three ways and confirmed the test failed each time:

- It caught when a requested `Chart.yaml` update was skipped.
- It caught when `Chart.yaml` received a tag different from the image tag.
- It caught when `Chart.yaml` was left out of the generated PR.
