### PR TITLE
test(openhands): PLTF-1257 assert values.schema.json rejections

### DIFF
--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -1,0 +1,29 @@
+suite: openhands values schema validation
+templates:
+  - service.yaml
+tests:
+  - it: rejects a non-integer uvicorn.workers
+    set:
+      uvicorn.workers: "four"
+    asserts:
+      - failedTemplate:
+          errorPattern: "uvicorn/workers.*want integer"
+  - it: rejects autoscaling.minReplicas below the minimum
+    set:
+      autoscaling.minReplicas: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: "autoscaling/minReplicas"
+  - it: rejects a non-boolean ingress.enabled
+    set:
+      ingress.enabled: "yes"
+    asserts:
+      - failedTemplate:
+          errorPattern: "ingress/enabled.*want boolean"
+  - it: accepts valid values
+    set:
+      uvicorn.workers: 4
+      autoscaling.minReplicas: 2
+      ingress.enabled: true
+    asserts:
+      - notFailedTemplate: {}


### PR DESCRIPTION
## Why

The chart's `values.schema.json` validates the type and shape of operator-supplied values on install/upgrade, but nothing guards against the schema silently regressing. This adds a helm-unittest suite asserting that representative violations are rejected at render time: a non-integer `uvicorn.workers`, an `autoscaling.minReplicas` below the schema minimum, and a non-boolean `ingress.enabled`. Each matches the schema error on the offending path, and a valid set of values is asserted to render cleanly. helm-unittest enforces `values.schema.json` because it renders through the Helm SDK, so no `helm dependency build` is needed.

## Validation

- `helm unittest charts/openhands` passes all four cases (three rejections and the valid-values case) on a fresh checkout with an empty Helm cache and no dependencies built, matching how the CI job runs.

_This PR was drafted by an AI agent on behalf of the user._
