### PR TITLE
fix(integrations-hub): default admin.emails to empty

### DIFF
--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -99,8 +99,10 @@ auth:
 # Admin configuration
 # Backend env var: INTHUB_APP_ADMIN_EMAILS (comma-separated; JSON array also accepted)
 admin:
-  # Comma-separated list of admin email addresses.
-  emails: "chuck@openhands.dev,chuck@all-hands.dev,graham@openhands.dev,graham@all-hands.dev"
+  # Comma-separated list of admin email addresses. Leave empty (the default)
+  # so that installs which do not opt in get no admins. Customers must set
+  # this explicitly to grant anyone access to /api/admin/* routes.
+  emails: ""
 
 # PostgreSQL database configuration
 # The backend expects a single URL via INTHUB_POSTGRES_URL. The chart


### PR DESCRIPTION
## Description

The `integrations-hub` subchart previously shipped with a hard-coded list of admin email addresses as the default value of `admin.emails`. As a result, any customer installing the chart — either the subchart directly or the parent `openhands` chart without overriding that field — would grant those addresses admin access to `/api/admin/*` routes without opting in.

This change sets the subchart default for `admin.emails` to `""`. The wiring at `templates/_env.yaml` already gates the `INTHUB_APP_ADMIN_EMAILS` env var on a non-empty value, and the backend treats an unset/empty allowlist as no admins.

The parent chart (`charts/openhands/values.yaml`) was already overriding this to `""`, so existing customer-facing installs via the parent chart are unaffected. The behavior change only affects installs that were relying on the subchart's previous hard-coded default — those now correctly require an explicit opt-in.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

Notes on the checklist:
- *Upgrade path:* not exercised locally in this environment; any internal install that was relying on the previous hard-coded default will need to set `integrations-hub.admin.emails` explicitly going forward. The parent chart already does this (`charts/openhands/values.yaml` overrides to `""`), so no internal install changes are required.
- *Backwards compatibility:* preserved for any install that explicitly sets `admin.emails` (the override still wins). The only behavior change is for installs relying on the prior hard-coded default, which is the bug being fixed.
- *README:* the subchart has no README.md, so no documentation update is required.

## Additional Notes

- AI-assisted change: this PR was prepared with help from an OpenHands agent on behalf of the author.
- The branch's working tree also contains unrelated edits to `charts/infra/Chart.lock` and `charts/openhands/Chart.lock` (local `file://../crd-check` overrides from a local helm dependency update). Those are intentionally not included in this PR.