### PR TITLE
fix(openhands): namespace-qualify bundled litellm url for sandboxes

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/_env.yaml
+++ b/charts/openhands/charts/runtime-api/templates/_env.yaml
@@ -12,6 +12,13 @@
 - name: PGSSLMODE
   value: {{ $dbSslMode | quote }}
 {{- end }}
+{{- if not (hasKey .Values.env "K8S_NAMESPACE") }}
+# Namespace runtime-api creates sandboxes in (not where runtime-api itself
+# runs). Defaults to the release namespace (sandbox_namespace empty); set
+# sandbox_namespace to create sandboxes in a dedicated one.
+- name: K8S_NAMESPACE
+  value: {{ .Values.sandbox_namespace | default .Release.Namespace | quote }}
+{{- end }}
 - name: RUNTIME_IDLE_SECONDS
   value: {{ .Values.cleanup.idle_seconds | default 1200 | quote }}
 - name: RUNTIME_DEAD_SECONDS

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -27,6 +27,13 @@ serviceAccount:
 runtimeInSameCluster: false
 defaultAPIKeySecretName: default-api-key
 
+# Namespace runtime-api creates sandbox pods (and their Service, Ingress, PVC)
+# in, surfaced to the pod as K8S_NAMESPACE. This is NOT where runtime-api
+# itself runs. Empty defaults to the release namespace. Point it at a dedicated
+# namespace to isolate untrusted sandbox workloads from the control plane.
+# Ignored if env.K8S_NAMESPACE is set.
+sandbox_namespace: ""
+
 # Mount a trust-manager / user-supplied CA bundle into the runtime-api pod and
 # point the Python TLS stack (httpx + requests) at it. Required when the
 # runtime ingress serves a cert signed by a CA that isn't in the OS trust

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -280,7 +280,11 @@
 {{- end }}
 {{- if and (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
 - name: LITE_LLM_API_URL
-  value: http://{{ .Release.Name }}-litellm:4000
+  # FQDN (not the bare Service name) so it resolves from any namespace. This URL
+  # is persisted into each user's LLM profile at first use, so it must be
+  # resolvable from sandboxes that run in a separate namespace. No-op for
+  # same-namespace installs.
+  value: http://{{ .Release.Name }}-litellm.{{ .Release.Namespace }}.svc.cluster.local:4000
 {{- else }}
 - name: LITE_LLM_API_URL
   value: {{ .Values.litellm.url }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -735,6 +735,11 @@ runtime-api:
   enabled: true
   replicaCount: 1
   runtimeInSameCluster: true
+  # Namespace runtime-api creates sandbox pods in (surfaced as K8S_NAMESPACE).
+  # NOT where runtime-api itself runs. Empty defaults to the release namespace;
+  # set a dedicated namespace to isolate untrusted sandbox workloads from the
+  # control plane.
+  sandbox_namespace: ""
   imagePullSecrets: []
   securityContext:
     runAsUser: 1000
@@ -809,7 +814,6 @@ runtime-api:
     PGSSLMODE: "prefer"
     DB_USER: postgres
     DB_NAME: runtime_api_db
-    K8S_NAMESPACE: "openhands"
     RUNTIME_CLASS: ""
     # REQUIRED: Update to match the host set in the ingress section above
     # RUNTIME_BASE_URL: "runtime.example.com"


### PR DESCRIPTION
## Description

Fixes #932. Running agent sandboxes in a dedicated namespace, separate from the control-plane workloads, was blocked. The app hands each sandbox the bundled litellm URL as a bare service name (`http://<release>-litellm:4000`), which only resolves inside the caller's own namespace. From a sandbox in another namespace, DNS fails and every conversation errors with a litellm connection error.

This namespace-qualifies that URL to an FQDN (`http://<release>-litellm.<release-namespace>.svc.cluster.local:4000`) so it resolves from any namespace. It's a no-op for same-namespace installs (today's default).

It has to be a chart default rather than a values override, because the URL is persisted into each user's LLM profile at first use. Overriding it later wouldn't fix existing profiles, so a fresh install needs a resolvable URL baked in from the start. This only affects newly-persisted profiles - I didn't touch data that's already been written.

While here, I promoted the sandbox namespace to a proper `runtime-api.sandbox_namespace` value. It was a static `K8S_NAMESPACE: "openhands"` buried in the `runtime-api.env` passthrough map. Since values files aren't templated, that literal could never track a differently-named release namespace. The new value defaults to the release namespace and is the clean knob for pointing sandboxes at a dedicated namespace. I named it `sandbox_namespace` rather than `namespace` so it's clear it controls where sandboxes are created, not where runtime-api itself runs.

## Approach

`K8S_NAMESPACE` is now emitted from `sandbox_namespace | default .Release.Namespace`, guarded the same way as `DB_SSL_MODE` so a legacy `env.K8S_NAMESPACE` override still wins with no double-emission. For the standard deploy (release namespace `openhands`) this resolves to `openhands`, matching the previous hardcoded default.

I checked the two other bare `<release>-...` service URLs in that app env block - `REDIS_HOST` and the Postgres `DB_HOST`. Neither is handed to sandboxes, and per the isolation goal a sandbox shouldn't reach redis or postgres at all, so litellm was the only URL that needed qualifying.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

No breaking changes and no new required values - `sandbox_namespace` defaults to the release namespace, so nothing needs README changes. `helm lint` passes. I verified backwards compat by rendering: default release namespace resolves `K8S_NAMESPACE` to `openhands` (prior behavior), a legacy `env.K8S_NAMESPACE` override still wins, and `--set runtime-api.sandbox_namespace=<ns>` places sandboxes and the litellm FQDN in the expected namespace.
