### PR TITLE
fix(backport): set default agent-server tag back to 1.36.0-python

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.36.1-python
+  tag: 1.36.0-python
   pullPolicy: Always
 
 runtimeClass: sysbox-runc

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -357,7 +357,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.36.1-python
+    tag: 1.36.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1114,7 +1114,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.36.1-python
+    tag: 1.36.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -988,9 +988,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.36.1-python
+          help_text: Image tag, e.g. 1.36.0-python
           type: text
-          default: "1.36.1-python"
+          default: "1.36.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
Backport of #908 onto the release/0.18.2 line. Reverts the agent-server default tag from 1.36.1-python back to 1.36.0-python (image-loader pre-pull, runtime-api standalone fallback, chart global, and the replicated custom-sandbox-image default). Enterprise-server stays cloud-1.46.2; no chart $.version change (release-please owns that).