### PR TITLE
fix(backport): raise embedded postgres memory limit to avoid OOM

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -667,6 +667,18 @@ postgresql:
     service:
       ports:
         postgresql: 5432
+    # Bitnami defaults to the "nano" resourcesPreset (192Mi memory limit), which
+    # is too small for a real workload — the primary settles around ~250Mi at
+    # idle and gets OOM-killed into a crash loop. Set resourcesPreset: none so
+    # the explicit resources below take effect.
+    resourcesPreset: none
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
     # Add the following if using Karpenter with persistence
     # podAnnotations:
     #   karpenter.sh/do-not-evict: "true"


### PR DESCRIPTION
Backport of #829 to `release/0.16.1`.

Sets `postgresql.primary.resourcesPreset: none` plus an explicit resources block (requests 250m / 512Mi, limits 1 / 1Gi) so the embedded Postgres primary is not OOM-killed by Bitnami's `nano` preset (192Mi limit).