### PR TITLE
chore(openhands): remove no-op values file keys

### DIFF
--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -128,7 +128,8 @@ filestore:
 # 2. Subchart of openhands: Set minio.enabled=false and configure minio.external
 #    to use the parent chart's minio instance
 minio:
-  # Deploy minio as a subchart (for standalone deployments)
+  # When true, point the app at the release's minio service
+  # (http://<release>-minio:9000) using the first svcaccts credentials below.
   # Set to false when deployed as subchart of openhands (uses parent's minio)
   enabled: false
 
@@ -139,28 +140,11 @@ minio:
     accessKey: "default"
     secretKey: "notasecret"
 
-  # Minio subchart configuration (used when enabled=true)
-  # These values are passed to the minio subchart
-  replicas: 1
-  mode: standalone
-  persistence:
-    enabled: false
-  buckets:
-    - name: automation-data
-      policy: none
-      purge: true
+  # Credentials used when enabled=true (only the first entry is read)
   svcaccts:
     - accessKey: "automationkey"
       secretKey: "automationsecret"
       user: root
-  rootUser: "root"
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 50m
-    limits:
-      memory: 512Mi
-      cpu: 100m
 
 # Service key from K8s secret (for staging/production)
 # Used by OpenHands SaaS to authenticate requests to the automation service
@@ -181,24 +165,11 @@ datadog:
 # Env vars passed directly to the container
 env: {}
 
-# PostgreSQL subchart configuration (for ephemeral/feature environments)
-# When enabled, deploys an in-cluster PostgreSQL instance
-# Service name will be "{release-name}-postgresql", secret name also "{release-name}-postgresql"
+# When true, an init container waits for an in-cluster PostgreSQL at
+# database.host before starting (ephemeral/feature environments that deploy
+# postgres alongside this chart). This chart does not deploy postgres itself.
 postgresql:
   enabled: false
-  image:
-    repository: bitnamilegacy/postgresql
-  auth:
-    username: postgres
-    database: automations
-  primary:
-    persistence:
-      enabled: false
-    initdb:
-      scriptsConfigMap: ""
-  service:
-    ports:
-      postgresql: 5432
 
 global:
   security:

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -46,8 +46,6 @@ probes:
 
 # Service configuration
 service:
-  # Public base URL where this service is reachable.
-  baseUrl: ""
   # Port the container listens on (8000 for Python/FastAPI backend)
   port: 8000
 
@@ -128,9 +126,6 @@ database:
   # Secret containing the database password
   secretName: "integrations-hub-db-secret"
   secretKey: "db-password"
-  # Use an existing secret instead of auto-generating one
-  # When true, the chart will not create the db secret
-  existingSecret: false
   # Create database and user in an existing PostgreSQL instance
   # When true, runs an init container to create the database and user
   # Useful when sharing a PostgreSQL instance with other services
@@ -140,9 +135,6 @@ database:
   # Only used when createDatabaseUser=true
   superuserSecretName: "postgres-password"
   superuserSecretKey: "password"
-  # Connection pool settings
-  poolSize: 10
-  maxOverflow: 5
 
 # Datadog configuration
 datadog:
@@ -163,24 +155,11 @@ cron:
 # such as NOTION_CLIENT_ID/NOTION_CLIENT_SECRET).
 env: {}
 
-# PostgreSQL subchart configuration (for ephemeral/feature environments)
-# When enabled, deploys an in-cluster PostgreSQL instance
-# Service name will be "{release-name}-postgresql", secret name also "{release-name}-postgresql"
+# When true, an init container waits for an in-cluster PostgreSQL at
+# database.host before starting (ephemeral/feature environments that deploy
+# postgres alongside this chart). This chart does not deploy postgres itself.
 postgresql:
   enabled: false
-  image:
-    repository: bitnamilegacy/postgresql
-  auth:
-    username: postgres
-    database: integrations_hub
-  primary:
-    persistence:
-      enabled: false
-    initdb:
-      scriptsConfigMap: ""
-  service:
-    ports:
-      postgresql: 5432
 
 global:
   security:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -112,14 +112,12 @@ jobSettings:
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
 
-nodeSelector: {}
-
 securityContext: {}
 
 # KVM device plugin (OSS SANDBOX_KVM_ENABLED parity). When enabled, runs a
 # smarter-device-manager DaemonSet that advertises /dev/kvm as an extended
