### PR TITLE
feat: route Integrations Hub on the primary OpenHands host

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -18,4 +18,6 @@ jobs:
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.1
       - name: Run chart unit tests
-        run: helm unittest charts/openhands
+        run: |
+          helm unittest charts/openhands
+          helm unittest charts/openhands/charts/integrations-hub

--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -18,6 +18,4 @@ jobs:
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.1
       - name: Run chart unit tests
-        run: |
-          helm unittest charts/openhands
-          helm unittest charts/openhands/charts/integrations-hub
+        run: helm unittest charts/openhands && helm unittest charts/openhands/charts/integrations-hub

--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -53,7 +53,7 @@
   value: "postgresql://$(INTHUB_DB_USER):$(INTHUB_DB_PASS)@$(INTHUB_DB_HOST):$(INTHUB_DB_PORT)/$(INTHUB_DB_NAME)?sslmode=$(INTHUB_DB_SSL_MODE)"
 {{- end }}
 
-# OpenHands identity provider used to validate session cookies / API keys.
+# OpenHands identity provider used to validate session cookies.
 {{- $openhandsBaseUrl := .Values.openhands.baseUrl }}
 {{- if and (not $openhandsBaseUrl) .Values.global }}
 {{- if .Values.global.ingress }}
@@ -126,13 +126,9 @@
 - name: INTHUB_OAUTH_REDIRECT_PROXY_URL
   value: {{ .Values.openhands.redirectProxyUrl | quote }}
 {{- end }}
-{{- $authUrl := .Values.openhands.authUrl }}
-{{- if .Values.sameOrigin }}
-{{- $authUrl = $openhandsBaseUrl }}
-{{- end }}
-{{- if $authUrl }}
+{{- if $openhandsBaseUrl }}
 - name: AUTH_URL
-  value: {{ $authUrl | quote }}
+  value: {{ $openhandsBaseUrl | quote }}
 {{- end }}
 
 {{- if .Values.datadog.enabled }}

--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -126,9 +126,13 @@
 - name: INTHUB_OAUTH_REDIRECT_PROXY_URL
   value: {{ .Values.openhands.redirectProxyUrl | quote }}
 {{- end }}
-{{- if .Values.openhands.authUrl }}
+{{- $authUrl := .Values.openhands.authUrl }}
+{{- if .Values.sameOrigin }}
+{{- $authUrl = $openhandsBaseUrl }}
+{{- end }}
+{{- if $authUrl }}
 - name: AUTH_URL
-  value: {{ .Values.openhands.authUrl | quote }}
+  value: {{ $authUrl | quote }}
 {{- end }}
 
 {{- if .Values.datadog.enabled }}

--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -17,6 +17,7 @@
     INTHUB_CREDENTIAL_ENCRYPTION_KEY
     INTHUB_STATIC_DIR                set in the Dockerfile to /app/out
     INTHUB_ROOT_PATH                 sub-path mount from .Values.rootPath
+    INTHUB_API_ROOT_PATH             public API prefix from .Values.apiRootPath
 
   In addition, backend/app/oauth_flow.py reads:
     INTHUB_OAUTH_REDIRECT_PROXY_URL  stable origin for OAuth callback proxy
@@ -81,6 +82,8 @@
 # empty rootPath override mounts the service at cluster root.
 - name: INTHUB_ROOT_PATH
   value: {{ .Values.rootPath | default "" | quote }}
+- name: INTHUB_API_ROOT_PATH
+  value: {{ .Values.apiRootPath | default "" | quote }}
 
 # Credential encryption key (required: signs/encrypts stored OAuth tokens
 # and other provider secrets at rest).

--- a/charts/openhands/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/deployment.yaml
@@ -132,26 +132,19 @@ spec:
         - containerPort: {{ .Values.service.port | default 8000 }}
         resources:
           {{- toYaml .Values.deployment.resources | nindent 12 }}
