### PR TITLE
feat(openhands): PLTF-1247 note when values still set the removed redis key

### DIFF
--- a/charts/openhands/templates/NOTES.txt
+++ b/charts/openhands/templates/NOTES.txt
@@ -36,3 +36,22 @@ Next steps:
 
 Docs: https://docs.all-hands.dev
 {{- end }}
+{{- if .Values.redis }}
+
+WARNING: your values still set `redis:`, which this chart no longer reads.
+
+    The cache is now the Valkey subchart, configured under `valkey:`. Helm
+    accepts the unused `redis:` block silently, so the cache is currently
+    running on chart defaults and any sizing you set under `redis:` is NOT
+    being applied.
+
+    Translate the keys you set, then remove the `redis:` block:
+
+        redis.enabled                     -> valkey.enabled
+        redis.master.resources            -> valkey.resources
+        redis.master.persistence.enabled  -> valkey.dataStorage.enabled
+        redis.replica.replicaCount: 0     -> valkey.replica.enabled: false
+        redis.auth.existingSecret         -> valkey.auth.usersExistingSecret
+
+    The `redis` Secret itself is unchanged; keep it as it is.
+{{- end }}

--- a/charts/openhands/tests/notes_test.yaml
+++ b/charts/openhands/tests/notes_test.yaml
@@ -25,3 +25,19 @@ tests:
     asserts:
       - matchRegexRaw:
           pattern: "was not deployed by this release"
+  - it: warns when values still set the removed redis key
+    set:
+      enabled: true
+      redis.master.resources.requests.cpu: 500m
+    asserts:
+      - matchRegexRaw:
+          pattern: "WARNING: your values still set .redis:."
+      - matchRegexRaw:
+          pattern: "redis.master.resources            -> valkey.resources"
+  - it: stays quiet when values do not set redis
+    set:
+      enabled: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "WARNING: your values still set"
+


### PR DESCRIPTION
## Why

An operator whose values still set `redis:` gets the cache on chart defaults, because Helm accepts the unused block without complaint. That is a silent downgrade of whatever sizing they had configured, and it only surfaces later as an undersized cache.

This prints a note after `helm install` and `helm upgrade`. It does not guard the render: the template still succeeds, because the cache does run and only its sizing is wrong, so blocking an otherwise healthy upgrade would be disproportionate. The note names the key mapping and states that the `redis` Secret is unchanged, so nobody rotates a credential they do not need to.

Worth knowing where this does and does not reach. Notes are printed by the Helm CLI, so this covers operators running `helm upgrade` themselves, which is where an untranslated values file is most likely. GitOps and KOTS deploys never render notes, so they are not covered by this and need their values translated directly.

## Validation

- **Asserted in both directions** — the notes suite compiles `NOTES.txt` and checks the note appears when values set a `redis:` key and is absent when they do not.

_This PR was drafted by an AI agent on behalf of the user._
