### PR TITLE
fix(automation): bump image to 1.1.6 — TEST 0.21.1 hotfix simulation

### DIFF
--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: ghcr.io/openhands/automation
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: 1.1.5
+  tag: 1.1.6
 
 imagePullSecrets: []
 


### PR DESCRIPTION
> ⚠️ **TEST / SIMULATION ONLY — DO NOT PROMOTE TO STABLE.**
> This PR exists to validate the emergency/hotfix Replicated release path. Any
> Replicated sequence it produces is harmless as long as it is **not promoted to
> Stable**.

## What this tests

Whether an emergency **hotfix** to the Replicated distribution can be cut through
the *sanctioned* release-branch flow — as opposed to hand-editing a tag + local
`make release` (which `Makefile` `check-release-guard` is designed to block).

## The flow being exercised

1. **Branch** `release/0.21.1` created off the released `openhands/0.21.0` tag
   (the actual repo convention: bare-semver `release/0.X.1`, cf. `release/0.18.1`).
2. **This PR** lands the hotfix on that branch via a `fix:` conventional commit,
   bumping a component image to a **semver** tag (not a sha):
   `charts/openhands/charts/automation/values.yaml` → `tag: 1.1.5 → 1.1.6`.
3. On merge into `release/0.21.1`, **release-please** (`release.yml` triggers on
   `release/**`) should open a release PR bumping the chart `version:`
   `0.21.0 → 0.21.1` (+ the openhands component version).
4. Merging *that* release PR cuts the `openhands/0.21.1` tag →
   `release-replicated-beta.yml` publishes a new sequence to the **Beta** channel.
5. Promotion Beta → Stable is a **manual** vendor-portal step and is intentionally
   **not** part of this test.

## Safety

- Nothing publishes to Replicated from this PR itself. The Beta publish only fires
  on the `openhands/0.21.1` **tag**, which only exists once the release-please PR
  (step 3) is merged.
- Even then it lands on **Beta**, which is harmless unless promoted to Stable.
- `validate-replicated.yml` runs `make lint` on this PR — that's the real
  bundle-validity signal (the `replicated` CLI isn't available locally).

## Open questions this answers (from review)

- **Release-branch naming:** `release/0.21.1` (bare semver), not `release/0.21.x`
  or `release/v0.21`.
- **Image tag manual vs release-please:** the **image tag is edited by hand** on
  the branch (this PR); release-please drives only the chart `version:` /
  component version bumps.
