### PR TITLE
feat: bump enterprise-server to cloud-1.48.0 and automation to 1.4.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.48.0
+appVersion: 1.48.0
 version: 0.31.0
 dependencies:
   - name: keycloak

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
-appVersion: cloud-1.47.1
+appVersion: cloud-1.48.0
 version: 0.31.0
 dependencies:
   - name: keycloak

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: ghcr.io/openhands/automation
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: 1.1.5
+  tag: 1.4.0
 
 imagePullSecrets: []
 

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.47.1
+  tag: cloud-1.48.0
 
 autoscaling:
   enabled: false

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: ghcr.io/openhands/enterprise-server
   # You must use a stable, semver tag. Do not use sha-based tags.
   # If you are hotfixing, you MUST create a patch release and use the semver tag.
-  tag: cloud-1.48.0
+  tag: 1.48.0
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Description

Routine image tag bump: enterprise-server to `cloud-1.48.0` and automation to `1.4.0`.

The chart's `appVersion` moves with the enterprise-server tag so the two stay in sync.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Values-only change, no template or schema edits.
