### PR TITLE
fix(openhands): mirror agentServerEnv into warm-runtime env so warm pools stay claimable

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
@@ -15,6 +15,16 @@
 {{- end }}
 {{- /* Default image for any entry that omits one: the global agent-server image. */ -}}
 {{- $agentServerImage := printf "%s:%s" .Values.global.agentServerImage.repository .Values.global.agentServerImage.tag }}
+{{- /*
+  The app injects global.agentServerEnv (LLM provider creds, proxy vars, CA
+  paths) into every per-session runtime request, and runtime-api claims warm
+  pods only on an exact env match — so those keys must be in the warm env too,
+  or the pool is never claimable and every conversation cold-starts.
+*/ -}}
+{{- $globalAgentEnv := dict }}
+{{- if .Values.global }}
+{{- $globalAgentEnv = (get .Values.global "agentServerEnv") | default dict }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,7 +46,7 @@ data:
           "count": {{ $config.count }},
           {{- end }}
           "command": {{ $config.command | toJson }},
-          "environment": {{ $config.environment | toJson }}
+          "environment": {{ mergeOverwrite (deepCopy ($config.environment | default dict)) (deepCopy $globalAgentEnv) | toJson }}
           {{- with $config.run_as_user }},
           "run_as_user": {{ $config.run_as_user }}
           {{- end }}

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -362,3 +362,7 @@ global:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267
     allowInsecureImages: true
+  # Env the app injects into every per-session runtime (LLM provider creds,
+  # proxy vars, CA paths). Mirrored into each warm-runtime entry's env so
+  # runtime-api's exact-env matching can claim warm pods.
+  agentServerEnv: {}

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -651,22 +651,30 @@
 {{- $defaults := include "openhands.env.defaults" . | fromYamlArray }}
 {{- /*
     Effective env-var overrides. Start from .Values.env, then fold the
-    structured .Values.agentServerEnv map into OH_AGENT_SERVER_ENV: the map is
+    structured agent-server env map into OH_AGENT_SERVER_ENV: the map is
     merged on top of any JSON string already present at
     .Values.env.OH_AGENT_SERVER_ENV and re-serialised to JSON. This lets callers
     (e.g. replicated/openhands.yaml) assemble OH_AGENT_SERVER_ENV from a
     recursively-merged map of individual keys instead of repeating a hand-written
-    JSON blob in every optionalValues block. When agentServerEnv is empty,
-    .Values.env passes through unchanged, so existing callers are unaffected.
+    JSON blob in every optionalValues block. The map lives at
+    .Values.global.agentServerEnv so the runtime-api subchart can mirror the
+    same keys into the warm-runtime env (exact-env matching); the legacy
+    .Values.agentServerEnv is still merged on top for compatibility. When both
+    are empty, .Values.env passes through unchanged.
    */}}
 {{- $envOverrides := .Values.env | default dict }}
-{{- if .Values.agentServerEnv }}
+{{- $agentServerEnv := dict }}
+{{- if .Values.global }}
+{{- $agentServerEnv = deepCopy ((get .Values.global "agentServerEnv") | default dict) }}
+{{- end }}
+{{- $agentServerEnv = mergeOverwrite $agentServerEnv (deepCopy (.Values.agentServerEnv | default dict)) }}
+{{- if $agentServerEnv }}
 {{- $envOverrides = deepCopy $envOverrides }}
 {{- $base := dict }}
 {{- with (get $envOverrides "OH_AGENT_SERVER_ENV") }}
 {{- $base = mustFromJson (. | toString) }}
 {{- end }}
-{{- $_ := set $envOverrides "OH_AGENT_SERVER_ENV" (mustToJson (mergeOverwrite $base (deepCopy .Values.agentServerEnv))) }}
+{{- $_ := set $envOverrides "OH_AGENT_SERVER_ENV" (mustToJson (mergeOverwrite $base $agentServerEnv)) }}
 {{- end }}
 {{- /* Build a lookup dict of override keys for O(1) membership checks */}}
 {{- $overrideKeys := dict }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -87,14 +87,11 @@ env:
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
-# Structured source for the OH_AGENT_SERVER_ENV environment variable, which the
-# enterprise-server passes through to every agent-server (sandbox) runtime it
-# spawns. Rather than hand-writing that JSON blob, list the runtime's env vars
-# as a map here and the chart serialises it to JSON (see the "openhands.env"
-# helper). The map is merged on top of any OH_AGENT_SERVER_ENV string set
-# directly in .Values.env, so callers that layer values — e.g. KOTS
-# optionalValues with recursiveMerge — can add keys without repeating the whole
-# blob in every block. Empty by default, which emits no OH_AGENT_SERVER_ENV.
+# Legacy location for the agent-server (sandbox) runtime env map. Prefer
+# global.agentServerEnv, which the runtime-api subchart also mirrors into the
+# warm-runtime env so warm pods stay claimable (exact-env matching). Keys set
+# here still reach OH_AGENT_SERVER_ENV (merged on top of the global map) but
+# are NOT mirrored into the warm env.
 agentServerEnv: {}
 
 integrations:
@@ -1124,6 +1121,12 @@ global:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267
     allowInsecureImages: true
+  # Env the app injects into every per-session runtime (LLM provider creds,
+  # proxy vars, CA paths): serialised into OH_AGENT_SERVER_ENV on the app AND
+  # mirrored into each warm-runtime entry's env by the runtime-api subchart —
+  # runtime-api claims warm pods by exact env match, so a key present here but
+  # absent from the warm env would make the pool unclaimable.
+  agentServerEnv: {}
 
 vertexAI:
   enabled: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -21,6 +21,18 @@ spec:
       # global.agentServerImage.
       agentServerImage:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/agent-server'
+      # Runtime (agent-server sandbox) env vars. The chart serialises this map
+      # into OH_AGENT_SERVER_ENV and mirrors it into every warm-runtime entry's
+      # env (runtime-api claims warm pods by exact env match, so a key here
+      # that is absent from the warm env would make the pool unclaimable).
+      # CA-bundle defaults live here once; the provider optionalValues blocks
+      # below recursively-merge their creds on top.
+      agentServerEnv:
+        SSL_CERT_FILE: /etc/openhands/ca-bundle/ca-bundle.crt
+        REQUESTS_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
+        GIT_SSL_CAINFO: /etc/openhands/ca-bundle/ca-bundle.crt
+        CURL_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
+        NODE_EXTRA_CA_CERTS: /etc/openhands/ca-bundle/ca-bundle.crt
 
     image:
       repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/enterprise-server'
@@ -51,8 +63,8 @@ spec:
       # unconditionally (not gated on analytics_enabled) so the Keycloak realm
       # redirect URIs stay on the analytics domain either way.
       LAMINAR_WEB_HOST: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
-      # OH_AGENT_SERVER_ENV is assembled by the chart from spec.values.agentServerEnv
-      # (see the map below), not hand-written here.
+      # OH_AGENT_SERVER_ENV is assembled by the chart from
+      # spec.values.global.agentServerEnv, not hand-written here.
       OPENHANDS_DEFAULT_ORG_ENABLED: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
       OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS: 'repl{{ ConfigOptionEquals "default_openhands_org_auto_add_users" "1" }}'
       # Hiding personal workspaces needs both forms: the structured flag drives
@@ -73,18 +85,6 @@ spec:
 
     integrations:
       resolverLabel: 'repl{{ ConfigOption "openhands_resolver_label" }}'
-
-    # Runtime (agent-server sandbox) env vars. The chart serialises this map into
-    # OH_AGENT_SERVER_ENV (see the openhands.env helper). These CA-bundle
-    # defaults apply to every provider; the provider optionalValues blocks below
-    # recursively-merge their own keys on top, so the bundle vars live here once
-    # instead of being repeated in each block.
-    agentServerEnv:
-      SSL_CERT_FILE: /etc/openhands/ca-bundle/ca-bundle.crt
-      REQUESTS_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
-      GIT_SSL_CAINFO: /etc/openhands/ca-bundle/ca-bundle.crt
-      CURL_CA_BUNDLE: /etc/openhands/ca-bundle/ca-bundle.crt
-      NODE_EXTRA_CA_CERTS: /etc/openhands/ca-bundle/ca-bundle.crt
 
     ingress:
       enabled: true
@@ -727,14 +727,15 @@ spec:
           HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
           NO_PROXY: '{{repl $computedNoProxy}}'
           SSL_VERIFY: '{{repl if ConfigOptionEquals "ssl_verify" "1"}}True{{repl else}}False{{repl end}}'
-        # Runtime proxy vars, recursively-merged onto the base agentServerEnv
+        # Runtime proxy vars, recursively-merged onto the base global.agentServerEnv
         # (CA-bundle) map, so only the proxy-specific keys need to appear here.
-        agentServerEnv:
-          HTTP_PROXY: '{{repl ConfigOption "http_proxy"}}'
-          HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
-          NO_PROXY: '{{repl $computedNoProxy}}'
-          SSL_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "True" "False"}}'
-          GIT_SSL_NO_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "False" "True"}}'
+        global:
+          agentServerEnv:
+            HTTP_PROXY: '{{repl ConfigOption "http_proxy"}}'
+            HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
+            NO_PROXY: '{{repl $computedNoProxy}}'
+            SSL_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "True" "False"}}'
+            GIT_SSL_NO_VERIFY: '{{repl ConfigOptionEquals "ssl_verify" "1" | ternary "False" "True"}}'
         keycloak:
           extraEnvVars:
             # Existing KC env vars (must be repeated because recursiveMerge replaces arrays)
