### PR TITLE
feat(charts): adopt kubernetes recommended labels

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -17,8 +17,13 @@ jobs:
           version: 'v3.18.4'
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.1
+      # Subchart suites are only picked up by the parent run when the subchart is
+      # enabled by default, so every chart with tests is listed explicitly.
       - name: Run chart unit tests
         run: |
           helm unittest charts/openhands
           helm unittest charts/openhands/charts/integrations-hub
+          helm unittest charts/openhands/charts/runtime-api
           helm unittest charts/openhands-secrets
+          helm unittest charts/image-loader
+          helm unittest charts/infra

--- a/charts/image-loader/templates/priority-class.yaml
+++ b/charts/image-loader/templates/priority-class.yaml
@@ -2,6 +2,9 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Values.nodeOverprovisioner.priorityClassName }}
+  labels:
+    {{- include "image-loader.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-overprovisioner
 value: -10
 globalDefault: false
 description: "This priority class is used for the node-overprovisioner deployment to ensure it gets evicted for other workloads."

--- a/charts/image-loader/tests/labels_test.yaml
+++ b/charts/image-loader/tests/labels_test.yaml
@@ -1,0 +1,28 @@
+suite: recommended labels
+templates:
+  - templates/priority-class.yaml
+tests:
+  - it: the node-overprovisioner PriorityClass carries the recommended labels
+    asserts:
+      - isKind:
+          of: PriorityClass
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: image-loader
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: node-overprovisioner
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^image-loader-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]

--- a/charts/infra/templates/_helpers.tpl
+++ b/charts/infra/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "infra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+
+Unlike the other charts, this one does not emit app.kubernetes.io/name. Each
+workload here is an independent cluster-level component rather than a copy of
+the chart, and its name doubles as the DaemonSet's spec.selector, which is
+immutable. So every resource sets app.kubernetes.io/name itself and this helper
+supplies the rest.
+*/}}
+{{- define "infra.labels" -}}
+helm.sh/chart: {{ include "infra.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: openhands
+{{- end }}

--- a/charts/infra/templates/sandbox-upgrade-coordinator.yaml
+++ b/charts/infra/templates/sandbox-upgrade-coordinator.yaml
@@ -61,8 +61,8 @@ metadata:
   name: {{ $name }}
   namespace: {{ $ns }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sandbox-upgrade-coordinator
-    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- with $c.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
@@ -79,8 +79,8 @@ kind: ClusterRole
 metadata:
   name: {{ $name }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sandbox-upgrade-coordinator
-    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["embeddedcluster.replicated.com"]
     resources: ["installations"]
@@ -94,8 +94,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ $name }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sandbox-upgrade-coordinator
-    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -111,8 +111,8 @@ metadata:
   name: {{ $name }}
   namespace: {{ $ns }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sandbox-upgrade-coordinator
-    app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   coordinator.sh: |
     #!/bin/sh
@@ -224,8 +224,8 @@ metadata:
   name: {{ $name }}
   namespace: {{ $ns }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sandbox-upgrade-coordinator
-    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:

--- a/charts/infra/templates/sysbox-installer.yaml
+++ b/charts/infra/templates/sysbox-installer.yaml
@@ -7,8 +7,8 @@ kind: RuntimeClass
 metadata:
   name: {{ .Values.sysbox.runtimeClassName }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sysbox-installer
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
 handler: {{ .Values.sysbox.runtimeClassName }}
 ---
 # Privileged DaemonSet that installs Sysbox onto every node and wires up the
@@ -26,8 +26,8 @@ metadata:
   name: sysbox-installer
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "infra.labels" . | nindent 4 }}
     app.kubernetes.io/name: sysbox-installer
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:

--- a/charts/infra/tests/labels_test.yaml
+++ b/charts/infra/tests/labels_test.yaml
@@ -1,0 +1,102 @@
+suite: recommended labels
+templates:
+  - templates/sysbox-installer.yaml
+  - templates/sandbox-upgrade-coordinator.yaml
+tests:
+  - it: the sysbox DaemonSet carries the recommended labels and keeps its selector
+    template: templates/sysbox-installer.yaml
+    documentIndex: 1
+    set:
+      sysbox.enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: sysbox-installer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^infra-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+      # spec.selector is immutable, so it stays on the workload's own name and
+      # the pod template keeps matching it unchanged.
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: sysbox-installer
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: sysbox-installer
+
+  - it: the sysbox RuntimeClass carries the recommended labels
+    template: templates/sysbox-installer.yaml
+    documentIndex: 0
+    set:
+      sysbox.enabled: true
+    asserts:
+      - isKind:
+          of: RuntimeClass
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: sysbox-installer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^infra-
+
+  - it: every sandbox-upgrade-coordinator resource carries the recommended labels
+    template: templates/sandbox-upgrade-coordinator.yaml
+    set:
+      sandboxUpgradeCoordinator.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 5
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: sandbox-upgrade-coordinator
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^infra-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+
+  - it: the sandbox-upgrade-coordinator DaemonSet keeps its selector
+    template: templates/sandbox-upgrade-coordinator.yaml
+    documentIndex: 4
+    set:
+      sandboxUpgradeCoordinator.enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: sandbox-upgrade-coordinator
+            app.kubernetes.io/instance: RELEASE-NAME
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: sandbox-upgrade-coordinator
+            app.kubernetes.io/instance: RELEASE-NAME

--- a/charts/openhands/charts/agent-canvas/templates/_helpers.tpl
+++ b/charts/openhands/charts/agent-canvas/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "image-loader.name" -}}
+{{- define "agent-canvas.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "image-loader.fullname" -}}
+{{- define "agent-canvas.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "image-loader.chart" -}}
+{{- define "agent-canvas.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "image-loader.labels" -}}
-helm.sh/chart: {{ include "image-loader.chart" . }}
-{{ include "image-loader.selectorLabels" . }}
+{{- define "agent-canvas.labels" -}}
+helm.sh/chart: {{ include "agent-canvas.chart" . }}
+{{ include "agent-canvas.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,7 +46,7 @@ app.kubernetes.io/part-of: openhands
 {{/*
 Selector labels
 */}}
-{{- define "image-loader.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "image-loader.name" . }}
+{{- define "agent-canvas.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent-canvas.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/openhands/charts/agent-canvas/templates/deployment.yaml
+++ b/charts/openhands/charts/agent-canvas/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: agent-canvas
   labels:
+    {{- include "agent-canvas.labels" . | nindent 4 }}
     app: agent-canvas
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -13,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "agent-canvas.selectorLabels" . | nindent 8 }}
         app: agent-canvas
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/openhands/charts/agent-canvas/templates/service-account.yaml
+++ b/charts/openhands/charts/agent-canvas/templates/service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
+    {{- include "agent-canvas.labels" . | nindent 4 }}
     app: agent-canvas
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/openhands/charts/agent-canvas/templates/service.yaml
+++ b/charts/openhands/charts/agent-canvas/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: agent-canvas
   labels:
+    {{- include "agent-canvas.labels" . | nindent 4 }}
     app: agent-canvas
 spec:
   type: ClusterIP

--- a/charts/openhands/charts/automation/templates/_helpers.tpl
+++ b/charts/openhands/charts/automation/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "image-loader.name" -}}
+{{- define "automation.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "image-loader.fullname" -}}
+{{- define "automation.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "image-loader.chart" -}}
+{{- define "automation.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "image-loader.labels" -}}
-helm.sh/chart: {{ include "image-loader.chart" . }}
-{{ include "image-loader.selectorLabels" . }}
+{{- define "automation.labels" -}}
+helm.sh/chart: {{ include "automation.chart" . }}
+{{ include "automation.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,7 +46,7 @@ app.kubernetes.io/part-of: openhands
 {{/*
 Selector labels
 */}}
-{{- define "image-loader.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "image-loader.name" . }}
+{{- define "automation.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "automation.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/openhands/charts/automation/templates/deployment.yaml
+++ b/charts/openhands/charts/automation/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: automation
   labels:
+    {{- include "automation.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
     app: automation
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -12,6 +14,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "automation.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
         app: automation
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/openhands/charts/automation/templates/events-deployment.yaml
+++ b/charts/openhands/charts/automation/templates/events-deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: automation-events
   labels:
+    {{- include "automation.labels" . | nindent 4 }}
+    app.kubernetes.io/component: events
     app: automation-events
 spec:
   replicas: {{ .Values.events.deployment.replicas }}
@@ -13,6 +15,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "automation.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: events
         app: automation-events
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/openhands/charts/automation/templates/events-service.yaml
+++ b/charts/openhands/charts/automation/templates/events-service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: automation-events
   labels:
+    {{- include "automation.labels" . | nindent 4 }}
+    app.kubernetes.io/component: events
     app: automation-events
 spec:
   ports:

--- a/charts/openhands/charts/automation/templates/service-account.yaml
+++ b/charts/openhands/charts/automation/templates/service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
+    {{- include "automation.labels" . | nindent 4 }}
     app: automation
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/openhands/charts/automation/templates/service.yaml
+++ b/charts/openhands/charts/automation/templates/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: automation
   labels:
+    {{- include "automation.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
     app: automation
 spec:
   ports:

--- a/charts/openhands/charts/integrations-hub/templates/_helpers.tpl
+++ b/charts/openhands/charts/integrations-hub/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "image-loader.name" -}}
+{{- define "integrations-hub.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "image-loader.fullname" -}}
+{{- define "integrations-hub.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "image-loader.chart" -}}
+{{- define "integrations-hub.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "image-loader.labels" -}}
-helm.sh/chart: {{ include "image-loader.chart" . }}
-{{ include "image-loader.selectorLabels" . }}
+{{- define "integrations-hub.labels" -}}
+helm.sh/chart: {{ include "integrations-hub.chart" . }}
+{{ include "integrations-hub.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,7 +46,7 @@ app.kubernetes.io/part-of: openhands
 {{/*
 Selector labels
 */}}
-{{- define "image-loader.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "image-loader.name" . }}
+{{- define "integrations-hub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "integrations-hub.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/openhands/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: integrations-hub
   labels:
+    {{- include "integrations-hub.labels" . | nindent 4 }}
     app: integrations-hub
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -12,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "integrations-hub.selectorLabels" . | nindent 8 }}
         app: integrations-hub
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/openhands/charts/integrations-hub/templates/service-account.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
+    {{- include "integrations-hub.labels" . | nindent 4 }}
     app: integrations-hub
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/openhands/charts/integrations-hub/templates/service.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: integrations-hub
   labels:
+    {{- include "integrations-hub.labels" . | nindent 4 }}
     app: integrations-hub
 spec:
   ports:

--- a/charts/openhands/charts/integrations-hub/tests/labels_test.yaml
+++ b/charts/openhands/charts/integrations-hub/tests/labels_test.yaml
@@ -1,0 +1,37 @@
+suite: recommended labels
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: the integrations-hub Deployment carries the recommended labels and keeps its app selector
+    set:
+      database.url: postgresql://example
+      credentialEncryption.secretName: encryption
+      cron.secretName: cron
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: integrations-hub
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^integrations-hub-
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: integrations-hub
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: integrations-hub
+      # The selector is intentionally left on the legacy app label (immutable field).
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: integrations-hub
+      - notExists:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]

--- a/charts/openhands/charts/plugin-directory/templates/_helpers.tpl
+++ b/charts/openhands/charts/plugin-directory/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "image-loader.name" -}}
+{{- define "plugin-directory.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "image-loader.fullname" -}}
+{{- define "plugin-directory.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "image-loader.chart" -}}
+{{- define "plugin-directory.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "image-loader.labels" -}}
-helm.sh/chart: {{ include "image-loader.chart" . }}
-{{ include "image-loader.selectorLabels" . }}
+{{- define "plugin-directory.labels" -}}
+helm.sh/chart: {{ include "plugin-directory.chart" . }}
+{{ include "plugin-directory.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,7 +46,7 @@ app.kubernetes.io/part-of: openhands
 {{/*
 Selector labels
 */}}
-{{- define "image-loader.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "image-loader.name" . }}
+{{- define "plugin-directory.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "plugin-directory.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/openhands/charts/plugin-directory/templates/deployment.yaml
+++ b/charts/openhands/charts/plugin-directory/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: plugin-directory
   labels:
+    {{- include "plugin-directory.labels" . | nindent 4 }}
     app: plugin-directory
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -12,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "plugin-directory.selectorLabels" . | nindent 8 }}
         app: plugin-directory
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/openhands/charts/plugin-directory/templates/service-account.yaml
+++ b/charts/openhands/charts/plugin-directory/templates/service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
+    {{- include "plugin-directory.labels" . | nindent 4 }}
     app: plugin-directory
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/openhands/charts/plugin-directory/templates/service.yaml
+++ b/charts/openhands/charts/plugin-directory/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: plugin-directory
   labels:
+    {{- include "plugin-directory.labels" . | nindent 4 }}
     app: plugin-directory
 spec:
   type: ClusterIP

--- a/charts/openhands/charts/runtime-api/templates/_helpers.tpl
+++ b/charts/openhands/charts/runtime-api/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "runtime-api.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: openhands
 {{- end }}
 
 {{/*

--- a/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
@@ -4,6 +4,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "runtime-api.fullname" . }}-cleanup
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.cleanup.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/charts/openhands/charts/runtime-api/templates/create-db-user-job.yaml
+++ b/charts/openhands/charts/runtime-api/templates/create-db-user-job.yaml
@@ -3,6 +3,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-postgres-user
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-10"

--- a/charts/openhands/charts/runtime-api/templates/hpa.yaml
+++ b/charts/openhands/charts/runtime-api/templates/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "runtime-api.fullname" . }}-hpa
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/openhands/charts/runtime-api/templates/ingress.yaml
+++ b/charts/openhands/charts/runtime-api/templates/ingress.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "runtime-api.fullname" . }}-ingress
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/openhands/charts/runtime-api/templates/monitoring.yaml
+++ b/charts/openhands/charts/runtime-api/templates/monitoring.yaml
@@ -3,6 +3,8 @@ apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
 metadata:
   name: {{ include "runtime-api.fullname" . }}-monitoring
+  labels:
+    {{- include "runtime-api.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/openhands/charts/runtime-api/templates/troubleshoot/secrets.yaml
+++ b/charts/openhands/charts/runtime-api/templates/troubleshoot/secrets.yaml
@@ -5,8 +5,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-preflight
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "runtime-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: troubleshoot
     troubleshoot.sh/kind: preflight
 stringData:
   preflight.yaml: |- {{- include "runtime.troubleshoot.preflights" . | nindent 4 }}
@@ -16,8 +16,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-support-bundle
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "runtime-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: troubleshoot
     troubleshoot.sh/kind: support-bundle
 stringData:
   support-bundle-spec: |- {{- include "runtime.troubleshoot.supportBundle" . | nindent 4 }}

--- a/charts/openhands/charts/runtime-api/tests/labels_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/labels_test.yaml
@@ -1,0 +1,115 @@
+suite: recommended labels
+templates:
+  - templates/cleanup-cronjob.yaml
+  - templates/create-db-user-job.yaml
+  - templates/hpa.yaml
+  - templates/ingress.yaml
+  - templates/monitoring.yaml
+tests:
+  - it: the cleanup CronJob carries the recommended labels
+    template: templates/cleanup-cronjob.yaml
+    set:
+      cleanup.enabled: true
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: runtime-api
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^runtime-api-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+
+  - it: the create-db-user hook Job carries the recommended labels and keeps its hook annotations
+    template: templates/create-db-user-job.yaml
+    set:
+      database.create: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: runtime-api
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^runtime-api-
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+
+  - it: the HPA carries the recommended labels
+    template: templates/hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: runtime-api
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^runtime-api-
+
+  - it: the Ingress carries the recommended labels alongside its annotations
+    template: templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: runtime.example.com
+      ingress.annotations:
+        kubernetes.io/ingress.class: nginx
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: runtime-api
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^runtime-api-
+      - equal:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
+          value: nginx
+
+  - it: the PodMonitoring carries the recommended labels and keeps its pod selector
+    template: templates/monitoring.yaml
+    set:
+      monitoring.enabled: true
+    asserts:
+      - isKind:
+          of: PodMonitoring
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: runtime-api
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^runtime-api-
+      # The scrape selector must keep matching the runtime-api pods.
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: runtime-api
+            app.kubernetes.io/instance: RELEASE-NAME

--- a/charts/openhands/templates/_helpers.tpl
+++ b/charts/openhands/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "image-loader.name" -}}
+{{- define "openhands.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "image-loader.fullname" -}}
+{{- define "openhands.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "image-loader.chart" -}}
+{{- define "openhands.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "image-loader.labels" -}}
-helm.sh/chart: {{ include "image-loader.chart" . }}
-{{ include "image-loader.selectorLabels" . }}
+{{- define "openhands.labels" -}}
+helm.sh/chart: {{ include "openhands.chart" . }}
+{{ include "openhands.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,7 +46,7 @@ app.kubernetes.io/part-of: openhands
 {{/*
 Selector labels
 */}}
-{{- define "image-loader.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "image-loader.name" . }}
+{{- define "openhands.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openhands.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/openhands/templates/budget-maintenance-cronjob.yaml
+++ b/charts/openhands/templates/budget-maintenance-cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-budget-maintenance
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: budget-maintenance
     app: {{ .Release.Name }}-budget-maintenance
 spec:
   schedule: {{ .Values.budgetMaintenance.schedule | quote }}
@@ -18,6 +20,8 @@ spec:
         metadata:
           name: budget-maintenance
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: budget-maintenance
             app: {{ .Release.Name }}-budget-maintenance
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/ca-bundle.yaml
+++ b/charts/openhands/templates/ca-bundle.yaml
@@ -4,6 +4,8 @@ apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
   name: {{ .Values.caBundle.name }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   sources:
     - useDefaultCAs: {{ .Values.caBundle.includeDefaultCAs }}

--- a/charts/openhands/templates/certificate.yaml
+++ b/charts/openhands/templates/certificate.yaml
@@ -4,6 +4,8 @@ kind: Certificate
 metadata:
   name: {{ .Values.certificate.name }}
   namespace: {{ .Values.certificate.namespace }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   {{- if .Values.certificate.commonName }}
   commonName: {{ .Values.certificate.commonName }}

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: openhands
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
     app: openhands
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -13,6 +15,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "openhands.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         app: openhands
       annotations:
         {{- if (include "openhands.keycloakProvisionRealm" .) }}

--- a/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
+++ b/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
@@ -5,6 +5,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 27 }}-enrich-user-interaction
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: enrich-user-interaction
     app: {{ .Release.Name | trunc 27 }}-enrich-user-interaction
 spec:
   schedule: {{ .Values.enrichUserInteractionData.schedule | quote }}
@@ -17,6 +19,8 @@ spec:
       template:
         metadata:
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: enrich-user-interaction
             app: {{ .Release.Name | trunc 27 }}-enrich-user-interaction
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
+++ b/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-install-gitlab-webhooks
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitlab-webhook-install
     app: {{ .Release.Name }}-install-gitlab-webhooks
 spec:
   schedule: {{ .Values.gitlabWebhookInstallation.schedule | quote }}
@@ -16,6 +18,8 @@ spec:
       template:
         metadata:
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: gitlab-webhook-install
             app: {{ .Release.Name }}-install-gitlab-webhooks
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/hpa.yaml
+++ b/charts/openhands/templates/hpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: openhands-hpa
   labels:
     {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/openhands/templates/ingress-agent-canvas.yaml
+++ b/charts/openhands/templates/ingress-agent-canvas.yaml
@@ -14,6 +14,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-agent-canvas-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   {{- with $ingress.annotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-automation.yaml
+++ b/charts/openhands/templates/ingress-automation.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-automation-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.root.annotations }}
     {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-integrations-hub.yaml
+++ b/charts/openhands/templates/ingress-integrations-hub.yaml
@@ -19,6 +19,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-integrations-hub-api-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   {{- with .Values.ingress.integrationsHubApi.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -47,6 +49,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-integrations-hub-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.root.annotations }}
     {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-integrations.yaml
+++ b/charts/openhands/templates/ingress-integrations.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-integrations-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.integrations.annotations }}
     {{ .Values.ingress.integrations.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-laminar-api.yaml
+++ b/charts/openhands/templates/ingress-laminar-api.yaml
@@ -9,6 +9,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: laminar-api-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   {{ with $apiIngress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/openhands/templates/ingress-mcp.yaml
+++ b/charts/openhands/templates/ingress-mcp.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-mcp-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.mcp.annotations }}
     {{ .Values.ingress.mcp.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-plugin-directory.yaml
+++ b/charts/openhands/templates/ingress-plugin-directory.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-plugin-directory-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.root.annotations }}
     {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/ingress-root.yaml
+++ b/charts/openhands/templates/ingress-root.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: openhands-root-ingress
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.root.annotations }}
     {{ .Values.ingress.root.annotations | toYaml | nindent 4 }}

--- a/charts/openhands/templates/integration-events-deployment.yaml
+++ b/charts/openhands/templates/integration-events-deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: openhands-integrations
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: integrations
     app: openhands-integrations
 spec:
   replicas: {{ .Values.integrationEvents.deployment.replicas | default 2 }}
@@ -13,6 +15,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "openhands.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: integrations
         app: openhands-integrations
       annotations:
         {{- if .Values.allowedUsers }}

--- a/charts/openhands/templates/integration-events-service.yaml
+++ b/charts/openhands/templates/integration-events-service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: openhands-integrations-service
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: integrations
     app: openhands-integrations
 spec:
   ports:

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: keycloak-config-script
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 data:
   keycloak-config.sh: |
     #!/bin/sh

--- a/charts/openhands/templates/keycloak-realm-template.yaml
+++ b/charts/openhands/templates/keycloak-realm-template.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: keycloak-realm-template
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 data:
   allhands-realm-github-provider.json.tmpl: |-
 {{ .Files.Get "files/allhands-realm-github-provider.json.tmpl" | indent 4 }}

--- a/charts/openhands/templates/litellm-config-script.yaml
+++ b/charts/openhands/templates/litellm-config-script.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: litellm-config-script
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 data:
   litellm-config.sh: |
     #!/bin/sh

--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-maintenance-tasks
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maintenance-tasks
     app: {{ .Release.Name }}-maintenance-tasks
 spec:
   schedule: {{ .Values.maintenanceTasks.schedule | quote }}
@@ -18,6 +20,8 @@ spec:
         metadata:
           name: maintenance-tasks
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: maintenance-tasks
             app: {{ .Release.Name }}-maintenance-tasks
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/mcp-events-deployment.yaml
+++ b/charts/openhands/templates/mcp-events-deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: openhands-mcp
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
     app: openhands-mcp
 spec:
   replicas: {{ .Values.mcpEvents.deployment.replicas | default 2 }}
@@ -13,6 +15,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "openhands.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp
         app: openhands-mcp
       annotations:
         {{- if .Values.allowedUsers }}

--- a/charts/openhands/templates/mcp-events-service.yaml
+++ b/charts/openhands/templates/mcp-events-service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: openhands-mcp-service
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
     app: openhands-mcp
 spec:
   ports:

--- a/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
+++ b/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-proactive-convo-clean
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proactive-convo-clean
     app: {{ .Release.Name }}-proactive-convo-clean
 spec:
   schedule: {{ .Values.proactiveConvoClean.schedule | quote }}
@@ -16,6 +18,8 @@ spec:
       template:
         metadata:
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: proactive-convo-clean
             app: {{ .Release.Name }}-proactive-convo-clean
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/resend-sync-cronjob.yaml
+++ b/charts/openhands/templates/resend-sync-cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-resend-sync
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: resend-sync
     app: {{ .Release.Name }}-resend-sync
 spec:
   schedule: {{ .Values.resendSync.schedule | quote }}
@@ -16,6 +18,8 @@ spec:
       template:
         metadata:
           labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: resend-sync
             app: {{ .Release.Name }}-resend-sync
         spec:
           {{- with .Values.securityContext }}

--- a/charts/openhands/templates/service-account.yaml
+++ b/charts/openhands/templates/service-account.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.serviceAccount.annotations }}
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/openhands/templates/service.yaml
+++ b/charts/openhands/templates/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: openhands-service
   labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
     app: openhands
 spec:
   ports:
@@ -21,6 +23,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: oh-main-runtime-api
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -38,6 +42,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: oh-main-postgresql
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   sessionAffinity: None
@@ -57,6 +63,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: oh-main-lite-llm
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   internalTrafficPolicy: Cluster

--- a/charts/openhands/templates/tlsstore.yaml
+++ b/charts/openhands/templates/tlsstore.yaml
@@ -3,6 +3,8 @@ apiVersion: traefik.io/v1alpha1
 kind: TLSStore
 metadata:
   name: {{ .Values.tlsStore.name }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 spec:
   defaultCertificate:
     secretName: {{ .Values.tlsStore.secretName }}

--- a/charts/openhands/templates/troubleshoot/secrets.yaml
+++ b/charts/openhands/templates/troubleshoot/secrets.yaml
@@ -5,8 +5,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-preflight
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: troubleshoot
     troubleshoot.sh/kind: preflight
 stringData:
   preflight.yaml: |- {{- include "troubleshoot.preflights" . | nindent 4 }}
@@ -16,8 +16,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-support-bundle
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: troubleshoot
     troubleshoot.sh/kind: support-bundle
 stringData:
   support-bundle-spec: |- {{- include "troubleshoot.supportBundle" . | nindent 4 }}

--- a/charts/openhands/templates/user-waitlist-configmap.yaml
+++ b/charts/openhands/templates/user-waitlist-configmap.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: user-waitlist
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
 data:
   user-waitlist.txt: |
     {{- range .Values.allowedUsers }}

--- a/charts/openhands/tests/labels_test.yaml
+++ b/charts/openhands/tests/labels_test.yaml
@@ -1,18 +1,18 @@
 suite: recommended labels
-# deployment.yaml can't be rendered in isolation by helm-unittest: it
-# unconditionally `include`s litellm-config-script.yaml for a checksum annotation,
-# and cross-template includes of sibling resources don't resolve here. The main
-# server Deployment shares the openhands.labels / selectorLabels helpers with
-# mcp-events-deployment.yaml, which renders standalone, so it stands in for the
-# Deployment label assertions. The server component is covered via the Service.
+# deployment.yaml checksums litellm-config-script.yaml into a pod annotation via a
+# cross-template include, so that template is listed here to make the include
+# resolvable. Each test sets `template:` to scope its assertions to one template.
 templates:
-  - mcp-events-deployment.yaml
+  - deployment.yaml
+  - litellm-config-script.yaml
   - service.yaml
 tests:
-  - it: a main-chart Deployment carries the recommended labels and keeps its app selector
-    template: mcp-events-deployment.yaml
+  - it: the openhands Deployment carries the recommended labels and keeps its app selector
+    template: deployment.yaml
     set:
       enabled: true
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
     asserts:
       - hasDocuments:
           count: 1
@@ -30,7 +30,7 @@ tests:
           value: openhands
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
-          value: mcp
+          value: server
       - matchRegex:
           path: metadata.labels["helm.sh/chart"]
           pattern: ^openhands-
@@ -42,15 +42,15 @@ tests:
           value: openhands
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]
-          value: mcp
+          value: server
       - equal:
           path: spec.template.metadata.labels.app
-          value: openhands-mcp
+          value: openhands
       # The selector is intentionally left on the legacy app label: spec.selector is
       # immutable, so changing it would break in-place upgrades.
       - equal:
           path: spec.selector.matchLabels.app
-          value: openhands-mcp
+          value: openhands
       - notExists:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
 

--- a/charts/openhands/tests/labels_test.yaml
+++ b/charts/openhands/tests/labels_test.yaml
@@ -1,0 +1,83 @@
+suite: recommended labels
+# deployment.yaml can't be rendered in isolation by helm-unittest: it
+# unconditionally `include`s litellm-config-script.yaml for a checksum annotation,
+# and cross-template includes of sibling resources don't resolve here. The main
+# server Deployment shares the openhands.labels / selectorLabels helpers with
+# mcp-events-deployment.yaml, which renders standalone, so it stands in for the
+# Deployment label assertions. The server component is covered via the Service.
+templates:
+  - mcp-events-deployment.yaml
+  - service.yaml
+tests:
+  - it: a main-chart Deployment carries the recommended labels and keeps its app selector
+    template: mcp-events-deployment.yaml
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: mcp
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+      # Pod template carries the recommended labels alongside the retained app label.
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: mcp
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: openhands-mcp
+      # The selector is intentionally left on the legacy app label: spec.selector is
+      # immutable, so changing it would break in-place upgrades.
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: openhands-mcp
+      - notExists:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+
+  - it: the openhands Service carries the recommended labels and keeps its app selector
+    template: service.yaml
+    set:
+      enabled: true
+      postgresql.enabled: false
+      runtime-api.enabled: false
+      litellm-helm.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: server
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels.app
+          value: openhands
+      - equal:
+          path: spec.selector.app
+          value: openhands
+      - notExists:
+          path: spec.selector["app.kubernetes.io/name"]

--- a/charts/openhands/tests/labels_test.yaml
+++ b/charts/openhands/tests/labels_test.yaml
@@ -1,11 +1,17 @@
 suite: recommended labels
-# deployment.yaml checksums litellm-config-script.yaml into a pod annotation via a
-# cross-template include, so that template is listed here to make the include
-# resolvable. Each test sets `template:` to scope its assertions to one template.
+# Some templates pull in others via a cross-template include, so those have to be
+# listed here to make the include resolvable: deployment.yaml checksums
+# litellm-config-script.yaml into a pod annotation, and troubleshoot/secrets.yaml
+# embeds the preflight and support-bundle specs. Each test sets `template:` to
+# scope its assertions to one template.
 templates:
+  - budget-maintenance-cronjob.yaml
   - deployment.yaml
   - litellm-config-script.yaml
   - service.yaml
+  - troubleshoot/preflights.yaml
+  - troubleshoot/secrets.yaml
+  - troubleshoot/support-bundle.yaml
 tests:
   - it: the openhands Deployment carries the recommended labels and keeps its app selector
     template: deployment.yaml
@@ -81,3 +87,72 @@ tests:
           value: openhands
       - notExists:
           path: spec.selector["app.kubernetes.io/name"]
+
+  - it: the budget maintenance CronJob carries the recommended labels and keeps its app label
+    template: budget-maintenance-cronjob.yaml
+    set:
+      enabled: true
+      budgetMaintenance.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: budget-maintenance
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+      - equal:
+          path: metadata.labels.app
+          value: RELEASE-NAME-budget-maintenance
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: budget-maintenance
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.app
+          value: RELEASE-NAME-budget-maintenance
+
+  - it: the troubleshoot Secrets carry the recommended labels and keep their troubleshoot.sh/kind
+    template: troubleshoot/secrets.yaml
+    set:
+      enabled: true
+      replicated.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: troubleshoot
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+      # KOTS discovers these specs by troubleshoot.sh/kind, so that label is load-bearing.
+      - matchRegex:
+          path: metadata.labels["troubleshoot.sh/kind"]
+          pattern: ^(preflight|support-bundle)$


### PR DESCRIPTION
## Description

Our chart resources carried a single generic `app:` label. This adopts the kubernetes [recommended label set](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) (`app.kubernetes.io/name`, `/instance`, `/version`, `/component`, `/part-of`, `/managed-by`, plus `helm.sh/chart`) on every resource the charts create, so standard tooling can identify and group them - monitoring relabeling, cost allocation, `kubectl -l` selectors, argocd grouping.

The change is deliberately additive. Every existing `app:` label and every Deployment and Service selector is left exactly as it was.

A Deployment's `spec.selector` is immutable, so changing it would fail an in-place `helm upgrade` (and the KOTS update path) with a "field is immutable" error. Pods now carry both label sets, and the recommended labels sit alongside the frozen `app:` selectors. Moving the selectors themselves onto the recommended labels would force a recreate of every workload, so I've left that as a separate, more invasive change.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Scope is the `openhands` umbrella and its subcharts (`agent-canvas`, `automation`, `integrations-hub`, `plugin-directory`), plus `runtime-api` and `image-loader`, which already used the recommended labels and now also get `part-of`. `openhands-secrets` is secrets-only and `crd-check` is a hook library, so neither was in scope. No `values.yaml` changed and no new or required values were introduced.

Five charts had no `_helpers.tpl`. I added one to each, modeled on the existing `runtime-api` convention, defining the standard `name`/`fullname`/`chart`/`labels`/`selectorLabels` helpers.

Bonus fix: `hpa.yaml` referenced an `openhands.labels` helper that was never defined, so rendering the HPA (with `autoscaling.enabled`) would have failed. Defining the helper fixes that.