### PR TITLE
revert: "feat(openhands): PLTF-3258 fail render when postgresql disabled without an external database (#928)"

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -6,6 +6,3 @@ mistake is caught at install/upgrade instead of producing a broken object.
 {{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
 {{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
 {{- end -}}
-{{- if and (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
-{{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
-{{- end -}}


### PR DESCRIPTION
Reverts #928.

This reverts commit bd33dbc578f7140863cd6c2a51c829b382a6fb19.

---

**Note:** This PR was opened by an AI agent (OpenHands) on behalf of the user.