### PR TITLE
test: PLTF-1257 helm-unittest setup

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -1,0 +1,21 @@
+name: Helm Unit Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/helm-unittest.yml'
+      - 'charts/**'
+
+jobs:
+  helm-unittest:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.18.4'
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.1
+      - name: Run chart unit tests
+        run: helm unittest charts/openhands

--- a/charts/openhands/tests/service_test.yaml
+++ b/charts/openhands/tests/service_test.yaml
@@ -1,0 +1,35 @@
+suite: openhands service
+templates:
+  - service.yaml
+tests:
+  - it: renders the openhands Service routing port 3000 to the app
+    set:
+      enabled: true
+      postgresql.enabled: false
+      runtime-api.enabled: false
+      litellm-helm.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: openhands-service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.selector.app
+          value: openhands
+      - contains:
+          path: spec.ports
+          content:
+            name: openhands
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+  - it: renders no Services when the chart is disabled
+    set:
+      enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Why

Sets up [helm-unittest](https://github.com/helm-unittest/helm-unittest) as the framework for chart render tests. Adds a standalone workflow and one initial test suite asserting on the openhands Service and that a disabled chart renders no Services. The suite only renders the chart's own templates, so external subcharts are not fetched. Helm unit test suite runs as a PR check.

## Validation

- `helm unittest charts/openhands` passes both example tests (2 passed, 2 total) on a clean checkout of this branch with only the committed local subcharts present

_This PR was drafted by an AI agent on behalf of the user._