-# resource (kvm.resourceName) so sandbox pods can use hardware-accelerated QEMU
-# WITHOUT being privileged. The node must expose /dev/kvm (bare-metal or a
+# resource (smarter-devices/kvm) so sandbox pods can use hardware-accelerated
+# QEMU WITHOUT being privileged. The node must expose /dev/kvm (bare-metal or a
 # nested-virt-capable VM). The plugin DaemonSet itself runs privileged, like
 # other device plugins; the sandbox pods do not.
 kvm:
@@ -128,7 +126,6 @@ kvm:
     repository: ghcr.io/smarter-project/smarter-device-manager
     tag: v1.20.11
     pullPolicy: IfNotPresent
-  resourceName: smarter-devices/kvm
   maxDevices: 20
   # The device plugin advertises /dev/kvm but the node's default 0660 root:kvm
   # perms still block the non-root sandbox UID from opening it. An init container
@@ -149,30 +146,16 @@ kvm:
   nodeSelector: {}
   tolerations: []
 
-tolerations: []
-
-affinity: {}
-
 postgresql:
   enabled: false
-  image:
-    repository: bitnamilegacy/postgresql
-  isFeatureDeploy: false
   primary:
-    persistence:
-      enabled: false
     service:
       ports:
         postgresql: 5432
   auth:
     username: postgres
-    password: "" # This should be set externally for security reasons
     existingSecret: postgres-password
     database: runtime_api_db
-
-externalDatabase:
-  enabled: false
-  existingSecret: postgres-password
 
 # External database configuration (used when postgresql.enabled=false)
 database:
@@ -186,17 +169,6 @@ database:
   maxOverflow:
     api: 10 # Max overflow for API deployment (default)
     cronjobs: 5 # Max overflow for cronjobs (default)
-
-helm-release-pruner:
-  enabled: false
-  job:
-    schedule: "0 */4 * * *"
-    dryRun: False
-  pruneProfiles:
-    - olderThan: "1 days ago"
-      helmReleaseFilter: "^runtime-api-.*$"
-      namespaceFilter: "^runtime-api-.*$"
-      maxReleasesToKeep: 10
 
 certificate:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1088,7 +1088,9 @@ automation:
   # Env vars passed directly to the container (overrides defaults)
   env: {}
   
-  # PostgreSQL subchart - disabled when using parent's PostgreSQL
+  # When true, an init container waits for an in-cluster PostgreSQL at
+  # database.host before starting. Disabled here because the service uses
+  # the parent chart's PostgreSQL (no postgres is deployed by this subchart).
   postgresql:
     enabled: false
 
@@ -1314,7 +1316,9 @@ integrations-hub:
   # Env vars passed directly to the container
   env: {}
 
-  # PostgreSQL subchart - disabled when using parent's PostgreSQL
+  # When true, an init container waits for an in-cluster PostgreSQL at
+  # database.host before starting. Disabled here because the service uses
+  # the parent chart's PostgreSQL (no postgres is deployed by this subchart).
   postgresql:
     enabled: false
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -822,9 +822,6 @@ runtime-api:
     auth:
       username: postgres
       existingSecret: postgres-password
-  externalDatabase:
-    enabled: false
-    existingSecret: postgres-password
   ingress:
     enabled: false
     # REQUIRED: Update to a hostname in a DNS domain you own
@@ -1127,10 +1124,6 @@ global:
   # absent from the warm env would make the pool unclaimable.
   agentServerEnv: {}
 
-vertexAI:
-  enabled: false
-  project: ""
-
 # Trust-manager Bundle that fans a CA bundle (public CAs + an optional
 # operator-supplied CA certificate) out as a ConfigMap into the release
 # namespace. Consumers (openhands deployments + outbound-HTTPS cronjobs,
@@ -1188,7 +1181,6 @@ crdCheck:
       memory: 64Mi
     limits:
       memory: 128Mi
-  location: ""
 
 # Integrations Hub - Agent context layer with managed connectors and MCP integrations
 integrations-hub:
@@ -1242,7 +1234,6 @@ integrations-hub:
 
   # Service configuration
   service:
-    baseUrl: ""
     # Port the FastAPI container listens on (matches the integrations-hub
     # Dockerfile's `EXPOSE 8000` on the development branch).
     port: 8000
@@ -1305,7 +1296,6 @@ integrations-hub:
     name: "integrations_hub"
     secretName: "integrations-hub-db-secret"
     secretKey: "db-password"