-        # Probe endpoints live on the FastAPI app. The leading prefix matches
-        # `.Values.rootPath` -- i.e. /integrations-hub/api/live by
-        # default, plain /api/live when rootPath is unset -- because
-        # the backend mounts all routes under INTHUB_ROOT_PATH. Keeping
-        # the probe URL in sync with the Helm value prevents probes
-        # from 404'ing whenever the chart's mount path changes.
-        # Liveness stays independent of external services, while readiness
-        # checks database availability before the pod receives traffic.
-        {{- $livePath := printf "%s/api/live" (.Values.rootPath | default "") }}
-        {{- $readyPath := printf "%s/api/ready" (.Values.rootPath | default "") }}
+        # Probes use the backend's internal routes and do not pass through the
+        # public ingress prefixes. Liveness stays independent of external
+        # services; readiness checks the database before receiving traffic.
         startupProbe:
           httpGet:
-            path: {{ $livePath | quote }}
+            path: /api/live
             port: {{ .Values.service.port | default 8000 }}
           failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
         livenessProbe:
           httpGet:
-            path: {{ $livePath | quote }}
+            path: /api/live
             port: {{ .Values.service.port | default 8000 }}
           initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
@@ -159,7 +152,7 @@ spec:
           timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            path: {{ $readyPath | quote }}
+            path: /api/ready
             port: {{ .Values.service.port | default 8000 }}
           initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.readiness.periodSeconds }}

--- a/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
+++ b/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
@@ -6,6 +6,10 @@ tests:
     set:
       rootPath: /integrations-hub
       apiRootPath: /api/integrations-hub
+      sameOrigin: true
+      openhands.baseUrl: https://pr-252.staging.all-hands.dev
+      openhands.authUrl: https://integrations-pr-252.staging.all-hands.dev
+      openhands.redirectProxyUrl: https://staging.all-hands.dev
       database.url: postgresql://example
       credentialEncryption.secretName: encryption
       cron.secretName: cron
@@ -26,3 +30,8 @@ tests:
           content:
             name: INTHUB_API_ROOT_PATH
             value: /api/integrations-hub
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_URL
+            value: https://pr-252.staging.all-hands.dev

--- a/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
+++ b/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
@@ -1,0 +1,28 @@
+suite: integrations hub deployment paths
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: configures public prefixes while keeping probes on internal API routes
+    set:
+      rootPath: /integrations-hub
+      apiRootPath: /api/integrations-hub
+      database.url: postgresql://example
+      credentialEncryption.secretName: encryption
+      cron.secretName: cron
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/live
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/ready
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTHUB_ROOT_PATH
+            value: /integrations-hub
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTHUB_API_ROOT_PATH
+            value: /api/integrations-hub

--- a/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
+++ b/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
@@ -6,9 +6,7 @@ tests:
     set:
       rootPath: /integrations-hub
       apiRootPath: /api/integrations-hub
-      sameOrigin: true
       openhands.baseUrl: https://pr-252.staging.all-hands.dev
-      openhands.authUrl: https://integrations-pr-252.staging.all-hands.dev
       openhands.redirectProxyUrl: https://staging.all-hands.dev
       database.url: postgresql://example
       credentialEncryption.secretName: encryption

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -46,8 +46,7 @@ probes:
 
 # Service configuration
 service:
-  # Public base URL where this service is reachable
-  # Example: https://integrations.example.com or https://domain/integrations
+  # Public base URL where this service is reachable.
   baseUrl: ""
   # Port the container listens on (8000 for Python/FastAPI backend)
   port: 8000
@@ -57,14 +56,8 @@ service:
 rootPath: "/integrations-hub"
 
 # Public API prefix routed by the parent chart. The backend translates it to
-# its existing internal /api routes, which remain available to pod probes and
-# legacy dedicated-host API clients.
+# its existing internal /api routes, which remain available to pod probes.
 apiRootPath: "/api/integrations-hub"
-
-# Route the UI and API prefixes on the primary OpenHands hostname. When true,
-# a legacy dedicated ingress host is ignored and OAuth preview callbacks return
-# to openhands.baseUrl instead of openhands.authUrl.
-sameOrigin: false
 
 # Bypass authentication for local development only. When true the FastAPI
 # app rejects non-loopback requests and uses a synthetic dev@localhost
@@ -73,7 +66,7 @@ sameOrigin: false
 disableAuth: false
 
 # OpenHands identity provider configuration. The backend validates session
