### PR TITLE
feat(openhands): PLTF-3258 add fail guard for ingress.enabled without ingress.host

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -1,0 +1,8 @@
+{{/*
+Render-time configuration guards. Emits no resources; each block fails the
+render with a clear message when values are invalid or conflicting, so the
+mistake is caught at install/upgrade instead of producing a broken object.
+*/}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
+{{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
+{{- end -}}


### PR DESCRIPTION
## Why

With `ingress.enabled: true` but `ingress.host` left empty, six ingress templates that read `.Values.ingress.host` — root, integrations, mcp, plugin-directory, automation, and integrations-hub — rendered `- host:` with no value, silently producing broken Ingress objects that Kubernetes accepts but never routes. This adds a render-time guard that fails the install/upgrade with a clear message, so the mistake is caught instead of shipped.

```
Error: ... ingress.enabled is true but ingress.host is empty. Set ingress.host
to the hostname operators reach OpenHands on (e.g. app.example.com), or set
ingress.enabled=false.
```

## Validation

Rendered with `helm template`:

- ingress off (default) → renders clean, guard not triggered
- ingress on, no host → fails with the message above
- ingress on + host set → renders clean

_This PR was drafted by an AI agent on behalf of the user._