-    existingSecret: false
     createDatabaseUser: false
     superuserSecretName: "postgres-password"
     superuserSecretKey: "password"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -883,10 +883,6 @@ spec:
             # app shows an unavailable badge). If the textarea resolves empty,
             # fall back to the old hardcoded route.
             model_list: repl{{ $models := list }}repl{{ $seen := dict }}repl{{ range $raw := splitList "\n" (ConfigOption "vertex_models" | replace "\r" "\n" | replace "," "\n") }}repl{{ $m := trim $raw }}repl{{ if and $m (not (hasKey $seen $m)) }}repl{{ $seen = set $seen $m true }}repl{{ $models = append $models (dict "model_name" $m "litellm_params" (dict "model" (printf "vertex_ai/%s" $m) "vertex_project" "os.environ/VERTEXAI_PROJECT" "vertex_location" "os.environ/VERTEXAI_LOCATION")) }}repl{{ end }}repl{{ end }}repl{{ if not $models }}repl{{ $models = list (dict "model_name" "gemini-2.5-flash" "litellm_params" (dict "model" "vertex_ai/gemini-2.5-flash" "vertex_project" "os.environ/VERTEXAI_PROJECT" "vertex_location" "os.environ/VERTEXAI_LOCATION")) }}repl{{ end }}repl{{ $models | mustToJson }}
-          vertexAI:
-            enabled: true
-            project: '{{repl ConfigOption "google_vertex_project_id"}}'
-            location: '{{repl ConfigOption "google_vertex_location"}}'
     # AWS Bedrock — static access keys. LiteLLM speaks Bedrock natively via the
     # AWS SDK; the AWS_* env vars are sourced from litellm-env-secrets and
     # referenced in model_list via os.environ/* so the keys never appear in

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -351,7 +351,6 @@ spec:
         KVM_DEVICE_RESOURCE: "smarter-devices/kvm"
       kvm:
         enabled: repl{{ ConfigOptionEquals "sandbox_kvm_enabled" "1" }}
-        resourceName: smarter-devices/kvm
         image: 
           repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/smarter-project/smarter-device-manager'
           # Do not override the image tag here. Pin to a stable version in the chart.


### PR DESCRIPTION
## Description

An audit of the values files for no-op keys (keys nothing consumes, prompted by an earlier typo where a postgres setting everyone believed was applied actually wasn't) turned up a batch in the openhands chart tree. The values file doubles as documentation of the available config options, so keys that do nothing are misleading. This removes them:

- Umbrella: the `vertexAI` block (superseded by the vertex wiring in openhands-secrets / litellm-env-secrets), `crdCheck.location` (the crd-check hook reads every other key in that block), `integrations-hub.service.baseUrl`, `integrations-hub.database.existingSecret`, and `runtime-api.externalDatabase` (the subchart has no `externalDatabase` handling; its external DB config is the `database` block).
- runtime-api: top-level `nodeSelector`/`tolerations`/`affinity` (the deployment never wires them; only `kvm.nodeSelector`/`kvm.tolerations` exist), `kvm.resourceName` (the device plugin hardcodes `^kvm$`; the comment claimed otherwise), the unused parts of the `postgresql` block, the `externalDatabase` block, and the `helm-release-pruner` block (not a dependency, referenced nowhere).
- automation and integrations-hub: the `minio` and `postgresql` blocks read like subchart pass-through config, but neither chart declares any dependency, so only the handful of keys their own templates read are live (`minio.enabled`/`external`/`svcaccts[0]`, `postgresql.enabled`). Everything else is removed and the comments now describe what the flags actually do.
- integrations-hub: `service.baseUrl` (templates read `openhands.baseUrl`), `database.existingSecret` (no secret-creating template exists), `database.poolSize`/`maxOverflow` (never emitted into env).
- replicated/openhands.yaml: the KOTS vertex block that set the dead umbrella `vertexAI` values. VERTEXAI_PROJECT/VERTEXAI_LOCATION already reach litellm through the openhands-secrets chart.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

I verified this is a pure no-op: `helm template` output is byte-identical to main, both with defaults and with automation, integrations-hub, plugin-directory, agent-canvas, and the runtime-api kvm plugin force-enabled. Consumers still setting any of the removed keys keep working; the keys were ignored before and remain ignored.

The one judgement call: I removed dead keys rather than wiring them up. If we actually want runtime-api pod-level `nodeSelector`/`tolerations`/`affinity` support, that should be a deliberate feature change, and I'd rather not sneak it into a cleanup.