### PR TITLE
feat(openhands): PLTF-1247 fail the render when values still set the removed redis key

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -12,3 +12,11 @@ are never rendered, so a server-less release must not trip them.
 {{- if and .Values.enabled (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
 {{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
 {{- end -}}
+{{/*
+Not scoped to .Values.enabled: the cache subchart installs independently of the
+enterprise-server, so a server-less release with stale cache values is still
+misconfigured.
+*/}}
+{{- if .Values.redis -}}
+{{- fail "values set `redis:`, which this chart no longer reads. The cache is the valkey subchart, configured under `valkey:`, and an unused `redis:` block is silently ignored, so any sizing set under it is NOT applied. Translate the keys you set, then delete the `redis:` block: redis.enabled -> valkey.enabled; redis.master.resources -> valkey.resources; redis.master.persistence.enabled -> valkey.dataStorage.enabled; redis.replica.replicaCount: 0 -> valkey.replica.enabled: false; redis.auth.existingSecret -> valkey.auth.usersExistingSecret. The `redis` Secret itself is unchanged; keep it as it is." -}}
+{{- end -}}

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -45,3 +45,24 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: fails when values still set the removed redis key
+    set:
+      redis.master.resources.requests.cpu: 500m
+    asserts:
+      - failedTemplate:
+          errorMessage: "values set `redis:`, which this chart no longer reads. The cache is the valkey subchart, configured under `valkey:`, and an unused `redis:` block is silently ignored, so any sizing set under it is NOT applied. Translate the keys you set, then delete the `redis:` block: redis.enabled -> valkey.enabled; redis.master.resources -> valkey.resources; redis.master.persistence.enabled -> valkey.dataStorage.enabled; redis.replica.replicaCount: 0 -> valkey.replica.enabled: false; redis.auth.existingSecret -> valkey.auth.usersExistingSecret. The `redis` Secret itself is unchanged; keep it as it is."
+  - it: fails on a stale redis block even when the server is not deployed
+    set:
+      enabled: false
+      redis.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "values set `redis:`, which this chart no longer reads. The cache is the valkey subchart, configured under `valkey:`, and an unused `redis:` block is silently ignored, so any sizing set under it is NOT applied. Translate the keys you set, then delete the `redis:` block: redis.enabled -> valkey.enabled; redis.master.resources -> valkey.resources; redis.master.persistence.enabled -> valkey.dataStorage.enabled; redis.replica.replicaCount: 0 -> valkey.replica.enabled: false; redis.auth.existingSecret -> valkey.auth.usersExistingSecret. The `redis` Secret itself is unchanged; keep it as it is."
+  - it: renders when values use the valkey key instead
+    set:
+      valkey.enabled: true
+      valkey.resources.requests.cpu: 500m
+    asserts:
+      - hasDocuments:
+          count: 0
+


### PR DESCRIPTION
## Why

Helm accepts a `redis:` block this chart no longer reads and silently ignores it, so an operator who does not translate their cache values keeps running on chart defaults with no signal that their sizing was dropped. This fails the render instead, with the key mapping in the failure message so the fix is immediate, and a note that the `redis` Secret is unchanged so nobody rotates a credential needlessly.

The guard is deliberately not scoped to `.Values.enabled`, unlike the two above it. The cache subchart installs independently of the enterprise-server, so a server-less release with stale cache values is still misconfigured.

**Merge only after every consumer's `redis:` block is gone, or their deploys break.** All four internal SaaS environments still set `redis:`, and the values changes for feature, staging and production deliberately keep it so they stay safe to merge in any order relative to the chart bump. Removing those blocks is a follow-up after the bump lands, and it is the real prerequisite here. Development is already a clean rename and would pass.

## Validation

- **Both directions asserted, plus the server-less case** — the guard fails with the mapping when values set a `redis:` key, fails too when `enabled: false` (proving it is not scoped to the server), and a default render still succeeds, so the guard does not trip on the chart's own values.
- **Checked the four internal SaaS environments as they stand** — every one currently sets `redis:` and would be blocked, which is the basis for the merge-order note above.

_This PR was drafted by an AI agent on behalf of the user._
