### PR TITLE
fix(integrations-hub): trust ingress forwarded headers for OAuth https

### DIFF
--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -102,7 +102,7 @@ auth:
 # Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted)
 admin:
   # Comma-separated list of admin email addresses.
-  emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev"
+  emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev,lila.garcia@openhands.dev"
 
 # PostgreSQL database configuration
 # The backend expects a single URL via INTHUB_POSTGRES_URL. The chart

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1290,7 +1290,7 @@ integrations-hub:
   # Admin allowlist for /api/admin/* routes.
   # Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted).
   admin:
-    emails: ""
+    emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev,lila.garcia@openhands.dev"
 
   # PostgreSQL database configuration. The backend reads a single
   # connection URL via INTHUB_POSTGRES_URL; the chart builds it from the
@@ -1321,8 +1321,14 @@ integrations-hub:
     secretName: "integrations-hub-cron-secret"
     secretKey: "cron-secret"
 
-  # Env vars passed directly to the container
-  env: {}
+  # Env vars passed directly to the container.
+  # FORWARDED_ALLOW_IPS lets uvicorn trust the ingress' X-Forwarded-* headers
+  # so request.url.scheme resolves to https behind Traefik (TLS terminates at
+  # the ingress). Without this, uvicorn defaults to trusting only 127.0.0.1,
+  # the internal hop is seen as http, and OAuth redirect_uri values are built
+  # with an http scheme -- causing provider redirect_uri mismatches.
+  env:
+    FORWARDED_ALLOW_IPS: "*"
 
   # PostgreSQL subchart - disabled when using parent's PostgreSQL
   postgresql:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1290,7 +1290,7 @@ integrations-hub:
   # Admin allowlist for /api/admin/* routes.
   # Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted).
   admin:
-    emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev,lila.garcia@openhands.dev"
+    emails: ""
 
   # PostgreSQL database configuration. The backend reads a single
   # connection URL via INTHUB_POSTGRES_URL; the chart builds it from the


### PR DESCRIPTION
## Summary

Two changes to the `integrations-hub` Helm config:

1. **Fix OAuth redirect errors on staging** — set `integrations-hub.env.FORWARDED_ALLOW_IPS: "*"` in the parent chart (`charts/openhands/values.yaml`).
2. **Add `lila.garcia@openhands.dev` as an integrations-hub admin** — in the subchart default (`charts/openhands/charts/integrations-hub/values.yaml`), alongside the existing entries where those admins were already configured.

## Why OAuth was failing

The integrations-hub backend builds the OAuth callback `redirect_uri` from the live request URL:

```python
# backend/app/oauth_flow.py  (oauth_callback_base_url -> used for redirect_uri)
proxy = INTHUB_OAUTH_REDIRECT_PROXY_URL
if proxy:
    return f"{origin}{...}"
return f"{request.url.scheme}://{request.url.netloc}{...}"   # fallback
```

`integrations-hub.openhands.redirectProxyUrl` is empty, so this falls back to `request.url.scheme`. The backend runs via a plain `uvicorn.run(...)` with no `FORWARDED_ALLOW_IPS`. Uvicorn defaults to `proxy_headers=True` but `forwarded_allow_ips="127.0.0.1"`. Behind Traefik the TCP peer is a **pod-network IP, not 127.0.0.1**, so `ProxyHeadersMiddleware` does not trust `X-Forwarded-Proto`. TLS terminates at the ingress, so the internal hop is plain HTTP and `request.url.scheme == "http"`.

Result: `redirect_uri` becomes `http://staging.all-hands.dev/api/integrations-hub/oauth/<provider>/callback`, mismatching the `https` callback the provider expects → redirect errors.

`FORWARDED_ALLOW_IPS: "*"` makes uvicorn trust the ingress `X-Forwarded-*` headers so the scheme resolves to `https`. This mirrors the existing Keycloak config (`proxyHeaders`/`KC_PROXY_HEADERS: xforwarded`) and is an appropriate shipped default because the chart defaults to a TLS-terminating Traefik ingress.

## Admin allowlist

integrations-hub admin access is a pure email allowlist (`INTHUB_APP_ADMIN_EMAILS`, case-insensitive vs the user's OpenHands identity email); there is no DB/runtime grant.

Following review feedback (repo code-review guideline: *"Defaults Serve the Self-Hosted User"*), the admin email is **not** placed in the parent umbrella `values.yaml` default — that stays `""` so a self-hosted umbrella install does not grant admin to specific individuals. Instead `lila.garcia@openhands.dev` is added to the **subchart** default where `chuck`/`graham` already live.

### ⚠️ Helm precedence caveat (needs reviewer decision)

When deployed via the umbrella `openhands` chart, the parent's `integrations-hub.admin.emails: ""` **overrides** the subchart default. So this change alone does **not** make lila an admin on the umbrella deployment (e.g. app.all-hands.dev / staging). To actually take effect there, either:

- set `integrations-hub.admin.emails` in **our environment's values overlay / Replicated config** (preferred, keeps it out of shipped defaults), or
- drop the parent `integrations-hub.admin.emails: ""` override so the subchart default flows through (would also expose chuck/graham/lila to self-hosted umbrella users — not recommended).

The subchart-default change is still useful for direct subchart installs and documents the intended internal admin list.

## Deploy note

After merge, an env change requires a `helm upgrade` + pod restart. Also verify each provider's OAuth app allow-lists the callback **including the API prefix**: `/api/integrations-hub/oauth/<provider>/callback`.

## Testing

- Validated both `values.yaml` files parse as YAML and render the expected values.
- Helm was not available in this environment to run `helm template`/unittest.

---
_This PR was created by an AI agent (OpenHands) on behalf of the requesting user._