### PR TITLE
feat(charts): add external S3 file store support

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -454,29 +454,31 @@ To use an external PostgreSQL database instead of deploying one with the chart:
 
 ### Bring Your Own S3-Compatible Storage
 
-To use an external S3-compatible storage instead of MinIO:
+To use an external S3 (or S3-compatible) store instead of the bundled MinIO,
+disable the ephemeral filestore and configure the connection:
 
-1. Disable the ephemeral filestore:
+```yaml
+filestore:
+  ephemeral: false          # stops deploying the in-cluster MinIO
+  type: s3
+  bucket: your-bucket-name
+  region: your-s3-region
+  # endpoint: https://your-s3-endpoint   # only for S3-compatible stores (MinIO/R2/…); omit for AWS S3
+  # secure: false                        # only for a plain-HTTP endpoint
+  existingSecret: s3-credentials         # omit to use IRSA / Pod Identity instead
+```
 
-   ```yaml
-   filestore:
-     ephemeral: false
-   ```
+Create the credentials secret (keys match the AWS SDK env var names):
 
-2. Configure the S3 connection:
+```bash
+kubectl create secret generic s3-credentials -n openhands \
+  --from-literal=AWS_ACCESS_KEY_ID=<your-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+```
 
-   ```yaml
-   filestore:
-     ephemeral: false
-     bucket: your-bucket-name
-     endpoint: https://your-s3-endpoint
-     region: your-s3-region
-     existingSecret: s3-credentials
-   # Make sure the secret exists with the correct credentials
-   # kubectl create secret generic s3-credentials \
-   #   --from-literal=access-key=<your-access-key> \
-   #   --from-literal=secret-key=<your-secret-key>
-   ```
+For AWS S3 on EKS you can skip the secret entirely and use a pod-level AWS
+identity: omit `existingSecret` and grant the app ServiceAccount an IAM role
+(via IRSA or EKS Pod Identity) with access to the bucket. Keep `region` set.
 
 ### Bring Your Own Redis
 

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -60,6 +60,42 @@
   value: {{ .Values.filestore.bucket }}
 - name: AWS_S3_SECURE
   value: 'false'
+{{- else if or (eq (.Values.filestore.type | default "") "s3") .Values.filestore.existingSecret .Values.filestore.region .Values.filestore.endpoint }}
+# External S3 (or S3-compatible) object store — the durable alternative to the
+# bundled MinIO. Engaged by filestore.type=s3 or any external marker
+# (existingSecret / region / endpoint). The app's S3FileStore uses boto3, so
+# credentials come from filestore.existingSecret when set, otherwise from the
+# pod's ambient AWS identity (IRSA / Pod Identity / instance profile). Unlike the
+# ephemeral branch, AWS_S3_ENDPOINT is left unset for real AWS so boto3 targets
+# the regional endpoint instead of being pinned to MinIO.
+- name: FILE_STORE
+  value: s3
+- name: AWS_S3_BUCKET
+  value: {{ .Values.filestore.bucket | quote }}
+{{- if .Values.filestore.region }}
+- name: AWS_REGION
+  value: {{ .Values.filestore.region | quote }}
+{{- end }}
+{{- if .Values.filestore.endpoint }}
+- name: AWS_S3_ENDPOINT
+  value: {{ .Values.filestore.endpoint | quote }}
+{{- end }}
+{{- $secure := .Values.filestore.secure }}
+{{- if kindIs "invalid" $secure }}{{- $secure = true }}{{- end }}
+- name: AWS_S3_SECURE
+  value: {{ $secure | quote }}
+{{- if .Values.filestore.existingSecret }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.existingSecret }}
+      key: {{ .Values.filestore.accessKeyIdKey | default "AWS_ACCESS_KEY_ID" }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.existingSecret }}
+      key: {{ .Values.filestore.secretAccessKeyKey | default "AWS_SECRET_ACCESS_KEY" }}
+{{- end }}
 {{- else }}
 - name: FILE_STORE
   value: {{ .Values.filestore.type }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -98,8 +98,34 @@ integrations:
   resolverLabel: "openhands"
 
 filestore:
+  # ephemeral: true deploys the bundled in-cluster MinIO (a conditional
+  # dependency) and points the app at it — handy for POC/feature envs. NOTE the
+  # bundled MinIO runs WITHOUT persistence, so its data is lost when the pod is
+  # rescheduled. For anything durable set ephemeral: false and use an external
+  # store (S3 or GCS) below.
   ephemeral: false
+  # Bucket name (S3/GCS) or MinIO bucket for conversation/session file storage.
   bucket: openhands-sessions
+  # Store backend when ephemeral: false. "s3" (AWS S3 or any S3-compatible store)
+  # or "google_cloud" / "gcs" (GCS via Workload Identity). Empty keeps the legacy
+  # behavior (FILE_STORE set to this raw value). The external-S3 path below also
+  # auto-engages if any of region/endpoint/existingSecret is set.
+  type: ""
+  # --- External S3 (used when type: s3, or any field below is set) ---
+  # AWS region of the bucket. Required for real AWS S3 (boto3 needs it to sign).
+  region: ""
+  # Custom endpoint for S3-compatible stores (MinIO/R2/GCS-interop/…). Leave
+  # empty for real AWS S3 so boto3 uses the regional endpoint.
+  endpoint: ""
+  # Use TLS. Defaults to true when unset; set false only for a plain-HTTP
+  # S3-compatible endpoint.
+  secure: true
+  # Name of an existing Secret holding AWS credentials. Omit to use the pod's
+  # ambient AWS identity (IRSA / Pod Identity / instance profile) with no keys.
+  existingSecret: ""
+  # Keys within existingSecret (defaults match the AWS SDK env var names).
+  accessKeyIdKey: AWS_ACCESS_KEY_ID
+  secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
 
 # Workspace archiving (app-server, explicit-delete path): before a still-running
 # sandbox is deleted, copy its workspace to object storage so the agent's work


### PR DESCRIPTION
## Description

The chart's file store could be backed by the bundled in-cluster minio (`filestore.ephemeral: true`) or by GCS. There was no first-class way to point the app's file store at an external S3 or S3-compatible bucket.

The README already documented S3 settings (`endpoint`, `region`, `existingSecret`), but the templates never implemented them, so "bring your own S3" didn't actually work.

This adds a real external-S3 path to the chart and fixes the docs to match.

## Approach

The new branch in `templates/_env.yaml` engages when `filestore.type: s3`, or when any of `region` / `endpoint` / `existingSecret` is set. Credentials are optional:

- With `filestore.existingSecret`, AWS creds are wired via `secretKeyRef` from that secret. The key names default to the standard AWS SDK env vars and are overridable.
- Without it, no credential env is emitted, so the app uses the pod's ambient AWS identity (IRSA, EKS Pod Identity, or an instance profile).

`AWS_S3_ENDPOINT` stays unset for real AWS so boto3 targets the regional endpoint. You set it only for an S3-compatible store like minio or R2.

The change is additive. Existing configs, including ephemeral minio and the GCS path, render identically.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

No new required values and no breaking changes. The new `filestore` keys are all optional and default to today's behavior.

What I checked with `helm template` on the rebased chart:

- Secret-backed external S3 renders credentials via `secretKeyRef`, with the right bucket and region and no endpoint for real AWS.
- Keyless external S3 (custom endpoint, `secure: false`) renders no credential env and relies on the ambient identity.
- Ephemeral minio and the default values render unchanged.

release-please owns the chart version, so `Chart.yaml` is deliberately untouched.