### PR TITLE
feat(replicated): add OEM User Creation Flow advanced option

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1196,13 +1196,9 @@ spec:
         - name: oem_user_creation_flow_enabled
           title: Enable OEM User Creation Flow
           help_text: >-
-            Superadmins can create organizations and provision users into them,
-            receiving an API key for each provisioned user so they can act on that
-            user's behalf. This registers the privileged
-            POST /api/organizations/provision-user endpoint (sets
-            USER_PROVISIONING_ENABLED=true). This setting is typically only used by
-            customers who OEM OpenHands Enterprise and integrate it with their own
-            user management system. Leave disabled unless you need headless,
-            programmatic user onboarding.
+            Let superadmins create organizations and provision users into them,
+            obtaining an API key to act on each user's behalf. Typically only used
+            by customers who OEM OpenHands Enterprise and integrate it with their
+            own user management system.
           type: bool
           default: "0"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1193,3 +1193,16 @@ spec:
             regex:
               pattern: '^[1-9][0-9]*$'
               message: Must be a positive number of seconds
+        - name: oem_user_creation_flow_enabled
+          title: Enable OEM User Creation Flow
+          help_text: >-
+            Superadmins can create organizations and provision users into them,
+            receiving an API key for each provisioned user so they can act on that
+            user's behalf. This registers the privileged
+            POST /api/organizations/provision-user endpoint (sets
+            USER_PROVISIONING_ENABLED=true). This setting is typically only used by
+            customers who OEM OpenHands Enterprise and integrate it with their own
+            user management system. Leave disabled unless you need headless,
+            programmatic user onboarding.
+          type: bool
+          default: "0"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -1083,6 +1083,19 @@ spec:
           rabbitmq:
             persistence:
               storageClass: "openebs-hostpath"
+    # OEM User Creation Flow: register the privileged
+    # POST /api/organizations/provision-user endpoint so superadmins can
+    # provision users (and mint per-user API keys) into orgs they create.
+    # Gated behind an admin config toggle because it is only relevant to
+    # customers OEM-integrating OHE with their own user-management system.
+    # Off by default; when off the chart leaves userProvisioning.enabled at
+    # its own false default (the value is only ever set when truthy, since
+    # the chart treats any non-empty string as enabled).
+    - when: '{{repl ConfigOptionEquals "oem_user_creation_flow_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        userProvisioning:
+          enabled: true
     - when: '{{repl ConfigOptionEquals "plugin_directory_enabled" "1" }}'
       recursiveMerge: true
       values:


### PR DESCRIPTION
## Why

Two recently merged OpenHands enterprise PRs introduced a super-admin org-management flow:

- [OpenHands/OpenHands#14864](https://github.com/OpenHands/OpenHands/pull/14864) — adds `POST /api/organizations/provision-user`, gated by `USER_PROVISIONING_ENABLED` (Helm value `userProvisioning.enabled`).
- [OpenHands/OpenHands#14937](https://github.com/OpenHands/OpenHands/pull/14937) — adds instance-level super roles; a `superadmin` can create organizations (permission-gated, always available) but creates them **without becoming a member** (`add_creator_as_owner=False`).

The gap: with provisioning **off** (the chart default), a `superadmin` can create organizations but has **no way to seed them** with an initial owner/admin. Every member-add path is blocked — the invitation flow requires the caller to already be a member of that org (superadmins are not), and the provisioning endpoint isn't even registered. So the superadmin org-creation feature is effectively inert on Replicated installs unless provisioning is enabled.

The Replicated installer had **no** knob for `userProvisioning.enabled` / `openOrgCreation.enabled` at all — these values existed only in the base chart and always resolved to their `false` defaults on VM installs.

## What

Adds a new **Advanced Options** toggle, `oem_user_creation_flow_enabled` (default off), and wires it to the chart's `userProvisioning.enabled` value via a KOTS `optionalValues` block (only sets the value when truthy, so the chart's `{{- if .Values.userProvisioning.enabled }}` gate behaves correctly).

When enabled, this registers `POST /api/organizations/provision-user` (`USER_PROVISIONING_ENABLED=true`), letting superadmins provision users into orgs they create and obtain a per-user API key to act on their behalf.

Kept **optional and off by default** because it is a specialized, privileged flow: it mints users, sets server-side non-temporary passwords, and returns per-user API keys. It is primarily needed by customers who OEM OpenHands Enterprise and integrate it with their own user-management system.

### Files
- `replicated/config.yaml` — new `oem_user_creation_flow_enabled` bool in the **Advanced Options** group.
- `replicated/openhands.yaml` — `optionalValues` block mapping the toggle to `userProvisioning.enabled: true`.

## Notes

- Superadmin org **creation** itself is permission-gated in the app and remains always-available; only the user-provisioning/API-key-minting half is gated by this toggle.
- Follow-up needed in the core app: a path for superadmins to invite users to an org for a *normal* (non-OEM) seeding flow, so the credential-minting provisioning endpoint isn't the only way to seed a fresh org. See OpenHands/enterprise#63.
- `openOrgCreation.enabled` / `OPEN_ORG_CREATION_ENABLED` is intentionally **not** wired here — after OpenHands/OpenHands#14937 it no longer gates any live route (org creation is now permission-based), so exposing it would be misleading.

## How to test

1. Build/render the Replicated release and confirm the **Enable OEM User Creation Flow** checkbox appears under **Advanced Options** (default unchecked).
2. With it unchecked: rendered chart values leave `userProvisioning.enabled` false, `USER_PROVISIONING_ENABLED` env var absent, `/api/organizations/provision-user` returns 404.
3. With it checked: `userProvisioning.enabled=true`, `USER_PROVISIONING_ENABLED=true`, endpoint registered.

---
This PR was created by an AI agent (OpenHands) on behalf of the user.
