### PR TITLE
fix(openhands): PLTF-3258 scope render guards to enabled releases

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -2,10 +2,13 @@
 Render-time configuration guards. Emits no resources; each block fails the
 render with a clear message when values are invalid or conflicting, so the
 mistake is caught at install/upgrade instead of producing a broken object.
+Each guard is scoped to .Values.enabled: when the enterprise-server is not
+deployed (enabled=false), the ingress and database env these guards check
+are never rendered, so a server-less release must not trip them.
 */}}
-{{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
+{{- if and .Values.enabled .Values.ingress.enabled (not .Values.ingress.host) -}}
 {{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
 {{- end -}}
-{{- if and (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
+{{- if and .Values.enabled (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
 {{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
 {{- end -}}

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -30,3 +30,18 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: skips the ingress guard when the release is disabled
+    set:
+      enabled: false
+      ingress.enabled: true
+      ingress.host: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: skips the postgres guard when the release is disabled
+    set:
+      enabled: false
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Why

The ingress and postgresql render guards in `validations.yaml` fire even when `.Values.enabled=false`. When the enterprise-server is not deployed (`enabled=false`, for example an automation-only release that runs just a subchart), the chart renders none of the ingress or database env that these guards check, so there is nothing for them to validate. They still failed `helm template`.

Every workload template in the chart is already gated on `.Values.enabled` (`deployment.yaml`, `service.yaml`, `ingress-root.yaml`, the cronjobs, keycloak). The guards were not. This scopes both guards to `.Values.enabled` so they only validate releases that actually deploy the components they protect. Standard installs (`enabled=true`) are unaffected.

No `Chart.yaml` bump. The release workflow cuts the version on merge.

## Validation

`helm unittest charts/openhands`: 6/6 pass, including two new cases asserting neither guard fires when `enabled=false`.

`helm template charts/openhands`:

| enabled | other values | expected | result |
|---|---|---|---|
| false | `postgresql=false`, no `externalDatabase` | no DB guard | no fire |
| true | `postgresql=false`, no `externalDatabase` | DB guard fires | fires |
| true | `postgresql=false`, `externalDatabase.host`/`username` set | no DB guard | no fire |
| false | `ingress.enabled=true`, empty `host` | no ingress guard | no fire |
| true | `ingress.enabled=true`, empty `host` | ingress guard fires | fires |

_This PR was drafted by an AI agent on behalf of the user._
