### PR TITLE
chore(openhands-secrets): remove no-op config keys

### DIFF
--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -8,9 +8,7 @@ automation:
 config:
   # Security secrets
   admin_password: ""
-  postgres_host: ""
   postgres_username: "postgres"
-  postgres_database: "openhands"
   postgres_password: ""
   redis_password: ""
   jwt_secret: ""
@@ -32,9 +30,10 @@ config:
   openai_api_key: ""
   google_gemini_api_key: ""
   google_vertex_credentials: ""
+  google_vertex_project_id: ""
+  google_vertex_location: ""
   deepseek_api_key: ""
   mistral_api_key: ""
-  azure_auth_method: "api_key"
   azure_api_key: ""
   azure_tenant_id: ""
   azure_client_id: ""
@@ -64,8 +63,6 @@ config:
   bitbucket_data_center_bot_token: ""
 
   # Azure DevOps credentials (Microsoft Entra OAuth)
-  azure_devops_tenant_id: ""
-  azure_devops_organization: ""
   azure_devops_client_id: ""
   azure_devops_client_secret: ""
 
@@ -107,5 +104,4 @@ config:
   tls_private_key: ""
   tls_ca_certificate: ""
   tls_env: ""
-  auth_hostname: ""
  

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -24,10 +24,7 @@ spec:
       sandbox_api_key: '{{repl ConfigOption "default_api_key"}}'
 
       # Database configuration
-      # TODO: is this the correct hostname fallback for embedded postgres?
-      postgres_host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
       postgres_username: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}{{repl ConfigOption "postgres_username"}}{{repl end}}'
-      postgres_database: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_database"}}{{repl else}}{{repl ConfigOption "postgres_database"}}{{repl end}}'
       postgres_password: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_password"}}{{repl else}}{{repl ConfigOption "postgres_password"}}{{repl end}}'
 
       # Keycloak configuration
@@ -45,7 +42,6 @@ spec:
         {{repl ConfigOptionData "google_vertex_credentials" | nindent 8}}
       deepseek_api_key: '{{repl ConfigOption "deepseek_api_key"}}'
       mistral_api_key: '{{repl ConfigOption "mistral_api_key"}}'
-      azure_auth_method: '{{repl ConfigOption "azure_auth_method"}}'
       azure_api_key: '{{repl ConfigOption "azure_api_key"}}'
       azure_tenant_id: '{{repl ConfigOption "azure_tenant_id"}}'
       azure_client_id: '{{repl ConfigOption "azure_client_id"}}'
@@ -77,8 +73,6 @@ spec:
       bitbucket_data_center_bot_token: '{{repl ConfigOption "bitbucket_data_center_bot_token"}}'
 
       # Azure DevOps credentials (Microsoft Entra OAuth)
-      azure_devops_tenant_id: '{{repl ConfigOption "azure_devops_tenant_id"}}'
-      azure_devops_organization: '{{repl ConfigOption "azure_devops_organization"}}'
       azure_devops_client_id: '{{repl ConfigOption "azure_devops_client_id"}}'
       azure_devops_client_secret: '{{repl ConfigOption "azure_devops_client_secret"}}'
 
@@ -123,10 +117,7 @@ spec:
         {{repl ConfigOptionData "tls_private_key" | nindent 8}}
       tls_ca_certificate: |
         {{repl ConfigOptionData "tls_ca_certificate" | nindent 8}}
-      wildcard-tls-cert: |
-        {{repl ConfigOptionData "tls_certificate" | nindent 8}}
       tls_env: '{{repl Namespace }}'
-      auth_hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
 
   optionalValues:
     - when: '{{repl ConfigOptionEquals "automations_enabled" "1" }}'


### PR DESCRIPTION
## Description

An audit of the values files for no-op keys (keys nothing consumes, prompted by an earlier typo where a postgres setting everyone believed was applied actually wasn't) found six dead `config.*` keys in this chart: `postgres_host`, `postgres_database`, `azure_auth_method`, `azure_devops_tenant_id`, `azure_devops_organization`, and `auth_hostname`. No template reads any of them, so setting them has never done anything. This removes them from values.yaml and drops the matching pass-throughs in replicated/secrets.yaml, which were feeding real config option values into a chart that ignores them.

Two related fixes in the same pass:

- `google_vertex_project_id` and `google_vertex_location` are the opposite case: litellm-env-secrets.yaml reads them and KOTS sets them, but they were missing from values.yaml. Added with empty defaults so the config surface is documented.
- `wildcard-tls-cert` in replicated/secrets.yaml duplicated `tls_certificate` into a key no template reads; dropped it too.

None of this loses function elsewhere. The postgres host/database and auth hostname reach the app through the openhands chart's own values, `azure_auth_method` still gates the KOTS config UI, and the Azure DevOps tenant/org still flow to the umbrella's `azureDevOps` block.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

`helm template` output is byte-identical to main with default values, and I confirmed the newly documented vertex keys still render VERTEXAI_PROJECT / VERTEXAI_LOCATION into litellm-env-secrets when set. Consumers still passing the removed keys keep working; the keys were ignored before and remain ignored.