@@ -771,12 +772,13 @@ spec:
           # textarea's first line from the legacy azure_deployment_name value,
           # so this stays byte-identical to today's azure-<deployment> default.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/azure-repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "azure_deployments" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
-        # Azure runtime creds, recursively-merged onto the base agentServerEnv
+        # Azure runtime creds, recursively-merged onto the base global.agentServerEnv
         # (CA-bundle) map.
-        agentServerEnv:
-          AZURE_API_KEY: '{{repl ConfigOption "azure_api_key"}}'
-          AZURE_API_BASE: '{{repl ConfigOption "azure_endpoint"}}'
-          AZURE_API_VERSION: '{{repl ConfigOption "azure_api_version"}}'
+        global:
+          agentServerEnv:
+            AZURE_API_KEY: '{{repl ConfigOption "azure_api_key"}}'
+            AZURE_API_BASE: '{{repl ConfigOption "azure_endpoint"}}'
+            AZURE_API_VERSION: '{{repl ConfigOption "azure_api_version"}}'
         litellm-helm:
           proxy_config:
             # One azure-<name> -> azure/<name> entry per non-empty line of the
@@ -819,10 +821,11 @@ spec:
           # user/org settings keep working.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "custom_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = splitList "/" $m | last }}repl{{ end }}repl{{ end }}repl{{ $first }}'
         # Custom-endpoint runtime creds, recursively-merged onto the base
