### PR TITLE
fix: improve integrations-hub Datadog and probe configuration

### DIFF
--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -134,12 +134,24 @@
   value: "datadog-agent.all-hands-system.svc.cluster.local"
 - name: DD_TRACE_AGENT_PORT
   value: "8126"
+- name: DD_DOGSTATSD_PORT
+  value: "8125"
 - name: DD_SERVICE
   value: {{ .Values.datadog.serviceName | quote }}
 - name: DD_ENV
   value: {{ .Values.datadog.env | quote }}
+- name: DD_VERSION
+  value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+- name: DD_LOGS_INJECTION
+  value: "true"
 - name: DD_TRACE_ENABLED
   value: "true"
+- name: DD_TRACE_SAMPLING_RULES
+  value: '[{"resource":"GET /api/health","sample_rate":0.0},{"resource":"GET /api/live","sample_rate":0.0},{"resource":"GET /api/ready","sample_rate":0.0}]'
+- name: LOG_JSON
+  value: "1"
+- name: LOG_JSON_LEVEL_KEY
+  value: "severity"
 {{- end }}
 {{- end }}
 

--- a/charts/openhands/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/deployment.yaml
@@ -132,35 +132,38 @@ spec:
         - containerPort: {{ .Values.service.port | default 8000 }}
         resources:
           {{- toYaml .Values.deployment.resources | nindent 12 }}
-        # Health endpoint lives at /api/health on the FastAPI app
-        # (backend/app/routers/health.py). The leading prefix matches
-        # `.Values.rootPath` -- i.e. /integrations-hub/api/health by
-        # default, plain /api/health when rootPath is unset -- because
+        # Probe endpoints live on the FastAPI app. The leading prefix matches
+        # `.Values.rootPath` -- i.e. /integrations-hub/api/live by
+        # default, plain /api/live when rootPath is unset -- because
         # the backend mounts all routes under INTHUB_ROOT_PATH. Keeping
         # the probe URL in sync with the Helm value prevents probes
         # from 404'ing whenever the chart's mount path changes.
-        # There is no separate /ready endpoint, so readiness reuses the
-        # same probe path.
-        {{- $healthPath := printf "%s/api/health" (.Values.rootPath | default "") }}
+        # Liveness stays independent of external services, while readiness
+        # checks database availability before the pod receives traffic.
+        {{- $livePath := printf "%s/api/live" (.Values.rootPath | default "") }}
+        {{- $readyPath := printf "%s/api/ready" (.Values.rootPath | default "") }}
         startupProbe:
           httpGet:
-            path: {{ $healthPath | quote }}
+            path: {{ $livePath | quote }}
             port: {{ .Values.service.port | default 8000 }}
           failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
         livenessProbe:
           httpGet:
-            path: {{ $healthPath | quote }}
+            path: {{ $livePath | quote }}
             port: {{ .Values.service.port | default 8000 }}
           initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
           failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            path: {{ $healthPath | quote }}
+            path: {{ $readyPath | quote }}
             port: {{ .Values.service.port | default 8000 }}
           initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
         env:
         {{- include "integrations-hub.env" . | nindent 8 }}

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -32,14 +32,17 @@ probes:
   startup:
     failureThreshold: 30
     periodSeconds: 10
+    timeoutSeconds: 2
   liveness:
     initialDelaySeconds: 10
     periodSeconds: 30
     failureThreshold: 3
+    timeoutSeconds: 2
   readiness:
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
+    timeoutSeconds: 2
 
 # Service configuration
 service:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1224,14 +1224,17 @@ integrations-hub:
     startup:
       failureThreshold: 30
       periodSeconds: 10
+      timeoutSeconds: 2
     liveness:
       initialDelaySeconds: 10
       periodSeconds: 30
       failureThreshold: 3
+      timeoutSeconds: 2
     readiness:
       initialDelaySeconds: 5
       periodSeconds: 10
       failureThreshold: 3
+      timeoutSeconds: 2
 
   # Service configuration
   service:


### PR DESCRIPTION
## Description

- enable Datadog log injection, service versioning, DogStatsD metadata, and JSON logs for integrations-hub
- suppress health/live/ready APM trace noise
- use `/api/live` for startup and liveness probes
- use the existing database-aware `/api/ready` endpoint for readiness
- configure explicit two-second probe timeouts

Companion deployment change for [OpenHands/integrations-hub#378](https://github.com/OpenHands/integrations-hub/issues/378) and Linear APP-2731. The application-side change is [OpenHands/integrations-hub#379](https://github.com/OpenHands/integrations-hub/pull/379).

## Reference configurations

This aligns integrations-hub with observability and health-check patterns already used by sibling services in this chart:

- [runtime-api Datadog environment](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/charts/runtime-api/templates/_env.yaml): reference for `DD_DOGSTATSD_PORT`, `DD_LOGS_INJECTION`, and resource-based `DD_TRACE_SAMPLING_RULES` that remove routine health traffic from APM.
- [runtime-api deployment probes](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/charts/runtime-api/templates/deployment.yaml) and [probe defaults](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/charts/runtime-api/values.yaml): reference for separately configurable startup, readiness, and liveness probes, including a two-second `timeoutSeconds` default.
- [main OpenHands environment](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/templates/_env.yaml) and [values](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/values.yaml): reference for Datadog log injection and the `LOG_JSON=1` / `LOG_JSON_LEVEL_KEY=severity` convention used to make application logs structured and Datadog-friendly.
- [main OpenHands deployment](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/templates/deployment.yaml) and [plugin-directory deployment](https://github.com/OpenHands/OpenHands-Cloud/blob/main/charts/openhands/charts/plugin-directory/templates/deployment.yaml): reference for keeping liveness independent from dependencies while using a distinct readiness endpoint before routing traffic.

`DD_VERSION` additionally completes Datadog unified service tagging for integrations-hub and is populated from the same image tag/AppVersion used by the deployment.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Validation

- `helm lint charts/openhands/charts/integrations-hub`
- standalone chart rendered with Datadog enabled, a pinned image SHA, and root-path probes
- parent chart lint was attempted but requires vendored chart dependencies that are absent from this shallow checkout

## Additional Notes

This is backward compatible: the new timeout values have defaults, and no existing value is removed or renamed.

## Live evidence

- 2026-07-12 UTC: rendered the PR head with `helm template integrations-hub charts/openhands/charts/integrations-hub --set image.tag=daily-evidence --set datadog.enabled=true --set datadog.env=staging --set datadog.serviceName=integrations-hub --set rootPath=/integrations-hub`.
- The rendered Deployment contains `DD_DOGSTATSD_PORT`, `DD_VERSION`, `DD_LOGS_INJECTION`, JSON log configuration, and sampling rules for `/api/health`, `/api/live`, and `/api/ready`; its probes render as `/integrations-hub/api/live` (startup/liveness) and `/integrations-hub/api/ready` (readiness), each with `timeoutSeconds: 2`.
- `helm lint charts/openhands/charts/integrations-hub` passed.