### PR TITLE
ci: PLTF-3193 dispatch development chart bumps after publish

### DIFF
--- a/.github/workflows/publish-release-charts.yml
+++ b/.github/workflows/publish-release-charts.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout (at the release tag)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Lowercase registry owner
         id: owner

--- a/.github/workflows/publish-release-charts.yml
+++ b/.github/workflows/publish-release-charts.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Publishing ${COMPONENT} ${VERSION} from charts/${COMPONENT}"
 
       - name: Checkout (at the release tag)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: 'latest'
 
@@ -68,7 +68,7 @@ jobs:
           echo "repo_owner=${REPO_OWNER}" >> "$GITHUB_OUTPUT"
 
       - name: Publish ${{ steps.parse.outputs.component }} chart to GHCR
-        uses: appany/helm-oci-chart-releaser@v0.4.2
+        uses: appany/helm-oci-chart-releaser@dd0551c15abe174eb57824ecde62e976091094da # v0.4.2
         with:
           name: ${{ steps.parse.outputs.component }}
           repository: helm-charts
@@ -113,5 +113,50 @@ jobs:
             -f "client_payload[chart]=${COMPONENT}" \
             -f "client_payload[version]=${VERSION}" \
             -f "client_payload[environment]=staging" \
+            -f "client_payload[source-repo]=${SOURCE_REPO}" \
+            -f "client_payload[source-sha]=${SOURCE_SHA}"
+
+  dispatch-development-chart-bump:
+    name: Dispatch development chart bump
+    needs: publish
+    if: >-
+      ${{
+        needs.publish.result == 'success' &&
+        needs.publish.outputs.component == 'openhands' &&
+        github.actor == 'openhands-release-bot[bot]' &&
+        github.actor_id == '290150379'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment: dev-chart-bump-dispatcher
+    permissions:
+      contents: read
+    steps:
+      - name: Mint saas-deploy development dispatcher token
+        id: dispatcher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CHART_BUMP_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: OpenHands
+          repositories: saas-deploy
+          permission-contents: write
+
+      - name: Dispatch bump-chart-to-development
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.dispatcher-token.outputs.token }}
+          COMPONENT: ${{ needs.publish.outputs.component }}
+          VERSION: ${{ needs.publish.outputs.version }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ needs.publish.outputs.source-sha }}
+        run: |
+          gh api \
+            --method POST \
+            /repos/OpenHands/saas-deploy/dispatches \
+            -f event_type=bump-chart-to-development \
+            -f "client_payload[chart]=${COMPONENT}" \
+            -f "client_payload[version]=${VERSION}" \
+            -f "client_payload[environment]=development" \
             -f "client_payload[source-repo]=${SOURCE_REPO}" \
             -f "client_payload[source-sha]=${SOURCE_SHA}"

--- a/.github/workflows/publish-release-charts.yml
+++ b/.github/workflows/publish-release-charts.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Checkout (at the release tag)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Bind publication to the immutable commit from the push event. The
+          # tag name could otherwise resolve to a commit moved after this run began.
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish-release-charts.yml
+++ b/.github/workflows/publish-release-charts.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve source commit
         id: source
@@ -123,7 +124,6 @@ jobs:
       ${{
         needs.publish.result == 'success' &&
         needs.publish.outputs.component == 'openhands' &&
-        github.actor == 'openhands-release-bot[bot]' &&
         github.actor_id == '290150379'
       }}
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ full instructions.
 # Automation
 
 - [Automated image-tag bumps](./docs/automated-image-tag-bumps.md)
+- [Automated development chart bumps](./docs/development-chart-bumps.md)
 - [Automated staging chart bumps](./docs/staging-chart-bumps.md)

