### PR TITLE
fix(postgres): raise embedded postgres memory limit to avoid OOM

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -667,6 +667,18 @@ postgresql:
     service:
       ports:
         postgresql: 5432
+    # Bitnami defaults to the "nano" resourcesPreset (192Mi memory limit), which
+    # is too small for a real workload — the primary settles around ~250Mi at
+    # idle and gets OOM-killed into a crash loop. Set resourcesPreset: none so
+    # the explicit resources below take effect.
+    resourcesPreset: none
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
     # Add the following if using Karpenter with persistence
     # podAnnotations:
     #   karpenter.sh/do-not-evict: "true"


### PR DESCRIPTION
## Problem

The embedded `postgresql` subchart never overrides Bitnami's default `resourcesPreset: "nano"`, which caps the primary at a **192Mi memory limit** (cpu 100m/150m, memory 128Mi/192Mi). Postgres 16 with `pgaudit` preloaded settles at **~250Mi at idle**, so the container is OOM-killed (exit 137) and lands in a permanent crash loop — each kill leaves the DB in "not properly shut down; automatic recovery in progress".

Observed on instance-1: `openhands-postgresql-0` with 5 restarts and `Last State: Terminated / Reason: OOMKilled`.

## Fix

Set `postgresql.primary.resourcesPreset: none` and give the primary an explicit resources block sized for the real workload:

| | request | limit |
|---|---|---|
| cpu | 250m | 1 |
| memory | 512Mi | 1Gi |

`resourcesPreset: none` is required — otherwise the preset would override the explicit `resources`.

## Verification

- `helm template` confirms the StatefulSet now renders `1Gi`/`512Mi` instead of the nano preset.
- Applied the equivalent patch live on instance-1: pod came up clean, memory plateaued at **~248Mi** across repeated 30s samples with **0 restarts** — comfortably under the new 1Gi ceiling and above the old 192Mi limit that was killing it.