### PR TITLE
revert: re-enable budget maintenance by default

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -781,8 +781,7 @@ maintenanceTasks:
       cpu: "500m"
 
 budgetMaintenance:
-  # Disabled until https://github.com/OpenHands/enterprise/pull/80 ships.
-  enabled: false
+  enabled: true
   schedule: "*/15 * * * *" # Run every 15 minutes
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Description

Reverts OpenHands/OpenHands-Cloud#978, which temporarily disabled the budget maintenance CronJob by default while OpenHands/enterprise#80 was still in flight.

Now that the enterprise fix has a PR image available and the flattened Docker import issue has been smoke-tested, this restores `budgetMaintenance.enabled: true` so the budget maintenance CronJob is rendered by default again.

Related:
- OpenHands/OpenHands-Cloud#978 — reverted by this PR
- OpenHands/enterprise#80 — fixes `run_budget_maintenance.py` in the production flattened `/app` image layout
- [OHE-2842](https://linear.app/all-hands-ai/issue/OHE-2842/user-and-team-overrides-enforcement-do-not-work-when-user-or-team-is)

## Validation

- `helm unittest charts/openhands` ✅
- `helm template charts/openhands --debug` renders `openhands/templates/budget-maintenance-cronjob.yaml` with `python -m run_budget_maintenance` ✅
- `helm template test-release charts/openhands --set image.repository=ghcr.io/openhands/enterprise-server --set image.tag=sha-362da3a` renders the budget maintenance CronJob against the enterprise PR #80 image ✅
- `docker run --rm --entrypoint /app/.venv/bin/python ghcr.io/openhands/enterprise-server:sha-362da3a -c "import run_budget_maintenance; print(run_budget_maintenance.run_maintenance_tasks.__name__)"` prints `run_maintenance_tasks`, confirming the import works inside the flattened production image layout ✅

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.