--- a/docs/development-chart-bumps.md
+++ b/docs/development-chart-bumps.md
@@ -60,8 +60,8 @@ expected release identity is `openhands-release-bot[bot]` (GitHub user ID
 check cannot protect secrets from workflow code on an untrusted tag.
 
 The `bump-chart-to-development` receiver must already exist on the default
-branch of `OpenHands/saas-deploy`. GitHub accepts dispatches only for event types
-handled by a workflow on the target repository's default branch.
+branch of `OpenHands/saas-deploy`. Otherwise, GitHub can accept the event
+without starting a receiver run.
 
 ## Failure behavior
 

--- a/docs/development-chart-bumps.md
+++ b/docs/development-chart-bumps.md
@@ -52,12 +52,15 @@ GitHub Environment:
 - `CHART_BUMP_DISPATCHER_APP_ID`
 - `CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY`
 
-The Environment must allow the `openhands/*` tag pattern. Before merging the
-sender, also add an active tag ruleset that protects `openhands/*` creation,
-updates, and deletion, with the release App as the intended bypass actor. The
-expected release identity is `openhands-release-bot[bot]` (GitHub user ID
-`290150379`). The sender checks the stable user ID as defense in depth, but a
-workflow check cannot protect secrets from workflow code on an untrusted tag.
+The Environment must allow the `openhands/*` tag pattern.
+
+A repository tag ruleset that protects `openhands/*` creation, updates, and
+deletion, with the release App as the intended bypass actor, remains recommended
+hardening for the existing release process but is not a prerequisite for this
+sender. The expected release identity is `openhands-release-bot[bot]` (GitHub
+user ID `290150379`). The sender checks the stable user ID as defense in depth,
+but a workflow check cannot protect secrets from workflow code on an untrusted
+tag.
 
 The `bump-chart-to-development` receiver must already exist on the default
 branch of `OpenHands/saas-deploy`. Otherwise, GitHub can accept the event

--- a/docs/development-chart-bumps.md
+++ b/docs/development-chart-bumps.md
@@ -56,8 +56,8 @@ The Environment must allow the `openhands/*` tag pattern. Before merging the
 sender, also add an active tag ruleset that protects `openhands/*` creation,
 updates, and deletion, with the release App as the intended bypass actor. The
 expected release identity is `openhands-release-bot[bot]` (GitHub user ID
-`290150379`). The sender checks both values as defense in depth, but a workflow
-check cannot protect secrets from workflow code on an untrusted tag.
+`290150379`). The sender checks the stable user ID as defense in depth, but a
+workflow check cannot protect secrets from workflow code on an untrusted tag.
 
 The `bump-chart-to-development` receiver must already exist on the default
 branch of `OpenHands/saas-deploy`. Otherwise, GitHub can accept the event

--- a/docs/development-chart-bumps.md
+++ b/docs/development-chart-bumps.md
@@ -54,13 +54,9 @@ GitHub Environment:
 
 The Environment must allow the `openhands/*` tag pattern.
 
-A repository tag ruleset that protects `openhands/*` creation, updates, and
-deletion, with the release App as the intended bypass actor, remains recommended
-hardening for the existing release process but is not a prerequisite for this
-sender. The expected release identity is `openhands-release-bot[bot]` (GitHub
-user ID `290150379`). The sender checks the stable user ID as defense in depth,
-but a workflow check cannot protect secrets from workflow code on an untrusted
-tag.
+The expected release identity is `openhands-release-bot[bot]` (GitHub user ID
+`290150379`). The sender checks the stable user ID before minting the dispatcher
+token.
 
 The `bump-chart-to-development` receiver must already exist on the default
 branch of `OpenHands/saas-deploy`. Otherwise, GitHub can accept the event

