### PR TITLE
fix(backport): bump agent-server to 1.36.0-python and enterprise-server to cloud-1.46.1

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.34.0-python
+  tag: 1.36.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.46.0
+appVersion: cloud-1.46.1
 version: 0.18.1
 dependencies:
   - name: keycloak

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -357,7 +357,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.34.0-python
+    tag: 1.36.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.46.0
+  tag: cloud-1.46.1
 
 autoscaling:
   enabled: false
@@ -1114,7 +1114,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.34.0-python
+    tag: 1.36.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -988,9 +988,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.34.0-python
+          help_text: Image tag, e.g. 1.36.0-python
           type: text
-          default: "1.34.0-python"
+          default: "1.36.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
Backport of #877 onto the 0.18 release line (target 0.18.2). Bumps agent-server 1.34.0-python -> 1.36.0-python (all four pin spots) and enterprise-server appVersion/image.tag -> cloud-1.46.1, plus the replicated custom-sandbox-image default. No chart $.version change (release-please owns that).