### PR TITLE
feat: Add replicated vendor portal links in release workflows

### DIFF
--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           # shell: bash runs with -o pipefail, so a failing `make` fails the step
           # even though its output is piped to tee.
@@ -100,10 +101,29 @@ jobs:
           echo "sequence=${SEQUENCE}" >> "$GITHUB_OUTPUT"
           echo "Replicated Beta release sequence: ${SEQUENCE}"
 
+          # Create immediate replicated release URL visible from workflow run
+          APP_SLUG=openhands
+          URL="https://vendor.replicated.com/apps/${APP_SLUG}/releases/${SEQUENCE}/overview"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          # ::notice:: puts a banner with the link at the top of the run.
+          echo "::notice title=Replicated Beta release ${SEQUENCE}::${URL}"
+          # Step summary renders markdown on the run's summary page.
+          {
+            echo "### Replicated Beta release published"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Channel | Beta |"
+            echo "| Release tag | \`${RELEASE_TAG}\` |"
+            echo "| Sequence | ${SEQUENCE} |"
+            echo "| Vendor portal | [Release ${SEQUENCE} overview](${URL}) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Tag the commit with the Beta release sequence
         env:
           SEQUENCE: ${{ steps.release.outputs.sequence }}
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
         run: |
           TAG="Replicated/Beta/${SEQUENCE}"
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
@@ -112,6 +132,8 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "Replicated Beta release ${SEQUENCE} for ${RELEASE_TAG}"
+          git tag -a "${TAG}" \
+            -m "Replicated Beta release ${SEQUENCE} for ${RELEASE_TAG}" \
+            -m "${RELEASE_URL}"
           git push origin "${TAG}"
           echo "Tagged ${GITHUB_SHA} as ${TAG}"

--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -40,7 +40,35 @@ jobs:
           sudo mv /tmp/replicated-cli/replicated /usr/local/bin/
 
       - name: Build and release to Replicated
+        id: release
+        shell: bash
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
-        run: make release ALLOW_MAIN_RELEASE=1
+        run: |
+          # shell: bash runs with -o pipefail, so a failing `make` fails the step
+          # even though its output is piped to tee. main maps to the Unstable
+          # channel in the Makefile.
+          make release ALLOW_MAIN_RELEASE=1 2>&1 | tee release.log
+          # `replicated release create` prints `SEQUENCE: <n>` for the release it
+          # created — the global release sequence the vendor portal URL uses.
+          SEQUENCE=$(grep -oE 'SEQUENCE:[[:space:]]*[0-9]+' release.log | grep -oE '[0-9]+' | tail -1)
+          if [ -z "$SEQUENCE" ]; then
+            echo "::warning::Could not parse a release SEQUENCE from the Replicated CLI output — skipping the vendor-portal link."
+            exit 0
+          fi
+          echo "sequence=${SEQUENCE}" >> "$GITHUB_OUTPUT"
+
+          # Generate replicated URL for sequence release
+          APP_SLUG=openhands
+          URL="https://vendor.replicated.com/apps/${APP_SLUG}/releases/${SEQUENCE}/overview"
+          echo "::notice title=Replicated Unstable release ${SEQUENCE}::${URL}"
+          {
+            echo "### Replicated Unstable release published"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Channel | Unstable |"
+            echo "| Sequence | ${SEQUENCE} |"
+            echo "| Vendor portal | [Release ${SEQUENCE} overview](${URL}) |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description

With release-please, the link between "a release I care about" and the Replicated
sequence can be hard to find.

This knits the workflow run and the Replicated UI together. When either workflow
publishes a release, the run now surfaces a **clickable vendor-portal link** to that
exact sequence`https://vendor.replicated.com/apps/openhands/releases/<sequence>/overview`
in three places: the run's **markdown step summary**, a blue **`::notice::` banner**
at the top of the run, and (Beta only) the body of the `Replicated/Beta/<sequence>`
git tag.

### Files

- **`.github/workflows/release-replicated-beta.yml`** — Beta already parsed
  `SEQUENCE:` to tag the commit. Reuse it: build the vendor URL, emit a `::notice::`
  banner + a step-summary table, expose the URL as a step output, and append it to
  the annotated `Replicated/Beta/<sequence>` tag as a second `-m` paragraph.
- **`.github/workflows/release-replicated.yml`** — the per-push-to-main (Unstable)
  path previously ran `make release` and discarded its output. Now it's `shell: bash`
  with `tee release.log`, parses `SEQUENCE:` the same way Beta does, and emits the
  same notice + step-summary link. A missing sequence is a `::warning::` (non-fatal),
  so a parse hiccup never fails an Unstable publish; no git tag here since Unstable
  isn't tagged.

The app slug (`openhands`) is a single commented variable per file — deliberately not
reused from the `REPLICATED_APP` secret, which may be an app id rather than the slug
the URL wants.

## What operators will see

Step summaries use the same GitHub-Flavored Markdown renderer as this PR body, so the
preview below is byte-identical to what renders on the run's summary page. Example
(Beta, sequence `1175`):

### Replicated Beta release published

| Field | Value |
| --- | --- |
| Channel | Beta |
| Release tag | `openhands/0.18.0` |
| Sequence | 1175 |
| Vendor portal | [Release 1175 overview](https://vendor.replicated.com/apps/openhands/releases/1175/overview) |

The Unstable path renders the same table with `Channel: Unstable` and no release-tag
row. Alongside it, GitHub shows a blue annotation banner at the top of the run:

> **Replicated Beta release 1175**
> https://vendor.replicated.com/apps/openhands/releases/1175/overview

## Helm Chart Checklist

<!-- No Helm charts modified in this PR — CI/visibility only. -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

- CI-only change; no chart or runtime behavior is affected. Couldn't exercise the
  workflows end-to-end (they need Replicated secrets), so validation was YAML-parse
  only — the shell logic mirrors the already-working Beta `SEQUENCE` parse.
- Follow-up worth considering: Unstable has no durable anchor equivalent to Beta's
  `Replicated/Beta/<sequence>` git tag. If we want per-push Unstable releases traceable
  the same way, a lightweight tag would close that gap.
