### PR TITLE
fix: increase Replicated MinIO resource headroom

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -420,6 +420,13 @@ spec:
     minio:
       persistence:
         enabled: true
+      resources:
+        requests:
+          cpu: "1"
+          memory: 512Mi
+        limits:
+          cpu: "2"
+          memory: 2Gi
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/minio/minio'
       imagePullSecrets:


### PR DESCRIPTION
## Description

Increase the resources assigned to the persistent MinIO instance bundled with
Replicated OHE installs:

- CPU request: `100m` → `1`
- CPU limit: `100m` → `2`
- Memory request: `100Mi` → `512Mi`
- Memory limit: `512Mi` → `2Gi`

The override is scoped to `replicated/openhands.yaml`. It does not change the
generic Helm chart defaults or SaaS deployment values.

## Root cause

The generic chart gives bundled MinIO a hard `100m` CPU limit. Replicated
enables that MinIO instance with persistent storage for the OHE filestore, so
moderate concurrent file activity exhausts the CFS quota even when the node
has spare CPU. Requests then queue behind throttled MinIO work and individual
S3 operations reach roughly two seconds.

## Controlled OHE validation

Validated on the R02 Replicated test instance running OHE 0.28.0. The workload
ran inside the `openhands` pod using its real S3 endpoint, credentials, and
`openhands-sessions` bucket.

Each run used:

- 400 objects at 256 KiB each
- 32 concurrent workers
- PUT, GET (including body consumption), and DELETE per object
- 1,200 total S3 operations
- the same application build and database configuration

| Metric | Shipped default | Fixed run 1 | Fixed run 2 | Restored default |
|---|---:|---:|---:|---:|
| Completed / errors | 400 / 0 | 400 / 0 | 400 / 0 | 400 / 0 |
| Throughput | 22.35 obj/s | 193.43 obj/s | 205.95 obj/s | 21.66 obj/s |
| Wall time | 17.90s | 2.07s | 1.94s | 18.46s |
| PUT p95 | 1.623s | 0.144s | 0.138s | 1.401s |
| GET p95 | 0.906s | 0.076s | 0.076s | 0.897s |
| DELETE p95 | 0.701s | 0.049s | 0.031s | 0.717s |
| CPU periods throttled | 179 / 197 | 0 / 32 | 0 / 26 | 186 / 194 |

The fixed profile increased throughput by 8.7–9.2x and reduced PUT p95 by
approximately 91%. Restoring the shipped resource profile immediately
restored the slowdown and 95.9% CPU-period throttling.

### CPU-only isolation

A separate run kept the shipped memory values while changing only CPU to the
proposed `1` request and `2` limit:

- 210.36 objects/s
- 1.90s wall time
- 0.129s PUT p95
- zero CPU throttling
- zero memory-pressure or OOM events

This identifies the CPU quota as the required correction. The memory increase
supplies conservative production headroom: MinIO idled around 176–180Mi
despite a 100Mi request, and the shipped-profile burst peaked around 370Mi
against a 512Mi hard limit.

### End-to-end verification

With the fixed profile active, the Replicated verification helper:

- loaded the authenticated OHE home screen;
- created a fresh conversation;
- sent the verification prompt;
- received an agent response;
- completed with exit code 0.

### Cleanup

After validation:

- R02 was restored to the shipped `100m/100m` CPU and `100Mi/512Mi` memory
  profile;
- the MinIO deployment was fully ready with zero restarts after the final
  rollout;
- the test object prefix contained zero remaining objects;
- recent MinIO logs contained no error, panic, fatal, or OOM messages;
- the application returned HTTP 200.

## Checks

- `make lint` — passed; Replicated lint reported only pre-existing
  informational/warning findings.
- `git diff --check` — passed.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
  - The exact deployment resource change and rollback were tested on R02, but
    a packaged KOTS release upgrade has not been run.
- [x] I have verified backwards compatibility with existing values.yaml
  configurations
- [x] I have updated the chart's README.md if there are any breaking changes
  or new required values
  - No breaking change or new required value is introduced.

## Additional Notes

- This changes only Replicated OHE values. Production, staging, and
  development SaaS use external object storage rather than bundled MinIO.
- No application image, database migration, or new administrator
  configuration is required.
