### PR TITLE
fix(minio): PLTF-1250 stop the bundled bucket job purging data on every upgrade

### DIFF
--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -12,3 +12,20 @@ are never rendered, so a server-less release must not trip them.
 {{- if and .Values.enabled (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
 {{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
 {{- end -}}
+{{/*
+Data-loss guard for the bundled MinIO. Its chart runs the bucket job on
+post-install AND post-upgrade, and purge: true makes that job delete the bucket
+contents before recreating it — so with purge on, every ordinary upgrade of a
+persistent install destroys the conversation and session files. Deliberately NOT
+scoped to .Values.enabled: the bundled store is shared with runtime-api and
+automation, so the data is at risk even in a server-less release. Scoped instead
+to filestore.ephemeral, which is what deploys the bundled store at all, so
+external-S3/GCS releases are unaffected by whatever sits in .Values.minio.
+*/}}
+{{- if .Values.filestore.ephemeral -}}
+{{- range .Values.minio.buckets -}}
+{{- if .purge -}}
+{{- fail (printf "minio.buckets entry %q sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data." .name) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -45,3 +45,61 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  # The bundled MinIO bucket job runs on post-upgrade too, so purge: true wipes
+  # conversation and session data on every ordinary upgrade of a persistent
+  # install. These cases pin the guard that rejects it.
+  - it: fails when the bundled MinIO bucket sets purge true
+    set:
+      filestore.ephemeral: true
+      minio.buckets:
+        - name: openhands-sessions
+          policy: none
+          purge: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'minio.buckets entry "openhands-sessions" sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data.'
+  - it: fails on a purging bucket even when the enterprise-server is disabled
+    # runtime-api and automation share the bundled store, so the data is at risk
+    # regardless of whether this release runs the server.
+    set:
+      enabled: false
+      filestore.ephemeral: true
+      minio.buckets:
+        - name: openhands-sessions
+          policy: none
+          purge: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'minio.buckets entry "openhands-sessions" sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data.'
+  - it: fails on any purging bucket, not just the first
+    set:
+      filestore.ephemeral: true
+      minio.buckets:
+        - name: openhands-sessions
+          policy: none
+          purge: false
+        - name: scratch
+          policy: none
+          purge: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'minio.buckets entry "scratch" sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data.'
+  - it: allows the bundled MinIO with the shipped purge false default
+    set:
+      filestore.ephemeral: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: ignores minio values entirely for external-store releases
+    # ephemeral: false never renders the minio dependency, so leftover values
+    # must not block an external-S3 or GCS install.
+    set:
+      filestore.ephemeral: false
+      minio.buckets:
+        - name: openhands-sessions
+          policy: none
+          purge: true
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -100,9 +100,12 @@ integrations:
 filestore:
   # ephemeral: true deploys the bundled in-cluster MinIO (a conditional
   # dependency) and points the app at it — handy for POC/feature envs. NOTE the
-  # bundled MinIO runs WITHOUT persistence, so its data is lost when the pod is
-  # rescheduled. For anything durable set ephemeral: false and use an external
-  # store (S3 or GCS) below.
+  # name is misleading: the bundled MinIO is only non-persistent with THIS
+  # chart's minio.persistence.enabled: false default, and Replicated installs
+  # override it to true (replicated/openhands.yaml), so those hold durable
+  # customer data in a PVC. Treat the bundled store as persistent unless you
+  # have checked minio.persistence for the install in front of you. For a
+  # managed store set ephemeral: false and use an external store (S3 or GCS).
   ephemeral: false
   # Bucket name (S3/GCS) or MinIO bucket for conversation/session file storage.
   bucket: openhands-sessions
@@ -677,7 +680,13 @@ minio:
   buckets:
     - name: openhands-sessions
       policy: none
-      purge: true
+      # MUST stay false. The minio chart runs its bucket job as a
+      # post-install,post-upgrade hook, and purge: true makes that job
+      # "mc rm -r --force" the bucket before recreating it — so every ordinary
+      # upgrade of a persistent install (Replicated sets persistence.enabled:
+      # true) would wipe every conversation and session file. A render-time
+      # guard in templates/validations.yaml rejects true for bundled installs.
+      purge: false
   svcaccts:
     # Bundled minio dev creds. The runtime-api reap path can't read .Values.minio
     # (separate subchart), so it carries its own matching default in


### PR DESCRIPTION
## Why

The bundled MinIO deletes every stored object on each upgrade. Its packaged chart runs the bucket job as a `post-install,post-upgrade` hook, and `purge: true` makes that job `mc rm -r --force` the bucket before recreating it. Our chart shipped `purge: true`, and Replicated installs set `minio.persistence.enabled: true`, so every ordinary upgrade of a persistent install destroyed the conversation and session files in `openhands-sessions`.

This flips the default to `purge: false` and adds a render-time guard that rejects `purge: true` whenever the bundled store is deployed, so the setting cannot be reintroduced by a values override. The guard is scoped to `filestore.ephemeral` rather than `.Values.enabled`, because that flag is what deploys the bundled store at all, and because runtime-api and automation share it so the data is at risk even in a release that does not run the server.

It also corrects the comment on `filestore.ephemeral`, which claimed the bundled MinIO always runs without persistence. That flag selects topology, not durability: it decides whether the in-cluster store is deployed, while `minio.persistence.enabled` decides whether that store gets a PVC. Reading the old comment, `purge: true` looks harmless, which is plausibly how this survived.

Fixing the default protects future upgrades but recovers nothing already lost, so any install that has upgraded with persistence on has already discarded that data.

## Validation

- **Traced all four conditions on the released chart** — `values.yaml` ships `purge: true`, `replicated/openhands.yaml` sets `filestore.ephemeral: true` with `minio.persistence.enabled: true`, the minio chart's `post-job.yaml` carries `"helm.sh/hook": post-install,post-upgrade`, and its bucket helper runs `mc rm -r --force` when purge is true.
- **The guard rejects the previously shipped configuration and permits the corrected one** — rendering with `purge: true` fails with the bucket name in the message; the new default and a Replicated-shaped render (`ephemeral: true` with persistence) both succeed.
- **Verified the tests fail without the guard** — neutering the purge condition fails exactly the three cases that expect rejection and leaves the two permitting cases green.

_This PR was drafted by an AI agent on behalf of the user._
