### PR TITLE
feat(openhands): PLTF-3257 add NOTES.txt post-install output to the openhands chart

### DIFF
--- a/charts/openhands/templates/NOTES.txt
+++ b/charts/openhands/templates/NOTES.txt
@@ -1,0 +1,38 @@
+{{- if not .Values.enabled }}
+The OpenHands application was not deployed by this release (enabled=false); only
+the enabled subcharts were installed.
+{{- else }}
+OpenHands "{{ .Release.Name }}" has been deployed to namespace "{{ .Release.Namespace }}".
+
+{{- $host := .Values.ingress.host }}
+{{- if .Values.ingress.prefixWithBranch }}
+{{- $host = printf "%s.%s" .Values.branchSanitized .Values.ingress.host }}
+{{- end }}
+{{- $scheme := ternary "https" "http" .Values.tls.enabled }}
+{{- if and .Values.ingress.enabled $host }}
+
+Access the app at:
+
+    {{ $scheme }}://{{ $host }}
+{{- else if .Values.ingress.enabled }}
+
+Ingress is enabled but `ingress.host` is not set. Set it to a hostname you own
+so the app is reachable, e.g.:
+
+    helm upgrade {{ .Release.Name }} ... --set ingress.host=app.example.com
+{{- else }}
+
+Ingress is disabled. Reach the app with a port-forward:
+
+    kubectl port-forward -n {{ .Release.Namespace }} svc/openhands-service 3000:3000
+
+then open http://localhost:3000
+{{- end }}
+
+Next steps:
+
+    # watch the rollout
+    kubectl get pods -n {{ .Release.Namespace }}
+
+Docs: https://docs.all-hands.dev
+{{- end }}


### PR DESCRIPTION
## Why

After an install or upgrade, Helm printed nothing to tell the operator how to reach OpenHands. This adds a `NOTES.txt` so the command ends with the access URL — or a `kubectl port-forward` command when ingress is off — plus a short next-step. It's the standard post-install signpost the chart was missing.

Example output with ingress enabled:

```
Access the app at:

    https://app.example.com
```

…or with ingress disabled:

```
Ingress is disabled. Reach the app with a port-forward:
    kubectl port-forward -n openhands svc/openhands-service 3000:3000
then open http://localhost:3000
```

## Validation

Rendered with `helm install --dry-run`; every case that changes the output is correct:

- ingress on + host → `https://<host>` (plain `http://` when TLS is off)
- ingress on + `prefixWithBranch` → `https://<branch>.<host>` (preview variant)
- ingress off → the port-forward command above
- ingress on but no host → a hint to set `ingress.host`
- `enabled: false` → a note that the app wasn't deployed by the release

_This PR was drafted by an AI agent on behalf of the user._