-# cookies / API keys against GET <baseUrl>/api/v1/users/me.
+# cookies against GET <baseUrl>/api/v1/users/me.
 openhands:
   # Base URL of the OpenHands instance. Falls back to the global ingress
   # host when left empty (see templates/_env.yaml).
@@ -87,11 +80,6 @@ openhands:
   # request host directly.
   # Backend env var: INTHUB_OAUTH_REDIRECT_PROXY_URL
   redirectProxyUrl: ""
-  # Optional callback target for preview deployments; used when
-  # redirectProxyUrl is set and oauth_flow.py needs to forward back to
-  # the originating deployment.
-  # Backend env var: AUTH_URL
-  authUrl: ""
 
 # Credential encryption key for stored provider credentials.
 # Generate with: openssl rand -base64 32

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -61,6 +61,11 @@ rootPath: "/integrations-hub"
 # legacy dedicated-host API clients.
 apiRootPath: "/api/integrations-hub"
 
+# Route the UI and API prefixes on the primary OpenHands hostname. When true,
+# a legacy dedicated ingress host is ignored and OAuth preview callbacks return
+# to openhands.baseUrl instead of openhands.authUrl.
+sameOrigin: false
+
 # Bypass authentication for local development only. When true the FastAPI
 # app rejects non-loopback requests and uses a synthetic dev@localhost
 # owner; never enable this in staging/production.

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -52,17 +52,14 @@ service:
   # Port the container listens on (8000 for Python/FastAPI backend)
   port: 8000
 
-# Path prefix the application is mounted under. Must match the SPA base
-# path baked into the image and the parent chart ingress path.
-#
-# Wired to the FastAPI container as `INTHUB_ROOT_PATH`, which causes
-# `backend/app/main.py::build_app` to mount every route -- including the
-# SPA static files and `/api/health` -- under this prefix. Container
-# probes below also honour the prefix automatically.
-#
-# Set to an empty string to serve the app from the cluster root, usually
-# when using a dedicated hostname.
+# UI path prefix baked into the Kubernetes SPA image and used by FastAPI's
+# static-file mount.
 rootPath: "/integrations-hub"
+
+# Public API prefix routed by the parent chart. The backend translates it to
+# its existing internal /api routes, which remain available to pod probes and
+# legacy dedicated-host API clients.
+apiRootPath: "/api/integrations-hub"
 
 # Bypass authentication for local development only. When true the FastAPI
 # app rejects non-loopback requests and uses a synthetic dev@localhost

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -1,28 +1,17 @@
 {{- /*
   Ingress entry for the integrations-hub service.
 
-  By default the hub is mounted at integrations-hub.rootPath under the main
-  OpenHands host. If integrations-hub.ingress.host is set, the same service is
-  served on that dedicated hostname instead, usually with rootPath="". Setting
-  sameOrigin=true takes precedence over legacy dedicated-host values. Host
-  values are rendered with tpl so environment-specific charts can choose their
-  own naming scheme without this shared chart knowing about it.
+  Integrations Hub follows the same deployment pattern as Agent Canvas and
+  Automations: Kubernetes owns fixed path routing on the primary OpenHands
+  host, and the main app only provides shared auth/navigation glue.
 */}}
 {{- $hub := index .Values "integrations-hub" -}}
 {{- if and .Values.enabled .Values.ingress.enabled $hub.enabled }}
 {{- $rootPath := $hub.rootPath | default "/integrations-hub" }}
 {{- $apiRootPath := $hub.apiRootPath | default "/api/integrations-hub" }}
-{{- $sameOrigin := $hub.sameOrigin | default false }}
-{{- $dedicated := and (not $sameOrigin) $hub.ingress.enabled $hub.ingress.host }}
 {{- $host := tpl .Values.ingress.host . }}
-{{- if $dedicated }}
-{{- $host = tpl $hub.ingress.host . }}
-{{- else if .Values.ingress.prefixWithBranch }}
+{{- if .Values.ingress.prefixWithBranch }}
 {{- $host = printf "%s.%s" .Values.branchSanitized $host }}
