### PR TITLE
fix(integrations-hub): derive public base URL

### DIFF
--- a/charts/openhands/charts/integrations-hub/templates/_env.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/_env.yaml
@@ -18,10 +18,10 @@
     INTHUB_STATIC_DIR                set in the Dockerfile to /app/out
     INTHUB_ROOT_PATH                 sub-path mount from .Values.rootPath
     INTHUB_API_ROOT_PATH             public API prefix from .Values.apiRootPath
+    INTHUB_PUBLIC_BASE_URL           externally visible Hub site URL
 
   In addition, backend/app/oauth_flow.py reads:
     INTHUB_OAUTH_REDIRECT_PROXY_URL  stable origin for OAuth callback proxy
-    AUTH_URL                         preview-deployment callback target
 */}}
 {{- define "integrations-hub.env.defaults" }}
 # Database connection -- backend reads INTHUB_POSTGRES_URL first; we build
@@ -84,6 +84,10 @@
   value: {{ .Values.rootPath | default "" | quote }}
 - name: INTHUB_API_ROOT_PATH
   value: {{ .Values.apiRootPath | default "" | quote }}
+{{- if .Values.service.baseUrl }}
+- name: INTHUB_PUBLIC_BASE_URL
+  value: {{ tpl .Values.service.baseUrl . | quote }}
+{{- end }}
 
 # Credential encryption key (required: signs/encrypts stored OAuth tokens
 # and other provider secrets at rest).
@@ -125,10 +129,6 @@
 {{- if .Values.openhands.redirectProxyUrl }}
 - name: INTHUB_OAUTH_REDIRECT_PROXY_URL
   value: {{ .Values.openhands.redirectProxyUrl | quote }}
-{{- end }}
-{{- if $openhandsBaseUrl }}
-- name: AUTH_URL
-  value: {{ $openhandsBaseUrl | quote }}
 {{- end }}
 
 {{- if .Values.datadog.enabled }}

--- a/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
+++ b/charts/openhands/charts/integrations-hub/tests/deployment_paths_test.yaml
@@ -6,6 +6,7 @@ tests:
     set:
       rootPath: /integrations-hub
       apiRootPath: /api/integrations-hub
+      service.baseUrl: https://pr-252.staging.all-hands.dev/integrations-hub
       openhands.baseUrl: https://pr-252.staging.all-hands.dev
       openhands.redirectProxyUrl: https://staging.all-hands.dev
       database.url: postgresql://example
@@ -31,5 +32,33 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: INTHUB_PUBLIC_BASE_URL
+            value: https://pr-252.staging.all-hands.dev/integrations-hub
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTHUB_OAUTH_REDIRECT_PROXY_URL
+            value: https://staging.all-hands.dev
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: AUTH_URL
             value: https://pr-252.staging.all-hands.dev
+  - it: allows an explicit public base URL environment override
+    set:
+      service.baseUrl: https://derived.example.com/integrations-hub
+      env.INTHUB_PUBLIC_BASE_URL: https://override.example.com/integrations-hub
+      database.url: postgresql://example
+      credentialEncryption.secretName: encryption
+      cron.secretName: cron
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTHUB_PUBLIC_BASE_URL
+            value: https://override.example.com/integrations-hub
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTHUB_PUBLIC_BASE_URL
+            value: https://derived.example.com/integrations-hub

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -46,6 +46,9 @@ probes:
 
 # Service configuration
 service:
+  # Externally visible Integrations Hub site URL, including rootPath.
+  # Rendered as INTHUB_PUBLIC_BASE_URL for OAuth callback construction.
+  baseUrl: ""
   # Port the container listens on (8000 for Python/FastAPI backend)
   port: 8000
 
@@ -75,7 +78,7 @@ openhands:
   authCookieName: "keycloak_auth"
   # Stable-origin URL used as the OAuth callback proxy for preview
   # deployments. Leave empty to register callbacks against the
-  # request host directly.
+  # configured service.baseUrl origin directly.
   # Backend env var: INTHUB_OAUTH_REDIRECT_PROXY_URL
   redirectProxyUrl: ""
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1239,6 +1239,9 @@ integrations-hub:
 
   # Service configuration
   service:
+    # Externally visible Integrations Hub site URL, including rootPath.
+    # Rendered as INTHUB_PUBLIC_BASE_URL for OAuth callback construction.
+    baseUrl: ""
     # Port the FastAPI container listens on (matches the integrations-hub
     # Dockerfile's `EXPOSE 8000` on the development branch).
     port: 8000


### PR DESCRIPTION
## Summary

- render `INTHUB_PUBLIC_BASE_URL` from the existing `integrations-hub.service.baseUrl` chart value
- stop treating `openhands.baseUrl` / `AUTH_URL` as the Hub OAuth callback-site configuration
- retain `INTHUB_OAUTH_REDIRECT_PROXY_URL` as the separate stable callback origin for feature previews
- preserve explicit `env.INTHUB_PUBLIC_BASE_URL` overrides through the existing environment deduplication helper
- document `service.baseUrl` in both the embedded subchart and umbrella values

## Why

`openhands.baseUrl` identifies the OpenHands service used for session validation. It is not the Integrations Hub's externally visible site URL. SaaS dev, staging, and feature-preview values already provide the correct Hub URL in `integrations-hub.service.baseUrl`, including `/integrations-hub`; the chart simply was not passing it to the container.

This is the deployment companion to OpenHands/integrations-hub#394. That application PR must land before this chart is released because older Hub images only understand `AUTH_URL`.

## Impact

- Dev derives `https://dev.all-hands.dev/integrations-hub` from its existing values.
- Staging derives `https://staging.all-hands.dev/integrations-hub` and retains the stable staging callback proxy.
- Feature previews derive their PR-specific Hub URL from the ApplicationSet and retain the stable staging proxy.
- No `saas-deploy` values change is required.

## Validation

- `helm unittest charts/openhands/charts/integrations-hub` (2 tests)
- `helm unittest charts/openhands` (26 tests)
- rendered the embedded chart with the dev `service.baseUrl` and confirmed `INTHUB_PUBLIC_BASE_URL` is emitted while `AUTH_URL` is absent
- `git diff --check`

Closes #962
