### PR TITLE
revert(openhands): PLTF-3258 remove ingress.host fail guard (#923)

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -1,8 +1,0 @@
-{{/*
-Render-time configuration guards. Emits no resources; each block fails the
-render with a clear message when values are invalid or conflicting, so the
-mistake is caught at install/upgrade instead of producing a broken object.
-*/}}
-{{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
-{{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
-{{- end -}}


### PR DESCRIPTION
## Why

This reverts #923, which added a render-time guard in `validations.yaml` failing the install/upgrade when `ingress.enabled: true` but `ingress.host` is empty.

The guard rejects a value combination that was previously accepted, so it is a breaking change for any consumer that renders with `ingress.enabled: true` and no host set. Reverting restores the prior render behavior while the guard is reworked.

## Validation

Rendered with `helm template`:

- `charts/openhands/templates/validations.yaml` removed, restoring the tree to its pre-#923 state
- ingress on, no host → renders again instead of failing
- ingress off (default) and ingress on + host set → unchanged

_This PR was drafted by an AI agent on behalf of the user._