-        # agentServerEnv (CA-bundle) map.
-        agentServerEnv:
-          CUSTOM_API_KEY: '{{repl ConfigOption "custom_api_key"}}'
-          CUSTOM_API_BASE: '{{repl ConfigOption "custom_base_url"}}'
+        # global.agentServerEnv (CA-bundle) map.
+        global:
+          agentServerEnv:
+            CUSTOM_API_KEY: '{{repl ConfigOption "custom_api_key"}}'
+            CUSTOM_API_BASE: '{{repl ConfigOption "custom_base_url"}}'
         litellm-helm:
           proxy_config:
             # One entry per non-empty line of the "Custom LLM Models" KOTS
@@ -849,16 +852,17 @@ spec:
           # falling back to gemini-2.5-flash — today's hardcoded default and
           # the textarea's prefilled line — if it resolves empty.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "vertex_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first | default "gemini-2.5-flash" }}'
-        # Vertex runtime creds, recursively-merged onto the base agentServerEnv
+        # Vertex runtime creds, recursively-merged onto the base global.agentServerEnv
         # (CA-bundle) map. ConfigOptionData returns the decoded (possibly
         # multi-line) service-account JSON; `default "{}" | mustFromJson |
         # mustToJson` minifies it to a single-line JSON string so it stays a
         # valid YAML scalar, and the chart then JSON-encodes that string as the
         # env value — matching the previous `... | toJson` handling.
-        agentServerEnv:
-          VERTEXAI_CREDENTIALS: '{{repl ConfigOptionData "google_vertex_credentials" | default "{}" | mustFromJson | mustToJson }}'
-          VERTEXAI_PROJECT: '{{repl ConfigOption "google_vertex_project_id"}}'
-          VERTEXAI_LOCATION: '{{repl ConfigOption "google_vertex_location"}}'
+        global:
+          agentServerEnv:
+            VERTEXAI_CREDENTIALS: '{{repl ConfigOptionData "google_vertex_credentials" | default "{}" | mustFromJson | mustToJson }}'
+            VERTEXAI_PROJECT: '{{repl ConfigOption "google_vertex_project_id"}}'
+            VERTEXAI_LOCATION: '{{repl ConfigOption "google_vertex_location"}}'
         litellm-helm:
           # volumes / volumeMounts are arrays — recursiveMerge replaces them,
           # so the ca-bundle entry from spec.values.litellm-helm above must
