### PR TITLE
feat: expose sandbox ephemeral-storage as a configurable field

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -854,6 +854,7 @@ runtime-api:
     MEMORY_REQUEST: "3072Mi"
     MEMORY_LIMIT: "3072Mi"
     CPU_REQUEST: "500m"
+    # Default; KOTS overrides via the sandbox_ephemeral_storage_size ConfigOption.
     EPHEMERAL_STORAGE_SIZE: "10Gi"
 
 jira:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -930,6 +930,15 @@ spec:
             regex:
               pattern: ^[1-9][0-9]*Mi$
               message: Must be a size in Mi (e.g., 10240Mi)
+        - name: sandbox_ephemeral_storage_size
+          title: Ephemeral Storage Size
+          help_text: Ephemeral storage reserved per sandbox. This is a scheduling reservation, so it caps how many sandboxes fit on a node.
+          type: text
+          default: "10Gi"
+          validation:
+            regex:
+              pattern: ^[1-9][0-9]*(Mi|Gi)$
+              message: Must be a size in Mi or Gi (e.g., 10Gi)
         - name: sandbox_memory_request
           title: Memory Request
           help_text: The minimum amount of memory to reserve for each sandbox.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -336,6 +336,7 @@ spec:
         SET_HOST_USERS: "true"
         RUNTIME_DISABLE_SSL: "false"
         PERSISTENT_STORAGE_SIZE: 'repl{{ ConfigOption "sandbox_storage_size" }}'
+        EPHEMERAL_STORAGE_SIZE: 'repl{{ ConfigOption "sandbox_ephemeral_storage_size" }}'
         MEMORY_REQUEST: 'repl{{ ConfigOption "sandbox_memory_request" }}'
         MEMORY_LIMIT: 'repl{{ ConfigOption "sandbox_memory_limit" }}'
         CPU_REQUEST: 'repl{{ ConfigOption "sandbox_cpu_request" }}'


### PR DESCRIPTION
## Problem

Every sandbox (runtime) pod reserves a fixed amount of **ephemeral-storage** (`EPHEMERAL_STORAGE_SIZE`, default `10Gi`) as a Kubernetes request+limit. Kubernetes admits pods by their *requests*, so this reservation — not actual disk usage — is what caps how many sandboxes fit on a node: roughly `node allocatable ephemeral-storage ÷ per-sandbox reservation`. On the recommended single-node install (~173 GiB allocatable) that ceiling is ~17 concurrent sandboxes, after which new ones fail to schedule with `Insufficient ephemeral-storage` — even though `df` shows the disk nearly empty (sandboxes barely use their reservation).

This value is currently the **only** sandbox resource *not* exposed in the Admin Console: CPU request/limit, memory request/limit, and persistent storage size are all configurable, but ephemeral storage is hard-coded. A customer on the recommended instance size hit this ceiling and had no supported way to tune it.

## Change

Expose ephemeral storage as an Admin Console field, next to the existing sandbox resource fields:

- New `sandbox_ephemeral_storage_size` KOTS config option (default `10Gi`, accepts `Mi`/`Gi`).
- Wired to the runtime-api `EPHEMERAL_STORAGE_SIZE` env in `replicated/openhands.yaml` — same mechanism as the sibling `PERSISTENT_STORAGE_SIZE`/`MEMORY_*`/`CPU_*` fields.
- Default unchanged (`10Gi`), so existing installs are unaffected.

Lowering it raises the concurrent-sandbox ceiling (e.g. `5Gi` ≈ 2×, `3Gi` ≈ 3× on the same node); raising it gives each sandbox more scratch space at the cost of fewer concurrent sandboxes.

## Validation

- `replicated release lint` clean (KOTS config + template render).
- The env→pod link is proven live: a runtime created with `EPHEMERAL_STORAGE_SIZE` set gets that exact `ephemeral-storage` request/limit on its pod (verified on an embedded-cluster instance).
- No `Chart.yaml` version bump — release-please owns versioning (`feat:` → minor).
