### PR TITLE
feat(openhands): PLTF-3258 re-add fail guard for postgresql disabled without external database

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -6,3 +6,6 @@ mistake is caught at install/upgrade instead of producing a broken object.
 {{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
 {{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
 {{- end -}}
+{{- if and (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
+{{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
+{{- end -}}


### PR DESCRIPTION
## Why

This restores the render-time guard that fails `helm template` when `postgresql.enabled=false` and `externalDatabase.host`/`externalDatabase.username` are unset. It catches a broken database configuration at install or upgrade time, instead of deploying a server that cannot reach its database.

The guard was reverted after it broke the SaaS staging ArgoCD sync. Those environments disable the bundled postgres and reach Cloud SQL over the cloud-sql-connector path, so they never set `externalDatabase.*` and the guard failed render. The SaaS environments that disable postgres (development, staging, production) now set `externalDatabase.host` and `externalDatabase.username` in saas-deploy, already merged and synced. The guard now passes there, while still protecting self-hosted operators who disable postgres without configuring a database.

No `Chart.yaml` bump here. The release is cut by the automated release workflow on merge.

## Validation

`helm template` against `charts/openhands`:

- Defaults (`postgresql.enabled=true`, bundled DB): guard silent, renders.
- `postgresql.enabled=false`, no `externalDatabase`: fails at `validations.yaml:10` with `Error: ... postgresql.enabled is false but the external database is not configured ...`.
- `postgresql.enabled=false` with `externalDatabase.host` and `externalDatabase.username` set: guard silent, renders.

_This PR was drafted by an AI agent on behalf of the user._
