### PR TITLE
feat: add root ingress redirect support

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -329,18 +329,19 @@
       key: tavily-api-key
 {{- end }}
 {{- if .Values.ingress.enabled }}
+{{- $authHost := .Values.ingress.authHost }}
 {{- if .Values.ingress.prefixWithBranch }}
 - name: WEB_HOST
   value: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
 - name: AUTH_WEB_HOST
-  value: {{ .Values.branchSanitized }}.auth.{{ .Values.ingress.host }}
+  value: {{ default (printf "%s.auth.%s" .Values.branchSanitized .Values.ingress.host) $authHost }}
 - name: MCP_HOST
   value: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
 {{- else }}
 - name: WEB_HOST
   value: {{ .Values.ingress.host }}
 - name: AUTH_WEB_HOST
-  value: auth.{{ .Values.ingress.host }}
+  value: {{ default (printf "auth.%s" .Values.ingress.host) $authHost }}
 - name: MCP_HOST
   value: {{ .Values.ingress.host }}
 {{- end }}

--- a/charts/openhands/templates/ingress-root-redirects.yaml
+++ b/charts/openhands/templates/ingress-root-redirects.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.enabled .Values.ingress.enabled .Values.ingress.redirects }}
+{{- range $redirect := .Values.ingress.redirects }}
+{{- $name := required "ingress.redirects[].name is required" $redirect.name }}
+{{- $host := required (printf "ingress.redirects[%s].host is required" $name) $redirect.host }}
+{{- $to := required (printf "ingress.redirects[%s].to is required" $name) $redirect.to }}
+{{- $resourceName := printf "openhands-%s-redirect" $name | trunc 63 | trimSuffix "-" }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $resourceName }}
+spec:
+  redirectRegex:
+    regex: {{ printf "^https://%s(.*)" ($host | replace "." "\\.") | quote }}
+    replacement: {{ $to | quote }}
+    permanent: {{ ternary $redirect.permanent true (hasKey $redirect "permanent") }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $resourceName }}
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: {{ printf "%s-%s@kubernetescrd" $.Release.Namespace $resourceName | quote }}
+    {{- with $redirect.annotations }}
+    {{ . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $.Values.ingress.class }}
+  rules:
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openhands-service
+                port:
+                  number: 3000
+{{- end }}
+{{- end }}

--- a/charts/openhands/tests/ingress_root_redirects_test.yaml
+++ b/charts/openhands/tests/ingress_root_redirects_test.yaml
@@ -1,0 +1,58 @@
+suite: root ingress redirects
+templates:
+  - ingress-root-redirects.yaml
+tests:
+  - it: renders Traefik middleware and ingress for redirect hosts
+    set:
+      enabled: true
+      ingress:
+        enabled: true
+        class: traefik
+        host: app.example.com
+        redirects:
+          - name: legacy-app
+            host: old.example.com
+            to: https://app.example.com${1}
+            permanent: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Middleware
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: openhands-legacy-app-redirect
+        documentIndex: 0
+      - equal:
+          path: spec.redirectRegex.regex
+          value: ^https://old\.example\.com(.*)
+        documentIndex: 0
+      - equal:
+          path: spec.redirectRegex.replacement
+          value: https://app.example.com${1}
+        documentIndex: 0
+      - equal:
+          path: spec.redirectRegex.permanent
+          value: true
+        documentIndex: 0
+      - isKind:
+          of: Ingress
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: openhands-legacy-app-redirect
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].host
+          value: old.example.com
+        documentIndex: 1
+  - it: renders no redirect resources without redirects
+    set:
+      enabled: true
+      ingress:
+        enabled: true
+        host: app.example.com
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -220,6 +220,15 @@ ingress:
       # Example: Add specific annotations for the root ingress
       # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
+  redirects: []
+    # Redirect legacy hostnames to the canonical root ingress host.
+    # Requires Traefik's Middleware CRD.
+    # - name: legacy-app-host
+    #   host: old-app.example.com
+    #   to: https://app.example.com${1}
+    #   permanent: true
+    #   annotations: {}
+
   integrations:
     annotations: {}
       # Example: Add specific annotations for integrations ingress

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -208,6 +208,8 @@ ingress:
   enabled: false
   # REQUIRED: Update to a hostname in a DNS domain you own
   # host: "app.example.com"
+  # Optional override when auth is served on a different hostname than auth.<host>.
+  authHost: ""
   class: traefik
   # Legacy annotations field - kept for backward compatibility
   annotations: {}


### PR DESCRIPTION
## Summary
- Add `ingress.redirects` values for redirecting legacy root ingress hostnames.
- Render a Traefik `Middleware` plus redirect-only `Ingress` per configured redirect host.
- Add `ingress.authHost` so deployments can keep auth on an existing hostname while moving the canonical app host.
- Add Helm unit coverage for redirect rendering.

## Why
The staging domain migration needs the Helm chart to own the app ingress/redirect behavior. `saas-deploy` can then consume this as preview chart `0.23.2-alpha.917` and configure `staging.openhands.dev` as canonical while redirecting `staging.all-hands.dev`.

## Validation
- `helm dependency update charts/openhands`
- `helm lint charts/openhands`
- `helm unittest charts/openhands`
- Rendered `templates/ingress-root-redirects.yaml` with sample redirect values.
- Rendered deployment env with `ingress.authHost` and confirmed `AUTH_WEB_HOST` uses the override.

_This PR was updated by an AI agent (OpenHands) on behalf of the user._
