### PR TITLE
feat: PLTF-3198 enable the Replicated SDK by default for helm installs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          # 'latest' falls back to helm v3.9.0 when the release lookup is
+          # rate-limited, which is too old to render the replicated SDK chart.
+          version: 'v3.21.3'
       - name: Build chart dependencies
         run: |
           helm repo add lmnr https://lmnr-ai.github.io/lmnr-helm

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # 'latest' falls back to helm v3.9.0 when the release lookup is
           # rate-limited, which is too old to render the replicated SDK chart.
-          version: 'v3.21.3'
+          version: 'v3.18.4'
       - name: Build chart dependencies
         run: |
           helm repo add lmnr https://lmnr-ai.github.io/lmnr-helm

--- a/.github/workflows/preview-helm-charts.yml
+++ b/.github/workflows/preview-helm-charts.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.check.outputs.should_publish == 'true'
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Compute preview version
         if: steps.check.outputs.should_publish == 'true'
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Lint ${{ matrix.chart.name }} chart
         env:

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Install Replicated CLI
         run: |

--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Install yq
         uses: mikefarah/yq@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
         if: steps.check.outputs.should_publish == 'true' && steps.candidate.outputs.has_candidate == 'true'
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Compute alpha version
         if: steps.check.outputs.should_publish == 'true' && steps.candidate.outputs.has_candidate == 'true'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           # 'latest' falls back to helm v3.9.0 when the release lookup is
           # rate-limited, which is too old to render the replicated SDK chart.
-          version: 'v3.21.3'
+          version: 'v3.18.4'
 
       - name: Build OpenHands chart dependencies
         run: |

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          # 'latest' falls back to helm v3.9.0 when the release lookup is
+          # rate-limited, which is too old to render the replicated SDK chart.
+          version: 'v3.21.3'
 
       - name: Build OpenHands chart dependencies
         run: |

--- a/.github/workflows/validate-replicated.yml
+++ b/.github/workflows/validate-replicated.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.18.4'
 
       - name: Install yq
         uses: mikefarah/yq@v4

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -434,14 +434,14 @@ spec:
         namespace: ingress-nginx
         limits:
           maxAge: 336h
