### PR TITLE
refactor(openhands): rename gitlab webhook install cronjob

### DIFF
--- a/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
+++ b/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-install-hooks
+  name: {{ .Release.Name }}-install-gitlab-webhooks
   labels:
-    app: {{ .Release.Name }}-install-hooks
+    app: {{ .Release.Name }}-install-gitlab-webhooks
 spec:
   schedule: {{ .Values.gitlabWebhookInstallation.schedule | quote }}
   concurrencyPolicy: {{ .Values.gitlabWebhookInstallation.concurrencyPolicy }}
@@ -16,7 +16,7 @@ spec:
       template:
         metadata:
           labels:
-            app: {{ .Release.Name }}-install-hooks
+            app: {{ .Release.Name }}-install-gitlab-webhooks
         spec:
           {{- with .Values.securityContext }}
           securityContext:
@@ -33,7 +33,7 @@ spec:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}
           {{- end }}
           containers:
-            - name: {{ .Release.Name }}-install-hooks
+            - name: {{ .Release.Name }}-install-gitlab-webhooks
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
               command: ["python", "-m", "sync.install_gitlab_webhooks"]


### PR DESCRIPTION
## Description

The CronJob that installs GitLab webhooks was named `<release>-install-hooks`. The "hooks" in that name reads like a helm lifecycle hook, so at a glance it looks like a misconfigured install/upgrade hook rather than the scheduled job it actually is. That's confusing.

This renames it to `<release>-install-gitlab-webhooks`, matching the command it runs (`python -m sync.install_gitlab_webhooks`) and the `gitlabWebhookInstallation` values key.

I also renamed the template file from `gitlab-webhook-verify-cronjob.yaml` to `gitlab-webhook-install-cronjob.yaml`, dropping the "verify" that never matched what the job does.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

No values changed and there are no new or renamed values, so existing `values.yaml` configs are unaffected.

Changing `metadata.name` does mean helm replaces the resource on upgrade: the old `-install-hooks` CronJob is deleted and the new one created. For a schedule-driven, reconciling CronJob that's harmless. The job stays gated behind `enabled` + `gitlabWebhookInstallation.enabled` (off by default).