### PR TITLE
test(openhands): PLTF-1257 assert NOTES.txt post-install output

### DIFF
--- a/charts/openhands/tests/notes_test.yaml
+++ b/charts/openhands/tests/notes_test.yaml
@@ -1,0 +1,27 @@
+suite: openhands post-install notes
+templates:
+  - NOTES.txt
+tests:
+  - it: shows the access URL when ingress has a host
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+    asserts:
+      - matchRegexRaw:
+          pattern: "http://app.example.com"
+  - it: shows port-forward instructions when ingress is disabled
+    set:
+      enabled: true
+      ingress.enabled: false
+    asserts:
+      - matchRegexRaw:
+          pattern: "kubectl port-forward"
+      - matchRegexRaw:
+          pattern: "svc/openhands-service 3000:3000"
+  - it: reports the app was not deployed when disabled
+    set:
+      enabled: false
+    asserts:
+      - matchRegexRaw:
+          pattern: "was not deployed by this release"


### PR DESCRIPTION
## Why

`templates/NOTES.txt` gives operators their post-install next steps, and its guidance branches on configuration, so a broken conditional would ship silently. This adds a helm-unittest suite asserting the three branches render the right guidance: the access URL when `ingress.host` is set, the `kubectl port-forward` fallback (with the correct service and port) when ingress is disabled, and the "not deployed" note when the app is disabled. Assertions use the raw matchers since NOTES.txt is free text, not a manifest. Scoping the suite to `NOTES.txt` keeps the render narrow, so no `helm dependency build` is needed.

## Validation

- `helm unittest charts/openhands` passes all three cases on a fresh checkout with an empty Helm cache and no dependencies built, matching how the CI job runs. Confirmed the narrow scope avoids the `crd-check` subchart that a full-chart render would require.

_This PR was drafted by an AI agent on behalf of the user._