@@ -913,12 +917,13 @@ spec:
           # alias in the model_list below, so existing user/org settings keep
           # working.
           LITELLM_DEFAULT_MODEL: 'litellm_proxy/repl{{ $first := "" }}repl{{ range $raw := splitList "\n" (ConfigOption "bedrock_model_ids" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not $first) }}repl{{ $first = $m }}repl{{ end }}repl{{ end }}repl{{ $first }}'
-        # Bedrock runtime creds, recursively-merged onto the base agentServerEnv
+        # Bedrock runtime creds, recursively-merged onto the base global.agentServerEnv
         # (CA-bundle) map.
-        agentServerEnv:
-          AWS_ACCESS_KEY_ID: '{{repl ConfigOption "aws_access_key_id"}}'
-          AWS_SECRET_ACCESS_KEY: '{{repl ConfigOption "aws_secret_access_key"}}'
-          AWS_REGION_NAME: '{{repl ConfigOption "aws_region_name"}}'
+        global:
+          agentServerEnv:
+            AWS_ACCESS_KEY_ID: '{{repl ConfigOption "aws_access_key_id"}}'
+            AWS_SECRET_ACCESS_KEY: '{{repl ConfigOption "aws_secret_access_key"}}'
+            AWS_REGION_NAME: '{{repl ConfigOption "aws_region_name"}}'
         litellm-helm:
           proxy_config:
             # One <id> -> bedrock/<id> entry per non-empty line of the


### PR DESCRIPTION
## Problem

On any KOTS install whose LLM provider populates `agentServerEnv` (azure api-key, custom, vertex, bedrock static keys — or `proxy_enabled`), the warm-runtime pool is **never claimable**: the app injects those env vars (e.g. `CUSTOM_API_KEY`/`CUSTOM_API_BASE`, `AZURE_API_KEY`/`AZURE_API_BASE`/`AZURE_API_VERSION`) into every per-session runtime request via `OH_AGENT_SERVER_ENV`, but the `warm-runtimes-config` ConfigMap env is rendered from a separate values path that never sees them. runtime-api claims warm pods by exact env match, so every claim fails with

```
environment: match=False only_in_warm=[] only_in_request=['CUSTOM_API_BASE', 'CUSTOM_API_KEY'] value_differs=[]
No warm runtimes found for API key default with session ID ...
```

and every conversation cold-starts (~1 min). Reported by a customer running the Custom and Azure providers; confirmed from their support bundle (warm CM has 21 infra keys, zero provider keys; all session runtimes carry the AZURE_* trio, the warm runtime doesn't). Same failure class as the LMNR_HTTP_PORT asymmetry fixed in #738 — this closes the whole class for provider creds instead of adding another per-key mirror.

## Fix

Move the canonical agent-server env map to `global.agentServerEnv` so both consumers read one source:

- `replicated/openhands.yaml`: the base CA-bundle map and the five provider/proxy `agentServerEnv` blocks now merge under `global.agentServerEnv`.
- `charts/openhands/templates/_env.yaml`: `OH_AGENT_SERVER_ENV` is assembled from `global.agentServerEnv`, with the legacy `.Values.agentServerEnv` still merged on top for compatibility.
- `charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml`: each warm entry's `environment` now `mergeOverwrite`s `global.agentServerEnv`, so the warm env always matches what the app sends.

## Verified

- `helm template` subchart: warm CM env picks up `global.agentServerEnv` keys and keeps entry defaults; without global set, output is byte-identical to before.
- `helm template` umbrella: `global.agentServerEnv.CUSTOM_API_*` lands in both `OH_AGENT_SERVER_ENV` and the warm CM in one render; legacy `agentServerEnv` keys still reach `OH_AGENT_SERVER_ENV`.
- Duplicate-key YAML check on `replicated/openhands.yaml`; `helm lint` on both charts.

## Notes

- Provider creds now also appear in the warm ConfigMap. Incremental exposure is limited — the identical values already sit as literal env in the openhands deployment spec (`OH_AGENT_SERVER_ENV`) and in every session runtime pod spec — but worth noting; the warm spec chain (ConfigMap → warm_runtimes.py → V1EnvVar) has no secret-ref support today.
- On key rotation the CM regenerates immediately; warm pods serve the old env until the per-minute warm-runtimes CronJob replaces them (brief self-healing cold-start window).
- Per-user BYOK is unaffected: user keys ride the conversation payload, not the runtime env, so request env stays identical across users.
