### PR TITLE
fix: allow auth-flow email verification redirect

### DIFF
--- a/charts/openhands/files/allhands-realm-github-provider.json.tmpl
+++ b/charts/openhands/files/allhands-realm-github-provider.json.tmpl
@@ -723,6 +723,7 @@
         "https://$WEB_HOST/slack/keycloak-callback",
         "https://$WEB_HOST/oauth/device/keycloak-callback",
         "https://$WEB_HOST/api/email/verified",
+        "https://$WEB_HOST/login?email_verified=true",
         "https://$WEB_HOST/plugins/auth/callback",
         "/realms/$KEYCLOAK_REALM_NAME/$KEYCLOAK_CLIENT_ID/*",
         "https://$LAMINAR_WEB_HOST/api/auth/callback/keycloak",

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -60,6 +60,19 @@ def test_realm_template_is_valid_json() -> None:
     json.loads(REALM_TEMPLATE.read_text(encoding="utf-8"))
 
 
+def test_realm_template_allows_auth_flow_email_verification_redirect() -> None:
+    realm = json.loads(REALM_TEMPLATE.read_text(encoding="utf-8"))
+    client = next(
+        client
+        for client in realm["clients"]
+        if client["clientId"] == "$KEYCLOAK_CLIENT_ID"
+    )
+
+    assert (
+        "https://$WEB_HOST/login?email_verified=true" in client["redirectUris"]
+    )
+
+
 def test_pkce_enabled_identity_providers_set_pkce_method() -> None:
     realm = json.loads(REALM_TEMPLATE.read_text(encoding="utf-8"))
     assert_pkce_enabled_providers_set_method(realm)


### PR DESCRIPTION
## Description

OHE's auth flow sends verification emails with
`https://<WEB_HOST>/login?email_verified=true` as the post-verification
redirect, but the bundled Keycloak client's valid redirect list only allowed
`/api/email/verified`. Keycloak therefore rejected the auth-flow request with
`400 Invalid redirect uri`, leaving users unable to complete verification
after an email change.

This adds the exact auth-flow URI to the bundled Keycloak client and a template
invariant test to prevent it from being removed. The exact URI keeps the
allowlist narrower than a `/login*` wildcard.

Existing installs are covered because the Keycloak configuration job upserts
the client definition when the chart is deployed.

## Validation

- `uv run --with pytest --with requests --with PyGithub --with fastapi --with uvicorn --with httpx --with ruamel.yaml python -m pytest scripts -q`
  - `441 passed`
- `helm lint charts/openhands`
  - `1 chart(s) linted, 0 chart(s) failed`
- Realm template JSON parsing and `git diff --check` passed.
- Reproduced and verified against a live OHE/Keycloak deployment on R01 using
  a disposable Keycloak user and an in-cluster SMTP sink:
  - Before: the application-generated redirect returned `baseline_rc=1` and
    `Invalid redirect uri.`
  - After adding the exact URI: the same `send-verify-email` request returned
    `after_rc=0`.
  - Cleanup proof: `redirect_count=0`, `smtp_restored=empty`,
    `matching_temp_users=0`, and `matching_temp_resources=0`.

## Helm Chart Checklist

- [ ] I have tested the packaged chart upgrade path from the previous version.
  The live client update behavior was validated directly; a branch release was
  not packaged for this one-line allowlist change.
- [x] I have verified backwards compatibility with existing `values.yaml`
  configurations.
- [x] No README update is needed because this adds no values or operator-facing
  configuration.

## Additional Notes

The change only expands the OHE Keycloak redirect allowlist for the URI already
generated by the application; it does not change the application auth flow or
SaaS behavior.
