### PR TITLE
chore(image-loader): remove unused runtimeClass value

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -4,8 +4,6 @@ image:
   tag: 1.36.0-python
   pullPolicy: Always
 
-runtimeClass: sysbox-runc
-
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
## Description

An audit of the values files for no-op keys (keys nothing consumes, prompted by an earlier typo where a postgres setting everyone believed was applied actually wasn't) found `runtimeClass: sysbox-runc` here. No template in the chart sets `runtimeClassName`; the key has been dead since the chart was first added. Since the values file documents the chart's config surface, this removes it.

The loader only pre-pulls the agent-server image onto sysbox nodes (targeted via `nodeSelector`/`tolerations`), and pulling doesn't need the runtime class, so I removed the key rather than wiring it. Running the loader pods under sysbox would be a deliberate behavior change if we ever want it.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

`helm template` output is byte-identical to main.