-    {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
+    {{- if and .Values.postgresql.enabled .Values.replicated.enabled .Values.replicated.postgresPassword }}
     - postgresql:
         collectorName: postgresql
         uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
         tls:
           disabled: true
     {{- end }}
-    {{- if and .Values.redis.enabled .Values.replicated.enabled }}
+    {{- if and .Values.redis.enabled .Values.replicated.enabled .Values.replicated.redisPassword }}
     - redis:
         collectorName: redis
         uri: redis://default:{{ .Values.replicated.redisPassword | urlquery }}@{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379
@@ -573,7 +573,7 @@ spec:
           - fail:
               when: "!= Healthy"
               message: "Pod {{`{{ .Namespace }}/{{ .Name }}`}} is not Healthy: {{`{{ .Status.Reason }}`}}"
-    {{- if and .Values.postgresql.enabled .Values.replicated.enabled }}
+    {{- if and .Values.postgresql.enabled .Values.replicated.enabled .Values.replicated.postgresPassword }}
     - postgresql:
         checkName: "PostgreSQL Database Health"
         collectorName: postgresql
@@ -591,7 +591,7 @@ spec:
               when: "connected == true"
               message: "PostgreSQL database is healthy"
     {{- end }}
-    {{- if and .Values.redis.enabled .Values.replicated.enabled }}
+    {{- if and .Values.redis.enabled .Values.replicated.enabled .Values.replicated.redisPassword }}
     - redis:
         checkName: "Redis Cache Health"
         collectorName: redis

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1100,12 +1100,14 @@ automation:
     enabled: false
 
 replicated:
-  enabled: false
-  # Database credentials below are rendered only into the support-bundle Secret
-  # (gated on replicated.enabled), following the same convention as the rest of
-  # replicated/openhands.yaml — the Replicated installer templates ConfigOption
-  # values into Secrets at install time. The troubleshoot v1beta2 redis/postgres
-  # collectors have no secretRef field, so auth must be inlined into the URI.
+  # Deploys the Replicated SDK subchart (license enforcement) and the
+  # troubleshoot preflight/support-bundle Secrets. The SDK's license is
+  # injected by the Replicated registry at chart-pull time, not set here.
+  enabled: true
+  # Database credentials below are rendered only into the support-bundle Secret;
+  # each collector also requires its password to be set. The troubleshoot
+  # v1beta2 redis/postgres collectors have no secretRef field, so auth must be
+  # inlined into the URI.
   redisPassword: ""
   postgresUsername: ""
   postgresPassword: ""

--- a/scripts/test_troubleshoot_secrets_template.py
+++ b/scripts/test_troubleshoot_secrets_template.py
@@ -1,0 +1,78 @@
+"""Tests for the replicated/troubleshoot rendering contract (PLTF-3198)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
+
+
+def render(*set_args: str, show_only: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = ["helm", "template", "openhands", str(OPENHANDS_CHART)]
+    if show_only is not None:
+        command.extend(["--show-only", show_only])
+    for arg in set_args:
+        command.extend(["--set", arg])
+    return subprocess.run(
+        command,
+        check=check,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def render_troubleshoot_secrets(*set_args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return render(*set_args, show_only="templates/troubleshoot/secrets.yaml", check=check)
+
+
+def test_troubleshoot_secrets_render_by_default() -> None:
+    manifest = render_troubleshoot_secrets().stdout
+
+    assert "troubleshoot.sh/kind: preflight" in manifest
+    assert "troubleshoot.sh/kind: support-bundle" in manifest
+    assert "name: openhands-preflight" in manifest
+    assert "name: openhands-support-bundle" in manifest
+
+
+def test_troubleshoot_secrets_absent_when_replicated_disabled() -> None:
+    result = render_troubleshoot_secrets("replicated.enabled=false", check=False)
+
+    # helm errors when --show-only matches no rendered manifests
+    assert result.returncode != 0
+    assert "could not find template" in result.stderr
+
+
+def test_db_collectors_absent_without_credentials() -> None:
+    manifest = render_troubleshoot_secrets().stdout
+
+    assert "- postgresql:" not in manifest
+    assert "- redis:" not in manifest
+
+
+def test_db_collectors_render_with_credentials() -> None:
+    manifest = render_troubleshoot_secrets(
+        "replicated.postgresUsername=oh",
+        "replicated.postgresPassword=pg-secret",
+        "replicated.postgresDatabase=openhands",
+        "replicated.redisPassword=redis-secret",
+    ).stdout
+
+    assert "- postgresql:" in manifest
+    assert "uri: postgresql://oh:pg-secret@openhands-postgresql" in manifest
+    assert "- redis:" in manifest
+    assert "uri: redis://default:redis-secret@openhands-redis-master" in manifest
+
+
+def test_replicated_sdk_renders_by_default() -> None:
+    manifest = render().stdout
+
+    assert "# Source: openhands/charts/replicated/" in manifest
+
+
+def test_replicated_sdk_absent_when_disabled() -> None:
+    manifest = render("replicated.enabled=false").stdout
+
+    assert "# Source: openhands/charts/replicated/" not in manifest


### PR DESCRIPTION
## Why
License enforcement requires the Replicated SDK to run in plain helm installs, not just KOTS/Embedded Cluster. Helm installs are served through the Replicated registry, which injects the customer license at chart-pull time, so flipping `replicated.enabled` to `true` is all the chart needs — no license values are added. The flip also turns on the preflight/support-bundle Secrets for helm installs (they were gated on the same flag), which is what enables troubleshoot CLI support bundles. The postgres/redis support-bundle collectors and analyzers now additionally require their password value to be set, so default helm installs don't render collector URIs with empty credentials (KOTS always sets them). Installs that should not run the Replicated SDK can set `replicated.enabled=false`.

## Validation
- `helm template` with default values renders the SDK subchart's resources and both troubleshoot Secrets (`troubleshoot.sh/kind: preflight` / `support-bundle`); with `replicated.enabled=false` neither renders — locked in as render tests in `scripts/test_troubleshoot_secrets_template.py`, alongside collector-credential gating in both directions.
- Live check on a kind cluster (bootstrapped with the kind harness from the closed #874 — cluster setup, seeded secrets, and kind values reused as-is): installed the current Unstable release (chart 0.22.0) from `oci://registry.replicated.com` with a dev license and `--set replicated.enabled=true`. The SDK pod came up licensed and the instance appeared in the Vendor Portal (`client: Replicated-SDK 1.9.0`, `appStatus: ready`, not KOTS/EC). `support-bundle --load-cluster-specs` discovered the chart and SDK specs and produced a bundle (203 files, all app pod logs + analyzers); `preflight secret/openhands/openhands-preflight` ran and passed. The generated bundle was then uploaded with `support-bundle upload` (authenticating with the license ID) and appeared on the customer's bundles page in the Vendor Portal — note the license needs the support-bundle-upload entitlement enabled for this step.
- In that live run the released chart's postgres/redis analyzers errored on empty-credential URIs — the exact failure mode the collector gating in this PR removes.

_This PR was drafted by an AI agent on behalf of the user._