--- a/docs/development-chart-bumps.md
+++ b/docs/development-chart-bumps.md
@@ -1,0 +1,76 @@
+# Automated development chart bumps
+
+When release-please publishes a stable `openhands` chart tag, this repository
+notifies `OpenHands/saas-deploy` so the new chart can deploy to development
+without waiting for a chart-bump pull request.
+
+The sender lives in
+[`.github/workflows/publish-release-charts.yml`](../.github/workflows/publish-release-charts.yml):
+
+1. An `openhands/<version>` tag created by `openhands-release-bot[bot]` publishes
+   `ghcr.io/openhands/helm-charts/openhands:<version>`.
+2. After the publish job succeeds, the `dispatch-development-chart-bump` job
+   mints a token for the dedicated development dispatcher GitHub App.
+3. The job sends `repository_dispatch` to `OpenHands/saas-deploy` with
+   `event_type: bump-chart-to-development` and `environment=development`.
+
+The development and staging dispatch jobs are independent siblings. A failure
+in one environment does not prevent the other dispatch from running.
+
+## Dispatch payload
+
+The payload sent to `saas-deploy` is:
+
+| Field | Value |
+| ----- | ----- |
+| `chart` | `openhands` |
+| `version` | The chart version from the tag, for example `0.21.0`. |
+| `environment` | `development` |
+| `source-repo` | `OpenHands/OpenHands-Cloud` |
+| `source-sha` | The commit checked out at the release tag. |
+
+The receiver treats the payload as requested state and provenance, not as its
+authorization boundary. Authorization comes from the dedicated dispatcher's
+GitHub App identity on the `saas-deploy` side.
+
+## Trust boundary and prerequisites
+
+Create the dispatcher with the generic App helper:
+
+```bash
+uv run scripts/create_chart_bump_dispatcher/create_chart_bump_dispatcher.py \
+  --org OpenHands \
+  --app-name dev-chart-bump-dispatcher
+```
+
+Install the App only on `OpenHands/saas-deploy`. It needs only `contents: write`
+and `metadata: read`, and it must not be a `saas-deploy` ruleset bypass actor.
+
+Store these environment-scoped secrets in the `dev-chart-bump-dispatcher`
+GitHub Environment:
+
+- `CHART_BUMP_DISPATCHER_APP_ID`
+- `CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY`
+
+The Environment must allow the `openhands/*` tag pattern. Before merging the
+sender, also add an active tag ruleset that protects `openhands/*` creation,
+updates, and deletion, with the release App as the intended bypass actor. The
+expected release identity is `openhands-release-bot[bot]` (GitHub user ID
+`290150379`). The sender checks both values as defense in depth, but a workflow
+check cannot protect secrets from workflow code on an untrusted tag.
+
+The `bump-chart-to-development` receiver must already exist on the default
+branch of `OpenHands/saas-deploy`. GitHub accepts dispatches only for event types
+handled by a workflow on the target repository's default branch.
+
+## Failure behavior
+
+A successful sender run means GitHub accepted the dispatch; it does not mean
+the `saas-deploy` receiver committed the bump or Argo CD deployed the chart.
+Receiver and deployment failures remain visible in `OpenHands/saas-deploy`.
+
+If token minting or `gh api` fails, this publish workflow is red and no dispatch
+is sent. Rerun the failed development dispatch job after fixing the credential
+or API problem; the chart does not need to be republished. Duplicate dispatches
+are safe because the receiver compares chart freshness and converges the same
+requested version idempotently.

--- a/scripts/create_chart_bump_dispatcher/README.md
+++ b/scripts/create_chart_bump_dispatcher/README.md
@@ -25,10 +25,10 @@ uv run scripts/create_chart_bump_dispatcher/create_chart_bump_dispatcher.py \
   --org OpenHands \
   --app-name staging-chart-bump-dispatcher
 
-# future dev
+# development
 uv run scripts/create_chart_bump_dispatcher/create_chart_bump_dispatcher.py \
   --org OpenHands \
