### PR TITLE
fix(chart): sync openhands appVersion to cloud-1.47.1

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.47.0
+appVersion: cloud-1.47.1
 version: 0.31.0
 dependencies:
   - name: keycloak


### PR DESCRIPTION
## Why

The `openhands` chart CI check flagged an `appVersion`/`image.tag` drift on [#780](https://github.com/OpenHands/OpenHands-Cloud/pull/780#issuecomment-5073013230), but the drift is on `main` itself, not that branch — `#780` merely inherited it.

| Location | Before | After |
| --- | --- | --- |
| `charts/openhands/Chart.yaml` → `appVersion` | `cloud-1.47.0` | `cloud-1.47.1` |
| `charts/openhands/values.yaml` → `image.tag` | `cloud-1.47.1` | `cloud-1.47.1` (unchanged) |

Bumps `appVersion` to match the deployed `image.tag` so the two stay in sync.

## Validation

- Confirmed via the GitHub API that `main` has `image.tag: cloud-1.47.1` and `appVersion: cloud-1.47.0` (the drift).
- Change is a single-line `appVersion` bump; the appversion-drift CI notice should clear once this merges.