-{{- end }}
-{{- $ingressPath := $rootPath }}
-{{- if $dedicated }}
-{{- $ingressPath = "/" }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -36,12 +25,7 @@ metadata:
     {{- end }}
 spec:
   ingressClassName: {{ default "traefik" .Values.ingress.class }}
-  {{- if and $dedicated $hub.ingress.tls.enabled }}
-  tls:
-  - hosts:
-    - {{ $host }}
-    secretName: {{ $hub.ingress.tls.secretName }}
-  {{- else if .Values.tls.enabled }}
+  {{- if .Values.tls.enabled }}
   tls:
   - hosts:
     - {{ $host }}
@@ -51,9 +35,6 @@ spec:
   - host: {{ $host }}
     http:
       paths:
-      {{- if not $dedicated }}
-      # Keep the API rule before the SPA rule so ingress controllers always
-      # select the more-specific backend path deterministically.
       - path: {{ $apiRootPath | quote }}
         pathType: Prefix
         backend:
@@ -61,8 +42,7 @@ spec:
             name: integrations-hub
             port:
               number: 80
-      {{- end }}
-      - path: {{ $ingressPath | quote }}
+      - path: {{ $rootPath | quote }}
         pathType: Prefix
         backend:
           service:

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -3,7 +3,8 @@
 
   By default the hub is mounted at integrations-hub.rootPath under the main
   OpenHands host. If integrations-hub.ingress.host is set, the same service is
-  served on that dedicated hostname instead, usually with rootPath="". Host
+  served on that dedicated hostname instead, usually with rootPath="". Setting
+  sameOrigin=true takes precedence over legacy dedicated-host values. Host
   values are rendered with tpl so environment-specific charts can choose their
   own naming scheme without this shared chart knowing about it.
 */}}
@@ -11,7 +12,8 @@
 {{- if and .Values.enabled .Values.ingress.enabled $hub.enabled }}
 {{- $rootPath := $hub.rootPath | default "/integrations-hub" }}
 {{- $apiRootPath := $hub.apiRootPath | default "/api/integrations-hub" }}
-{{- $dedicated := and $hub.ingress.enabled $hub.ingress.host }}
+{{- $sameOrigin := $hub.sameOrigin | default false }}
+{{- $dedicated := and (not $sameOrigin) $hub.ingress.enabled $hub.ingress.host }}
 {{- $host := tpl .Values.ingress.host . }}
 {{- if $dedicated }}
 {{- $host = tpl $hub.ingress.host . }}

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -10,6 +10,7 @@
 {{- $hub := index .Values "integrations-hub" -}}
 {{- if and .Values.enabled .Values.ingress.enabled $hub.enabled }}
 {{- $rootPath := $hub.rootPath | default "/integrations-hub" }}
+{{- $apiRootPath := $hub.apiRootPath | default "/api/integrations-hub" }}
 {{- $dedicated := and $hub.ingress.enabled $hub.ingress.host }}
 {{- $host := tpl .Values.ingress.host . }}
 {{- if $dedicated }}
@@ -46,6 +47,17 @@ spec:
   - host: {{ $host }}
     http:
       paths:
