### PR TITLE
fix(openhands): stop warm-runtimes job pods matching the runtime-api Service selector

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/deployment.yaml
+++ b/charts/openhands/charts/runtime-api/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
     metadata:
       labels:
         {{- include "runtime-api.selectorLabels" . | nindent 8 }}
+        {{- /* Distinguishes API pods from the kvm-device-plugin DaemonSet and
+        warm-runtimes CronJob pods that share the selectorLabels; lets the
+        Service selector be tightened to component=api in a later release. */}}
+        app.kubernetes.io/component: api
     spec:
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
@@ -13,10 +13,10 @@ spec:
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ .Values.jobSettings.activeDeadlineSeconds }}
+      {{- /* No selectorLabels on the job pods: they would match the
+      runtime-api Service selector. Jobs track their pods by controller-uid,
+      so no pod labels are needed (the other cronjobs set none either). */}}
       template:
-        metadata:
-          labels:
-            {{- include "runtime-api.selectorLabels" . | nindent 12 }}
         spec:
           {{- with .Values.securityContext }}
           securityContext:


### PR DESCRIPTION
## Problem

The `openhands-runtime-api` Service selects on `runtime-api.selectorLabels` (`app.kubernetes.io/name` + `instance`), and two other workloads' pods carry those same labels: the warm-runtimes CronJob pods (exactly the selector set) and the kvm-device-plugin DaemonSet pods (selector set + a component label). A customer flagged this overlap while debugging (it shows up confusingly in EndpointSlices, where the kvm pod appears in a slice with `ports: null`).

In practice no traffic misroutes — the Service uses the **named** targetPort `http` and only the API Deployment's container declares a port with that name, so the endpoints controller excludes the other pods, and their support bundle confirms the Endpoints object holds exactly one address. This is hygiene, not a routing fix.

## Change (upgrade-safe half)

- **warm-runtimes CronJob**: drop the pod-template labels entirely. Jobs track pods by `controller-uid`, no consumer reads these labels (no NetworkPolicies; PodMonitoring is GKE-only/disabled), and the chart's four other CronJobs already set none. This removes the only exact selector match.
- **runtime-api Deployment**: add `app.kubernetes.io/component: api` to the pod template (labels only — `spec.selector` is immutable and untouched).

Both changes are no-ops for routing today. A follow-up release can then tighten the Service selectors (subchart `service.yaml` + the parent `oh-main-runtime-api` alias) to include `component: api` without an empty-endpoints window, since running pods will already carry the label. The kvm-device-plugin DaemonSet keeps its labels — its own immutable `spec.selector` includes them — and is excluded once the Service selector tightens.

## Verified

`helm lint` + `helm template`: cronjob job pods render with no labels; Deployment selector unchanged with `component: api` added to pod labels only.
