### PR TITLE
fix(openhands): validate filestore values and test external S3 env

### DIFF
--- a/charts/openhands/tests/filestore_env_test.yaml
+++ b/charts/openhands/tests/filestore_env_test.yaml
@@ -1,0 +1,186 @@
+suite: filestore env wiring
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+tests:
+  - it: wires external S3 credentials from an existing secret (real AWS)
+    set:
+      enabled: true
+      filestore.type: s3
+      filestore.bucket: prod-sessions
+      filestore.region: us-west-2
+      filestore.existingSecret: s3-creds
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: s3
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_BUCKET
+            value: prod-sessions
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-west-2
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+            value: "true"
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-creds
+                key: AWS_ACCESS_KEY_ID
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-creds
+                key: AWS_SECRET_ACCESS_KEY
+      # No endpoint for real AWS so boto3 targets the regional endpoint.
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="AWS_S3_ENDPOINT")]
+
+  - it: reads credentials from overridden secret keys
+    set:
+      enabled: true
+      filestore.type: s3
+      filestore.bucket: prod-sessions
+      filestore.region: us-east-1
+      filestore.existingSecret: s3-creds
+      filestore.accessKeyIdKey: access-key
+      filestore.secretAccessKeyKey: secret-key
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-creds
+                key: access-key
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-creds
+                key: secret-key
+
+  - it: uses ambient identity and a custom endpoint when no secret is set
+    set:
+      enabled: true
+      filestore.type: s3
+      filestore.bucket: bk
+      filestore.endpoint: https://minio.example.com
+      filestore.secure: false
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: s3
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: https://minio.example.com
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+            value: "false"
+      # Keyless: the app relies on IRSA / Pod Identity / instance profile, so no
+      # AWS credential env is emitted.
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="AWS_ACCESS_KEY_ID")]
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="AWS_SECRET_ACCESS_KEY")]
+
+  - it: auto-engages the external S3 path from a marker field without type=s3
+    set:
+      enabled: true
+      filestore.bucket: bk
+      filestore.region: eu-central-1
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: s3
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: eu-central-1
+
+  - it: leaves the ephemeral MinIO wiring unchanged
+    set:
+      enabled: true
+      filestore.ephemeral: true
+      filestore.bucket: openhands-sessions
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: s3
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-minio:9000
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+            value: "false"
+
+  - it: passes a non-S3 store type straight through to FILE_STORE
+    set:
+      enabled: true
+      filestore.type: google_cloud
+      filestore.bucket: bk
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: google_cloud
+      # The external-S3 branch stays dormant, so none of its AWS_S3_* env leaks.
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="AWS_S3_BUCKET")]

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -20,10 +20,36 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "ingress/enabled.*want boolean"
+  - it: rejects a non-boolean filestore.secure
+    set:
+      filestore.secure: "yes"
+    asserts:
+      - failedTemplate:
+          errorPattern: "filestore/secure.*want boolean"
+  - it: rejects a non-boolean filestore.ephemeral
+    set:
+      filestore.ephemeral: "nope"
+    asserts:
+      - failedTemplate:
+          errorPattern: "filestore/ephemeral.*want boolean"
+  - it: rejects a non-string filestore.region
+    set:
+      filestore.region: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "filestore/region.*want string"
   - it: accepts valid values
     set:
       uvicorn.workers: 4
       autoscaling.minReplicas: 2
       ingress.enabled: true
+      filestore.type: s3
+      filestore.bucket: prod-sessions
+      filestore.region: us-west-2
+      filestore.endpoint: https://minio.example.com
+      filestore.secure: false
+      filestore.existingSecret: s3-creds
+      filestore.accessKeyIdKey: access-key
+      filestore.secretAccessKeyKey: secret-key
     asserts:
       - notFailedTemplate: {}

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -80,6 +80,21 @@
       "properties": {
         "workers": { "type": "integer", "minimum": 1 }
       }
+    },
+    "filestore": {
+      "type": "object",
+      "properties": {
+        "ephemeral": { "type": "boolean" },
+        "bucket": { "type": "string" },
+        "type": { "type": "string" },
+        "provider": { "type": "string" },
+        "region": { "type": "string" },
+        "endpoint": { "type": "string" },
+        "secure": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "accessKeyIdKey": { "type": "string" },
+        "secretAccessKeyKey": { "type": "string" }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

#946 added external S3 (and S3-compatible) filestore support to the chart, but it merged with two gaps: `values.schema.json` was never taught about the `filestore` block, and the new env wiring had no unit tests. This fills both.

The schema now validates the whole `filestore` block. That's the pre-existing `ephemeral`/`bucket`/`provider` plus the keys #946 introduced: `type`, `region`, `endpoint`, `secure`, `existingSecret`, `accessKeyIdKey`, `secretAccessKeyKey`.

The unit tests cover the new schema rejections and the `_env.yaml` rendering across every filestore branch: secret-backed real AWS, overridden secret key names, keyless with a custom endpoint, marker-field auto-engage without `type: s3`, the ephemeral MinIO path (unchanged), and non-S3 passthrough. The suite goes from 11 to 20 tests.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Two deliberate choices in the schema, both to stay backwards-compatible:

- No `minLength` on the string fields. They default to `""`, so a minimum would reject the chart's own defaults.
- No `enum` on `type`. An empty or unknown `type` passes straight through to `FILE_STORE`, so an enum would break that legacy path.

Backwards compat here means the existing default render is unchanged, which the full unit-test suite exercises. There are no new required values, so nothing to update in the README (#946 already handled the docs).

Heads up for the next person editing these tests: the absence checks (no credentials in keyless mode, no endpoint for real AWS) use JSONPath `notExists` filters. `matchRegexRaw` silently passes on YAML documents - it's meant for raw text like NOTES.txt - so it can't be trusted for those.