-  --app-name saas-deploy-dev-chart-dispatcher-openhands
+  --app-name dev-chart-bump-dispatcher
 ```
 
 The private key is written under `scripts/create_chart_bump_dispatcher/keys/`

--- a/scripts/test_publish_release_charts_workflow.py
+++ b/scripts/test_publish_release_charts_workflow.py
@@ -95,7 +95,7 @@ def test_development_dispatch_runs_only_after_openhands_publish() -> None:
     condition = job["if"]
     assert "needs.publish.result == 'success'" in condition
     assert "needs.publish.outputs.component == 'openhands'" in condition
-    assert "github.actor == 'openhands-release-bot[bot]'" in condition
+    assert "github.actor ==" not in condition
     assert "github.actor_id == '290150379'" in condition
     assert job["environment"] == "dev-chart-bump-dispatcher"
     assert job["permissions"] == {"contents": "read"}
@@ -208,11 +208,13 @@ def test_development_and_staging_dispatches_are_independent_siblings() -> None:
 def test_chart_publish_supply_chain_uses_immutable_action_revisions() -> None:
     publish = load_workflow()["jobs"]["publish"]
     actions = {step["uses"] for step in publish["steps"] if "uses" in step}
+    checkout = step_by_name(publish, "Checkout (at the release tag)")
 
     assert CHECKOUT_ACTION in actions
     assert HELM_ACTION in actions
     assert PUBLISH_ACTION in actions
     assert all("@v" not in action for action in actions)
+    assert checkout["with"]["persist-credentials"] is False
 
 
 def test_development_sender_docs_match_live_app_and_environment() -> None:

--- a/scripts/test_publish_release_charts_workflow.py
+++ b/scripts/test_publish_release_charts_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -92,11 +93,12 @@ def test_development_dispatch_runs_only_after_openhands_publish() -> None:
     job = load_workflow()["jobs"][DEV_JOB]
 
     assert job["needs"] == "publish"
-    condition = job["if"]
-    assert "needs.publish.result == 'success'" in condition
-    assert "needs.publish.outputs.component == 'openhands'" in condition
-    assert "github.actor ==" not in condition
-    assert "github.actor_id == '290150379'" in condition
+    condition = " ".join(job["if"].split())
+    assert condition == (
+        "${{ needs.publish.result == 'success' && "
+        "needs.publish.outputs.component == 'openhands' && "
+        "github.actor_id == '290150379' }}"
+    )
     assert job["environment"] == "dev-chart-bump-dispatcher"
     assert job["permissions"] == {"contents": "read"}
     assert job["timeout-minutes"] == 5
@@ -125,6 +127,7 @@ def test_development_dispatch_payload_matches_receiver_contract(tmp_path: Path) 
     dispatch = step_by_name(job, "Dispatch bump-chart-to-development")
 
     assert dispatch["shell"] == "bash"
+    assert dispatch.get("continue-on-error", False) is False
     assert dispatch["env"] == {
         "GH_TOKEN": "${{ steps.dispatcher-token.outputs.token }}",
         "COMPONENT": "${{ needs.publish.outputs.component }}",
@@ -139,7 +142,8 @@ def test_development_dispatch_payload_matches_receiver_contract(tmp_path: Path) 
     fake_gh = bin_dir / "gh"
     fake_gh.write_text(
         "#!/usr/bin/env bash\n"
-        'printf "%s\\n" "$@" > "$GH_CAPTURE"\n',
+        'printf "%s\\n" "$@" > "$GH_CAPTURE"\n'
+        'exit "${GH_EXIT_CODE:-0}"\n',
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
@@ -157,17 +161,18 @@ def test_development_dispatch_payload_matches_receiver_contract(tmp_path: Path) 
         }
     )
 
+    command = [
+        "bash",
+        "--noprofile",
+        "--norc",
+        "-e",
+        "-o",
+        "pipefail",
+        "-c",
+        dispatch["run"],
+    ]
     result = subprocess.run(
-        [
-            "bash",
-            "--noprofile",
-            "--norc",
-            "-e",
-            "-o",
-            "pipefail",
-            "-c",
-            dispatch["run"],
-        ],
+        command,
         check=False,
         capture_output=True,
         env=environment,
@@ -194,6 +199,16 @@ def test_development_dispatch_payload_matches_receiver_contract(tmp_path: Path) 
         f"client_payload[source-sha]={'a' * 40}",
     ]
 
+    failure = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        env=environment | {"GH_EXIT_CODE": "23"},
+        text=True,
+    )
+
+    assert failure.returncode == 23
+
 
 def test_development_and_staging_dispatches_are_independent_siblings() -> None:
     jobs = load_workflow()["jobs"]
@@ -206,15 +221,27 @@ def test_development_and_staging_dispatches_are_independent_siblings() -> None:
 
 
 def test_chart_publish_supply_chain_uses_immutable_action_revisions() -> None:
-    publish = load_workflow()["jobs"]["publish"]
+    workflow = load_workflow()
+    publish = workflow["jobs"]["publish"]
     actions = {step["uses"] for step in publish["steps"] if "uses" in step}
+    all_actions = {
+        step["uses"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if "uses" in step
+    }
     checkout = step_by_name(publish, "Checkout (at the release tag)")
+    helm = step_by_name(publish, "Set up Helm")
 
     assert CHECKOUT_ACTION in actions
     assert HELM_ACTION in actions
     assert PUBLISH_ACTION in actions
-    assert all("@v" not in action for action in actions)
+    assert all(
+        re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action) for action in all_actions
+    )
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
     assert checkout["with"]["persist-credentials"] is False
+    assert helm["with"]["version"] == "v3.18.4"
 
 
 def test_development_sender_docs_match_live_app_and_environment() -> None:

--- a/scripts/test_publish_release_charts_workflow.py
+++ b/scripts/test_publish_release_charts_workflow.py
@@ -226,6 +226,7 @@ def test_development_sender_docs_match_live_app_and_environment() -> None:
     assert "environment=development" in text
     assert "accepted the dispatch" in text
     assert "does not mean" in text
+    assert "without starting a receiver run" in text
     assert "tag ruleset" in text.lower()
     assert "openhands-release-bot[bot]" in text
     assert "290150379" in text

--- a/scripts/test_publish_release_charts_workflow.py
+++ b/scripts/test_publish_release_charts_workflow.py
@@ -256,7 +256,7 @@ def test_development_sender_docs_match_live_app_and_environment() -> None:
     assert "accepted the dispatch" in text
     assert "does not mean" in text
     assert "without starting a receiver run" in text
-    assert "tag ruleset" in text.lower()
+    assert "tag ruleset" not in text.lower()
     assert "openhands-release-bot[bot]" in text
     assert "290150379" in text
     assert "docs/development-chart-bumps.md" in README.read_text(encoding="utf-8")

--- a/scripts/test_publish_release_charts_workflow.py
+++ b/scripts/test_publish_release_charts_workflow.py
@@ -2,12 +2,30 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
+
+from ruamel.yaml import YAML
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-release-charts.yml"
 DOCS = REPO_ROOT / "docs" / "staging-chart-bumps.md"
+DEVELOPMENT_DOCS = REPO_ROOT / "docs" / "development-chart-bumps.md"
+README = REPO_ROOT / "README.md"
+APP_DOCS = REPO_ROOT / "scripts" / "create_chart_bump_dispatcher" / "README.md"
+DEV_JOB = "dispatch-development-chart-bump"
+TOKEN_ACTION = (
+    "actions/create-github-app-token@"
+    "bcd2ba49218906704ab6c1aa796996da409d3eb1"
+)
+CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+HELM_ACTION = "azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78"
+PUBLISH_ACTION = (
+    "appany/helm-oci-chart-releaser@"
+    "dd0551c15abe174eb57824ecde62e976091094da"
+)
 
 
 def workflow_text() -> str:
@@ -16,6 +34,18 @@ def workflow_text() -> str:
 
 def docs_text() -> str:
     return DOCS.read_text(encoding="utf-8")
+
+
+def load_workflow() -> dict:
+    return YAML(typ="safe").load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def step_by_id(job: dict, step_id: str) -> dict:
+    return next(step for step in job["steps"] if step.get("id") == step_id)
+
+
+def step_by_name(job: dict, name: str) -> dict:
+    return next(step for step in job["steps"] if step["name"] == name)
 
 
 def test_openhands_release_dispatches_staging_bump_after_publish() -> None:
@@ -56,3 +86,151 @@ def test_staging_chart_bump_docs_use_environment_secret_names() -> None:
     assert "STAGING_CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY" in text
     assert "STAGING_CHART_DISPATCHER_APP_ID" not in text
     assert "STAGING_CHART_DISPATCHER_APP_PRIVATE_KEY" not in text
+
+
+def test_development_dispatch_runs_only_after_openhands_publish() -> None:
+    job = load_workflow()["jobs"][DEV_JOB]
+
+    assert job["needs"] == "publish"
+    condition = job["if"]
+    assert "needs.publish.result == 'success'" in condition
+    assert "needs.publish.outputs.component == 'openhands'" in condition
+    assert "github.actor == 'openhands-release-bot[bot]'" in condition
+    assert "github.actor_id == '290150379'" in condition
+    assert job["environment"] == "dev-chart-bump-dispatcher"
+    assert job["permissions"] == {"contents": "read"}
+    assert job["timeout-minutes"] == 5
+
+
+def test_development_dispatcher_token_is_environment_scoped_and_minimal() -> None:
+    job = load_workflow()["jobs"][DEV_JOB]
+    token = step_by_id(job, "dispatcher-token")
+
+    assert token["uses"] == TOKEN_ACTION
+    assert token["with"] == {
+        "app-id": "${{ secrets.CHART_BUMP_DISPATCHER_APP_ID }}",
+        "private-key": "${{ secrets.CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY }}",
+        "owner": "OpenHands",
+        "repositories": "saas-deploy",
+        "permission-contents": "write",
+    }
+    assert "STAGING_CHART_BUMP_DISPATCHER" not in str(job)
+    assert len(job["steps"]) == 2
+    assert "actions/checkout" not in str(job)
+    assert "continue-on-error" not in job
+
+
+def test_development_dispatch_payload_matches_receiver_contract(tmp_path: Path) -> None:
+    job = load_workflow()["jobs"][DEV_JOB]
+    dispatch = step_by_name(job, "Dispatch bump-chart-to-development")
+
+    assert dispatch["shell"] == "bash"
+    assert dispatch["env"] == {
+        "GH_TOKEN": "${{ steps.dispatcher-token.outputs.token }}",
+        "COMPONENT": "${{ needs.publish.outputs.component }}",
+        "VERSION": "${{ needs.publish.outputs.version }}",
+        "SOURCE_REPO": "${{ github.repository }}",
+        "SOURCE_SHA": "${{ needs.publish.outputs.source-sha }}",
+    }
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    capture = tmp_path / "gh-args"
+    fake_gh = bin_dir / "gh"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf "%s\\n" "$@" > "$GH_CAPTURE"\n',
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{environment['PATH']}",
+            "GH_CAPTURE": str(capture),
+            "GH_TOKEN": "fake-local-token",
+            "COMPONENT": "openhands",
+            "VERSION": "0.20.0",
+            "SOURCE_REPO": "OpenHands/OpenHands-Cloud",
+            "SOURCE_SHA": "a" * 40,
+        }
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-e",
+            "-o",
+            "pipefail",
+            "-c",
+            dispatch["run"],
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert capture.read_text(encoding="utf-8").splitlines() == [
+        "api",
+        "--method",
+        "POST",
+        "/repos/OpenHands/saas-deploy/dispatches",
+        "-f",
+        "event_type=bump-chart-to-development",
+        "-f",
+        "client_payload[chart]=openhands",
+        "-f",
+        "client_payload[version]=0.20.0",
+        "-f",
+        "client_payload[environment]=development",
+        "-f",
+        "client_payload[source-repo]=OpenHands/OpenHands-Cloud",
+        "-f",
+        f"client_payload[source-sha]={'a' * 40}",
+    ]
+
+
+def test_development_and_staging_dispatches_are_independent_siblings() -> None:
+    jobs = load_workflow()["jobs"]
+    development = jobs[DEV_JOB]
+    staging = jobs["dispatch-staging-chart-bump"]
+
+    assert development["needs"] == staging["needs"] == "publish"
+    assert development["environment"] == "dev-chart-bump-dispatcher"
+    assert staging["environment"] == "staging-chart-bump-dispatcher"
+
+
+def test_chart_publish_supply_chain_uses_immutable_action_revisions() -> None:
+    publish = load_workflow()["jobs"]["publish"]
+    actions = {step["uses"] for step in publish["steps"] if "uses" in step}
+
+    assert CHECKOUT_ACTION in actions
+    assert HELM_ACTION in actions
+    assert PUBLISH_ACTION in actions
+    assert all("@v" not in action for action in actions)
+
+
+def test_development_sender_docs_match_live_app_and_environment() -> None:
+    assert DEVELOPMENT_DOCS.is_file(), "development sender docs are missing"
+    text = DEVELOPMENT_DOCS.read_text(encoding="utf-8")
+
+    assert "dev-chart-bump-dispatcher" in text
+    assert "CHART_BUMP_DISPATCHER_APP_ID" in text
+    assert "CHART_BUMP_DISPATCHER_APP_PRIVATE_KEY" in text
+    assert "bump-chart-to-development" in text
+    assert "environment=development" in text
+    assert "accepted the dispatch" in text
+    assert "does not mean" in text
+    assert "tag ruleset" in text.lower()
+    assert "openhands-release-bot[bot]" in text
+    assert "290150379" in text
+    assert "docs/development-chart-bumps.md" in README.read_text(encoding="utf-8")
+
+    app_docs = APP_DOCS.read_text(encoding="utf-8")
+    assert "--app-name dev-chart-bump-dispatcher" in app_docs
+    assert "saas-deploy-dev-chart-dispatcher-openhands" not in app_docs


### PR DESCRIPTION
## Why

Stable OpenHands chart publishes currently notify staging but not development, so a newly published chart cannot reach the development environment immediately through the new direct-bump receiver. This adds an independent development dispatch after a successful `openhands` publish, authenticated by the dedicated low-privilege `dev-chart-bump-dispatcher` App and restricted to the verified release actor.

The publish path now checks out the immutable push-event SHA, pins its Actions and Helm inputs, and documents the sender contract and failure semantics.

## Validation

- A fake `gh` execution verified the exact `bump-chart-to-development` payload and that API failures remain fatal.
- All 12 manual sender safety mutants were caught; `zizmor`, a security static analyzer for GitHub Actions workflows, reported no findings.
