### PR TITLE
fix: preserve Integrations Hub API auth responses

### DIFF
--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -1,9 +1,11 @@
 {{- /*
   Ingress entry for the integrations-hub service.
 
-  Integrations Hub follows the same deployment pattern as Agent Canvas and
-  Automations: Kubernetes owns fixed path routing on the primary OpenHands
-  host, and the main app only provides shared auth/navigation glue.
+  The browser UI inherits the root ingress annotations so installations can
+  protect it with an OAuth proxy. The API uses a separate Ingress because the
+  Integrations Hub authenticates API keys and session cookies itself. In
+  particular, an OAuth error middleware must not replace the API's intentional
+  401/403 JSON responses (including case-by-case approval requests).
 */}}
 {{- $hub := index .Values "integrations-hub" -}}
 {{- if and .Values.enabled .Values.ingress.enabled $hub.enabled }}
@@ -13,6 +15,34 @@
 {{- if .Values.ingress.prefixWithBranch }}
 {{- $host = printf "%s.%s" .Values.branchSanitized $host }}
 {{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openhands-integrations-hub-api-ingress
+  {{- with .Values.ingress.integrationsHubApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ default "traefik" .Values.ingress.class }}
+  {{- if .Values.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ $host }}
+    secretName: app-all-hands-{{ .Values.tls.env }}-tls
+  {{- end }}
+  rules:
+  - host: {{ $host }}
+    http:
+      paths:
+      - path: {{ $apiRootPath | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: integrations-hub
+            port:
+              number: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,13 +65,6 @@ spec:
   - host: {{ $host }}
     http:
       paths:
-      - path: {{ $apiRootPath | quote }}
-        pathType: Prefix
-        backend:
-          service:
-            name: integrations-hub
-            port:
-              number: 80
       - path: {{ $rootPath | quote }}
         pathType: Prefix
         backend:

--- a/charts/openhands/tests/integrations_hub_ingress_test.yaml
+++ b/charts/openhands/tests/integrations_hub_ingress_test.yaml
@@ -2,30 +2,83 @@ suite: integrations hub ingress
 templates:
   - ingress-integrations-hub.yaml
 tests:
-  - it: routes UI and API prefixes on the primary OpenHands host
+  - it: routes UI and API separately so root OAuth cannot rewrite API errors
     set:
       enabled: true
       ingress.enabled: true
       ingress.host: app.example.com
       ingress.prefixWithBranch: true
+      ingress.root.annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: oauth-errors,oauth-auth
       branchSanitized: pr-252
       tls.enabled: false
       integrations-hub.enabled: true
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
       - equal:
           path: spec.rules[0].host
           value: pr-252.app.example.com
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-api-ingress
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /api/integrations-hub
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-api-ingress
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: integrations-hub
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-api-ingress
+      - notExists:
+          path: metadata.annotations
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-api-ingress
       - equal:
-          path: spec.rules[0].http.paths[1].path
+          path: spec.rules[0].host
+          value: pr-252.app.example.com
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-ingress
+      - equal:
+          path: spec.rules[0].http.paths[0].path
           value: /integrations-hub
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-ingress
       - equal:
-          path: spec.rules[0].http.paths[1].backend.service.name
+          path: spec.rules[0].http.paths[0].backend.service.name
           value: integrations-hub
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-ingress
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.middlewares: oauth-errors,oauth-auth
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-ingress
+
+  - it: supports API-specific non-OAuth annotations
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      ingress.integrationsHubApi.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: 10m
+      tls.enabled: false
+      integrations-hub.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/proxy-body-size: 10m
+        documentSelector:
+          path: metadata.name
+          value: openhands-integrations-hub-api-ingress

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -220,6 +220,12 @@ ingress:
       # Example: Add specific annotations for the root ingress
       # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
+  # Integrations Hub API routes authenticate API keys and session cookies in
+  # the application. Keep these annotations separate from root/browser OAuth
+  # middleware so API 401/403 JSON responses reach callers unchanged.
+  integrationsHubApi:
+    annotations: {}
+
   integrations:
     annotations: {}
       # Example: Add specific annotations for integrations ingress


### PR DESCRIPTION
## Summary

- split the Integrations Hub API and browser UI onto separate Ingress resources
- keep the root OAuth middleware on `/integrations-hub`
- let `/api/integrations-hub` rely on the application's API-key/session authentication so JSON `401`/`403` responses are preserved
- add an explicit `ingress.integrationsHubApi.annotations` escape hatch for non-OAuth API ingress configuration

## Historical context

This regression came from two individually reasonable deployment changes interacting:

1. On July 15, [OpenHands/saas-deploy#266](https://github.com/OpenHands/saas-deploy/pull/266) attached the shared Traefik `oauth-errors` and `oauth-auth` middlewares to the development root ingress. The goal was to protect browser access to `dev.all-hands.dev` with the same GitHub allowlist already used by staging.
2. On July 20, [OpenHands/OpenHands-Cloud#899](https://github.com/OpenHands/OpenHands-Cloud/pull/899) moved Integrations Hub onto the primary OpenHands origin. Its Helm template rendered `/integrations-hub` and `/api/integrations-hub` as two paths on one Ingress and inherited the root ingress annotations for that whole resource.

The first change was appropriate for browser routes. The second unintentionally extended the browser OAuth error middleware to machine API routes that already authenticate themselves. Because Kubernetes Ingress annotations apply to the whole Ingress resource rather than individual paths, the original one-Ingress/two-path shape could not express the intended boundary.

The July 20 live validation exercised the browser UI and `/api/integrations-hub/health`, both successful `200` paths. Those continued to work, so the incompatibility stayed hidden until an authenticated API call deliberately returned an application-level error.

## Observed failure chain

The triggering request was an authenticated Notion `post_page` call requiring case-by-case approval:

1. `oauth-auth` accepted the request (`/oauth2` returned `202`).
2. Integrations Hub authenticated the agent API key and intentionally returned `403 application/json`, including the approval URL and request ID.
3. Traefik's `oauth-errors` middleware treated that upstream `403` as a browser authentication failure and requested `/oauth2/sign_in`.
4. The caller received a GitHub OAuth HTML redirect instead of the application's approval JSON.

This was not a failed Notion OAuth connection or an invalid agent key. It was an ingress scoping problem: a browser-oriented error middleware could not distinguish its own authentication failures from valid application-level `401`/`403` responses.

## Why existing tests missed it

- The Helm unit test asserted only that both paths rendered on the expected host and targeted the Integrations Hub service.
- The live preview checks covered only successful responses: UI `200 text/html` and health `200 application/json`.
- No test rendered realistic root OAuth annotations and asserted that API routes were isolated from them.
- No live smoke test exercised an API error response through Traefik.

## Regression coverage in this PR

- The Helm test now supplies realistic root OAuth middleware annotations and asserts that the API and UI render as separate Ingress resources.
- It asserts that the API ingress does not inherit root OAuth annotations while the browser UI still does.
- A second test verifies that operators can add explicit non-OAuth API annotations through `ingress.integrationsHubApi.annotations`.

A complementary post-deploy smoke test can catch this class of integration failure end to end without external credentials: request `/api/integrations-hub/agent/openapi` without an agent key and assert the response is the application's `401 application/json`, includes its `WWW-Authenticate`/`X-Request-ID` headers, has no GitHub OAuth `Location` header, and is not HTML. An approval-required tool call with a valid test key should similarly preserve its application-level `403` body.

## Impact

Browser access remains OAuth-protected. Agent, MCP, user-key, and session API routes continue to use Integrations Hub's existing route-level authentication without an ingress error middleware rewriting their responses.

## Validation

- `helm unittest charts/openhands` — 4 tests passed
- `helm lint charts/openhands` — passed
- rendered `templates/ingress-integrations-hub.yaml` with the development values: API ingress has no root OAuth annotations; UI ingress retains `oauth-errors` and `oauth-auth`
- reproduced and correlated the original response chain in Datadog: OAuth auth check `202` → Integrations Hub `403` → OAuth sign-in response
- all GitHub checks, including preview chart publication and lint/render checks, passed
