### PR TITLE
chore(openhands): pin redis master resources to effective values

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -732,15 +732,15 @@ redis:
   master:
     persistence:
       enabled: false
+    resources:
+      requests:
+        memory: 100Mi
+        cpu: 100m
+      limits:
+        memory: 512Mi
+        cpu: 100m
   replica:
     replicaCount: 0
-  resources:
-    requests:
-      memory: 100Mi
-      cpu: 100m
-    limits:
-      memory: 512Mi
-      cpu: 100m
 
 maintenanceTasks:
   enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -732,9 +732,7 @@ redis:
   master:
     persistence:
       enabled: false
-    # Matches the effective values the chart has always deployed: the previous
-    # top-level `resources` block was a no-op (the bitnami chart only reads
-    # master.resources), so the master ran with the "nano" resourcesPreset.
+    # Pinned copy of the bitnami "nano" resourcesPreset.
     resources:
       requests:
         cpu: 100m

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -732,13 +732,18 @@ redis:
   master:
     persistence:
       enabled: false
+    # Matches the effective values the chart has always deployed: the previous
+    # top-level `resources` block was a no-op (the bitnami chart only reads
+    # master.resources), so the master ran with the "nano" resourcesPreset.
     resources:
       requests:
-        memory: 100Mi
         cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 50Mi
       limits:
-        memory: 512Mi
-        cpu: 100m
+        cpu: 150m
+        memory: 192Mi
+        ephemeral-storage: 2Gi
   replica:
     replicaCount: 0
 


### PR DESCRIPTION
## Description

An audit of the values files for no-op keys (keys that nothing consumes, prompted by an earlier typo where a postgres setting everyone believed was applied actually wasn't) found that `redis.resources` is one of them.

The bitnami redis chart has no top-level `resources` key. The master pod reads `master.resources`, and when that's empty it falls back to `resourcesPreset: nano`. So the 100m/512Mi block we set has never been applied; every deployment has been running the master with the nano preset.

This moves the block to `redis.master.resources` and pins it to the nano preset's effective values (100m cpu / 128Mi / 50Mi ephemeral-storage requests, 150m cpu / 192Mi / 2Gi ephemeral-storage limits). Clusters keep exactly the resources they run with today; the values file just stops lying about them. If we later decide the master deserves more than nano, that becomes an explicit change to this block.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

`helm template` output is byte-identical to main, so this deploys no change. Any consumer already overriding `redis.master.resources` keeps their value; a consumer overriding `redis.resources` was already a no-op and stays one.