### PR TITLE
fix(backport): bump image tag to cloud-1.46.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.44.0
+appVersion: cloud-1.46.0
 version: 0.13.1
 dependencies:
   - name: keycloak

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.44.0
+  tag: cloud-1.46.0
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Backport of #834 to the `release/0.13.2` branch.

Bumps the enterprise-server image to `cloud-1.46.0`:
- `charts/openhands/values.yaml`: `image.tag` `cloud-1.44.0` → `cloud-1.46.0`
- `charts/openhands/Chart.yaml`: `appVersion` `cloud-1.44.0` → `cloud-1.46.0`

Cherry-picked `9e33cdc`. Resolved a conflict against the older 0.13.1 base: kept the release branch's `version: 0.13.1` (release-please owns the chart `version`) and did not pull in `main`'s intermediate `cloud-1.45.1` state — the tag goes straight to `cloud-1.46.0`.