### PR TITLE
feat(rustfs): PLTF-1250 optional in-cluster object store

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           helm repo add lmnr https://lmnr-ai.github.io/lmnr-helm
           helm repo add minio https://charts.min.io/
+          helm repo add rustfs https://charts.rustfs.com/
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build charts/openhands
       - name: Install test dependencies

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           helm repo add lmnr https://lmnr-ai.github.io/lmnr-helm
           helm repo add minio https://charts.min.io/
+          helm repo add rustfs https://charts.rustfs.com/
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build charts/openhands
 

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -20,6 +20,9 @@ dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
   version: 1.9.0
+- name: rustfs
+  repository: https://charts.rustfs.com/
+  version: 0.10.0
 - name: crd-check
   repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.0
@@ -38,5 +41,5 @@ dependencies:
 - name: agent-canvas
   repository: ""
   version: '*'
-digest: sha256:40485c9d50eaec81c717aaf76c1bbbe08dfeb5a288cd606a6bda929416c6ec91
-generated: "2026-06-25T15:27:15.536667-04:00"
+digest: sha256:693867877f59079af43583137beeb95dc6298f7b1c5a72d8e429a7ab954770e1
+generated: "2026-07-28T22:40:10.320867-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -32,6 +32,10 @@ dependencies:
     repository: oci://registry.replicated.com/library
     version: 1.9.0
     condition: replicated.enabled
+  - name: rustfs
+    version: 0.10.0
+    repository: https://charts.rustfs.com/
+    condition: rustfs.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -704,6 +704,30 @@ minio:
       memory: 512Mi
       cpu: 100m
 
+# Opt-in alternative to the bundled MinIO. RustFS speaks S3, so point the app at
+# it with the existing external-S3 values — no separate wiring:
+#   filestore: {ephemeral: false, type: s3, secure: false,
+#               endpoint: "http://<release>-rustfs-svc:9000", existingSecret: <s3 keys>}
+rustfs:
+  enabled: false
+  replicaCount: 1
+  mode:
+    standalone:
+      enabled: true
+    distributed:
+      enabled: false
+  storageclass:
+    name: ""
+    dataStorageSize: 100Gi
+    logStorageSize: 1Gi
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 1Gi
+      cpu: 500m
+
 postgresql:
   enabled: true
   image:


### PR DESCRIPTION
## Why

This adds RustFS as a chart dependency and settles its values shape, ahead of replacing the bundled MinIO store with it. Keeping it gated on `rustfs.enabled` and defaulting to false means nothing renders and no existing install changes, so the swap that follows is a small diff against a values shape already exercised. Pointing a deployment at RustFS needs no new template logic, since it speaks S3 and the existing external-store values already accept an arbitrary endpoint.

The values block overrides four upstream defaults that suit a multi-node cluster rather than a bundled store: a four-replica distributed topology, the `local-path` storage class, 256Mi volumes, and no resource limits. The empty storage class depends on standalone mode, which omits `storageClassName` so the cluster default applies.

## Validation

- **The values shape works on a fresh install:** enabled into a clean namespace on a local kind cluster, it came up ready in 15s as a single-replica Deployment, with both PVCs bound at the shipped sizes on the cluster default storage class. An S3 create-bucket, upload and read-back returned the object intact.
- **Release packaging:** `make release` built a release from this branch, confirming the release path resolves the new chart repository.

_This PR was drafted by an AI agent on behalf of the user._
