### PR TITLE
fix(budget-maintenance): disable the budget maintenance cronjob by default

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -772,7 +772,8 @@ maintenanceTasks:
       cpu: "500m"
 
 budgetMaintenance:
-  enabled: true
+  # Disabled until https://github.com/OpenHands/enterprise/pull/80 ships.
+  enabled: false
   schedule: "*/15 * * * *" # Run every 15 minutes
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Description

The budget maintenance cronjob shipped enabled by default, and it needs a fix that's still in flight over in the enterprise repo: https://github.com/OpenHands/enterprise/pull/80

This flips the default to `false` so nobody runs it until that lands. The values comment points at the PR so it's clear when the default can go back to `true`.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Anyone who already sets `budgetMaintenance.enabled` explicitly is unaffected.