### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @jlav @mamoodi @aivong-openhands @dylan-openhands


### PR DESCRIPTION
## Description

Adding a CODEOWNERS so the Platform team is added to the reviewers by default.
I'm not turning on "Require review from Code Owners", so anyone with write access can still approve a PR.

## Helm Chart Checklist

<!-- No Helm charts modified -->