### PR TITLE
feat: enable the pending-runtime reaper on OHE installs

### DIFF
--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: ghcr.io/openhands/runtime-api
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: 0.5.2
+  tag: 0.5.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -819,6 +819,9 @@ runtime-api:
     CPU_REQUEST: "500m"
     # Default; KOTS overrides via the sandbox_ephemeral_storage_size ConfigOption.
     EPHEMERAL_STORAGE_SIZE: "10Gi"
+    # OHE clusters are fixed-size (no autoscaler), so an unschedulable sandbox
+    # never schedules — reap it instead of letting it pile up until dead_seconds.
+    RUNTIME_PENDING_REAP_ENABLED: "true"
 
 jira:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -819,9 +819,11 @@ runtime-api:
     CPU_REQUEST: "500m"
     # Default; KOTS overrides via the sandbox_ephemeral_storage_size ConfigOption.
     EPHEMERAL_STORAGE_SIZE: "10Gi"
-    # OHE clusters are fixed-size (no autoscaler), so an unschedulable sandbox
-    # never schedules — reap it instead of letting it pile up until dead_seconds.
-    RUNTIME_PENDING_REAP_ENABLED: "true"
+    # Off here so it never reaches SaaS (this umbrella chart is shared, and SaaS
+    # is autoscaled where an unschedulable pod is what triggers a node). The
+    # Replicated installer turns it on in replicated/openhands.yaml, since OHE
+    # clusters are fixed-size.
+    RUNTIME_PENDING_REAP_ENABLED: "false"
 
 jira:
   enabled: false

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -337,6 +337,8 @@ spec:
         RUNTIME_DISABLE_SSL: "false"
         PERSISTENT_STORAGE_SIZE: 'repl{{ ConfigOption "sandbox_storage_size" }}'
         EPHEMERAL_STORAGE_SIZE: 'repl{{ ConfigOption "sandbox_ephemeral_storage_size" }}'
+        # Reap unschedulable sandboxes; safe here because OHE clusters are fixed-size (no autoscaler).
+        RUNTIME_PENDING_REAP_ENABLED: "true"
         MEMORY_REQUEST: 'repl{{ ConfigOption "sandbox_memory_request" }}'
         MEMORY_LIMIT: 'repl{{ ConfigOption "sandbox_memory_limit" }}'
         CPU_REQUEST: 'repl{{ ConfigOption "sandbox_cpu_request" }}'


### PR DESCRIPTION
Turns on the runtime pending-runtime reaper for OHE installs, and pins runtime-api to the first release that has it.

- Bumps the runtime-api image from `0.5.2` to `0.5.3` (runtime-api#655, the reaper, shipped in that release).
- Sets `RUNTIME_PENDING_REAP_ENABLED: "true"` in `replicated/openhands.yaml` (Replicated installer only, since OHE clusters are fixed-size with no autoscaler).
- Keeps it `false` in `charts/openhands/values.yaml` so it never reaches SaaS, which is autoscaled and shares this umbrella chart via saas-deploy (per review).

With both, an OHE install reaps sandbox pods stuck Pending/Unschedulable instead of letting them pile up (the Verizon issue, PLTF-3281). Effective reap is bounded by the idle grace: about 60 min for a new runtime on OHE, ~10 min for a resumed one, versus days today. This rides the next OHE release.