+      {{- if not $dedicated }}
+      # Keep the API rule before the SPA rule so ingress controllers always
+      # select the more-specific backend path deterministically.
+      - path: {{ $apiRootPath | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: integrations-hub
+            port:
+              number: 80
+      {{- end }}
       - path: {{ $ingressPath | quote }}
         pathType: Prefix
         backend:

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -17,6 +17,8 @@
 {{- $host := tpl .Values.ingress.host . }}
 {{- if $dedicated }}
 {{- $host = tpl $hub.ingress.host . }}
+{{- else if .Values.ingress.prefixWithBranch }}
+{{- $host = printf "%s.%s" .Values.branchSanitized $host }}
 {{- end }}
 {{- $ingressPath := $rootPath }}
 {{- if $dedicated }}

--- a/charts/openhands/tests/integrations_hub_ingress_test.yaml
+++ b/charts/openhands/tests/integrations_hub_ingress_test.yaml
@@ -1,0 +1,54 @@
+suite: integrations hub ingress
+templates:
+  - ingress-integrations-hub.yaml
+tests:
+  - it: routes UI and API prefixes on the primary OpenHands host
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      tls.enabled: false
+      integrations-hub.enabled: true
+      integrations-hub.ingress.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.rules[0].host
+          value: app.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /api/integrations-hub
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: integrations-hub
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /integrations-hub
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: integrations-hub
+
+  - it: keeps the dedicated hostname compatibility route at root
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      tls.enabled: false
+      integrations-hub.enabled: true
+      integrations-hub.rootPath: ""
+      integrations-hub.ingress.enabled: true
+      integrations-hub.ingress.host: integrations.example.com
+      integrations-hub.ingress.tls.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.rules[0].host
+          value: integrations.example.com
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /

--- a/charts/openhands/tests/integrations_hub_ingress_test.yaml
+++ b/charts/openhands/tests/integrations_hub_ingress_test.yaml
@@ -9,7 +9,9 @@ tests:
       ingress.host: app.example.com
       tls.enabled: false
       integrations-hub.enabled: true
-      integrations-hub.ingress.enabled: false
+      integrations-hub.sameOrigin: true
+      integrations-hub.ingress.enabled: true
+      integrations-hub.ingress.host: integrations.example.com
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/openhands/tests/integrations_hub_ingress_test.yaml
+++ b/charts/openhands/tests/integrations_hub_ingress_test.yaml
@@ -7,6 +7,8 @@ tests:
       enabled: true
       ingress.enabled: true
       ingress.host: app.example.com
+      ingress.prefixWithBranch: true
+      branchSanitized: pr-252
       tls.enabled: false
       integrations-hub.enabled: true
       integrations-hub.sameOrigin: true
@@ -17,7 +19,7 @@ tests:
           count: 1
       - equal:
           path: spec.rules[0].host
-          value: app.example.com
+          value: pr-252.app.example.com
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /api/integrations-hub

--- a/charts/openhands/tests/integrations_hub_ingress_test.yaml
+++ b/charts/openhands/tests/integrations_hub_ingress_test.yaml
@@ -11,9 +11,6 @@ tests:
       branchSanitized: pr-252
       tls.enabled: false
       integrations-hub.enabled: true
-      integrations-hub.sameOrigin: true
-      integrations-hub.ingress.enabled: true
-      integrations-hub.ingress.host: integrations.example.com
     asserts:
       - hasDocuments:
           count: 1
@@ -32,27 +29,3 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[1].backend.service.name
           value: integrations-hub
-
-  - it: keeps the dedicated hostname compatibility route at root
-    set:
-      enabled: true
-      ingress.enabled: true
-      ingress.host: app.example.com
-      tls.enabled: false
-      integrations-hub.enabled: true
-      integrations-hub.rootPath: ""
-      integrations-hub.ingress.enabled: true
-      integrations-hub.ingress.host: integrations.example.com
-      integrations-hub.ingress.tls.enabled: false
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: spec.rules[0].host
-          value: integrations.example.com
-      - lengthEqual:
-          path: spec.rules[0].http.paths
-          count: 1
-      - equal:
-          path: spec.rules[0].http.paths[0].path
-          value: /

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1257,24 +1257,13 @@ integrations-hub:
   # Public API prefix routed to the same service. The application translates
   # this prefix to its internal /api routes; probes remain internal/unprefixed.
   apiRootPath: "/api/integrations-hub"
-  # Route both prefixes on the primary OpenHands hostname. This takes
-  # precedence over legacy dedicated ingress/authUrl values.
-  sameOrigin: false
-
   # Bypass authentication for local development only -- never enable in
   # staging/production. Exposed as INTHUB_DISABLE_AUTH.
   disableAuth: false
 
   ingress:
     enabled: false
-    # Optional dedicated hostname, e.g. integrations.openhands.dev. When unset,
-    # the parent ingress mounts rootPath under the main OpenHands host.
-    host: ""
-    tls:
-      enabled: true
-      secretName: integrations-hub-tls
-
-  # OpenHands identity provider used to validate session cookies / API keys.
+  # OpenHands identity provider used to validate session cookies.
   openhands:
     # Backend env var: INTHUB_OPENHANDS_BASE_URL (falls back to the global
     # ingress host when left empty -- see charts/openhands/charts/integrations-hub/templates/_env.yaml).
@@ -1284,9 +1273,6 @@ integrations-hub:
     # Stable-origin URL used as the OAuth callback proxy for preview
     # deployments. Backend env var: INTHUB_OAUTH_REDIRECT_PROXY_URL.
     redirectProxyUrl: ""
-    # Optional callback target for preview deployments paired with
-    # redirectProxyUrl. Backend env var: AUTH_URL.
-    authUrl: ""
 
   # Credential encryption key configuration.
   # Backend env var: INTHUB_CREDENTIAL_ENCRYPTION_KEY.

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1254,6 +1254,9 @@ integrations-hub:
   #   - The FastAPI container's `INTHUB_ROOT_PATH` env var.
   #   - The SPA base path baked into the image at build time.
   rootPath: "/integrations-hub"
+  # Public API prefix routed to the same service. The application translates
+  # this prefix to its internal /api routes; probes remain internal/unprefixed.
+  apiRootPath: "/api/integrations-hub"
 
   # Bypass authentication for local development only -- never enable in
   # staging/production. Exposed as INTHUB_DISABLE_AUTH.

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1257,6 +1257,9 @@ integrations-hub:
   # Public API prefix routed to the same service. The application translates
   # this prefix to its internal /api routes; probes remain internal/unprefixed.
   apiRootPath: "/api/integrations-hub"
+  # Route both prefixes on the primary OpenHands hostname. This takes
+  # precedence over legacy dedicated ingress/authUrl values.
+  sameOrigin: false
 
   # Bypass authentication for local development only -- never enable in
   # staging/production. Exposed as INTHUB_DISABLE_AUTH.


### PR DESCRIPTION
## Summary

- add `/api/integrations-hub` ahead of `/integrations-hub` on the primary OpenHands ingress
- pass `INTHUB_API_ROOT_PATH` into the embedded Integrations Hub chart while keeping pod probes on internal paths
- add `integrations-hub.sameOrigin` so path deployments ignore stale dedicated ingress and OAuth host overrides
- make same-origin ingress follow `prefixWithBranch`, enabling exact primary-origin feature previews
- retain the dedicated-host root route as a compatibility option
- run Helm unit tests for both the parent and embedded charts in CI

## Validation

- `helm lint charts/openhands`
- `helm unittest charts/openhands` (4 tests)
- `helm unittest charts/openhands/charts/integrations-hub` (1 test)
- adversarial render with legacy `integrations-pr-252` overrides produces only `pr-252.staging.all-hands.dev`, with UI/API paths and same-origin `AUTH_URL`
- preview chart `0.22.1-alpha.899` published successfully

## Live evidence

- 2026-07-15 on PR head `29c7a2ba79cf64912d2828103ced0f743f3b5b7b`: re-ran `helm dependency update charts/openhands`, `helm lint charts/openhands`, `helm template charts/openhands --debug`, `helm unittest charts/openhands` (4 tests), and `helm unittest charts/openhands/charts/integrations-hub` (1 test); all passed.
- Same-origin render for the saas-deploy PR 252 shape produced host `pr-252.staging.all-hands.dev` with `/api/integrations-hub` before `/integrations-hub`, both routing to the `integrations-hub` service.
- Live preview `https://pr-252.staging.all-hands.dev/integrations-hub/` returned HTTP 200 `text/html` and browser-rendered “OpenHands Integrations Hub”.
- Live preview `https://pr-252.staging.all-hands.dev/api/integrations-hub/health` returned HTTP 200 `application/json`: `{"status":"ok","backend":"fastapi"}`.

_This PR body update was generated by an AI agent (OpenHands) on behalf of the user._

## Rollout

Application support is in OpenHands/integrations-hub#384. OpenHands/saas-deploy#252 pins this preview chart and the Integrations Hub PR image for dev, staging, and an exact same-origin feature preview.

Linear: https://linear.app/all-hands-ai/issue/OHE-2647/add-same-origin-path-routing-for-integrations-hub

Closes #925

<!-- Issue association added by Codex during daily workflow resolution. -->
