### PR TITLE
feat(chart): expose RATE_LIMIT_AUTH_WINDOWS for auth rate limiter control

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -503,6 +503,31 @@ To use an external Redis instance:
    #   --from-literal=redis-password=<your-redis-password>
    ```
 
+### Disabling the Authentication Rate Limiter
+
+The enterprise server applies a Redis-backed per-user rate limiter on the
+authentication path. By default the chart sets
+`RATE_LIMIT_AUTH_WINDOWS` to `"10/second; 100/minute"`, matching the
+server's own default. For local development or staging where hitting Redis
+on every auth call is undesirable, set the variable to an empty string to
+opt out entirely:
+
+```yaml
+env:
+  RATE_LIMIT_AUTH_WINDOWS: ""
+```
+
+You can also supply a custom `limits`-style window string (multiple windows
+separated by `;`) to keep the limiter but tune it:
+
+```yaml
+env:
+  RATE_LIMIT_AUTH_WINDOWS: "5/minute; 50/hour"
+```
+
+Note that an empty value disables the limiter cleanly; non-empty malformed
+values still raise on startup so misconfigurations fail loudly.
+
 ### Storage Class Configuration
 
 By default, the chart expects a storage class named `standard-rwo`. If you're using EKS, which typically has a `gp2` storage class, you can configure the chart to use it instead:

--- a/charts/openhands/tests/rate_limit_env_test.yaml
+++ b/charts/openhands/tests/rate_limit_env_test.yaml
@@ -1,0 +1,43 @@
+suite: authentication rate limiter env wiring
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+tests:
+  - it: emits the default RATE_LIMIT_AUTH_WINDOWS value matching the enterprise server
+    set:
+      enabled: true
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RATE_LIMIT_AUTH_WINDOWS
+            value: "10/second; 100/minute"
+
+  - it: lets operators disable the Redis auth rate limiter with an empty value
+    set:
+      enabled: true
+      env:
+        RATE_LIMIT_AUTH_WINDOWS: ""
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RATE_LIMIT_AUTH_WINDOWS
+            value: ""
+
+  - it: accepts a custom limits-style window string
+    set:
+      enabled: true
+      env:
+        RATE_LIMIT_AUTH_WINDOWS: "5/minute; 50/hour"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RATE_LIMIT_AUTH_WINDOWS
+            value: "5/minute; 50/hour"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -84,6 +84,11 @@ env:
   DISABLE_WAITLIST: "true"
   SANDBOX_REMOTE_RUNTIME_API_TIMEOUT: "60"
   RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.app.example.com"
+  # Redis-backed authentication rate limiter (limits-style window string; multiple
+  # windows separated by ';'). Set to "" to disable — useful for local dev or
+  # staging where hitting Redis on every auth call is undesirable. Matches the
+  # enterprise server's own default when unset.
+  RATE_LIMIT_AUTH_WINDOWS: "10/second; 100/minute"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 


### PR DESCRIPTION
Surfaces the `RATE_LIMIT_AUTH_WINDOWS` env var in the chart's top-level `env` map so operators can configure or disable the Redis-backed authentication rate limiter from `site-values.yaml`.

Companion to OpenHands/enterprise#97, which added the empty-string opt-out: with the value set to `""`, `enterprise/server/rate_limit.py:create_redis_rate_limiter` returns `None` and `SaasUserAuth.get_instance` skips `rate_limiter.hit(...)` — useful for local dev and staging where hitting Redis on every auth call is undesirable. Non-empty malformed values still raise on startup so misconfigurations fail loudly.

## Why

Before this change, the chart had no entry for `RATE_LIMIT_AUTH_WINDOWS`, so it always fell through to the enterprise server's hardcoded default (`10/second; 100/minute`). There was no clean way for an operator to disable the limiter — the empty-string opt-out existed in the server but was unreachable from a chart install.

## Changes

- **`charts/openhands/values.yaml`**: adds `RATE_LIMIT_AUTH_WINDOWS: "10/second; 100/minute"` to the top-level `env` map with a comment explaining the empty-string opt-out. The default mirrors the server's fallback, so behavior is unchanged for existing installs.
- **`charts/openhands/tests/rate_limit_env_test.yaml`** (new): three helm-unittest cases covering (1) the default rendering, (2) the empty-value disable path, and (3) a custom `limits`-style window string.
- **`charts/openhands/README.md`**: short "Disabling the Authentication Rate Limiter" section under **Hardening** showing both the disable and the tune-with-custom-window patterns.

Operators can now disable the limiter entirely:

```yaml
env:
  RATE_LIMIT_AUTH_WINDOWS: ""
```

…or tune it without disabling:

```yaml
env:
  RATE_LIMIT_AUTH_WINDOWS: "5/minute; 50/hour"
```

## Test

```
$ helm unittest charts/openhands
...
 PASS  authentication rate limiter env wiring   charts/openhands/tests/rate_limit_env_test.yaml
...
Tests:       47 passed, 47 total
```

(44 pre-existing + 3 new.)

## Notes

- Only the **authentication** Redis limiter is exposed. The other rate-limit knobs in `enterprise/server/utils/rate_limit_utils.py` (`RATE_LIMIT_USER_SECONDS`, `RATE_LIMIT_AUTH_VERIFY_EMAIL_*`, `RATE_LIMIT_EMAIL_RESEND_*`, `RATE_LIMIT_ORG_INVITATION_USER_SECONDS`) were intentionally left alone — that PR's scope and notes call them out as unchanged, and none of them gained a new operator-facing behavior in OpenHands/enterprise#97.
- The Replicated layer can override the value via the existing `env` override path in `replicated/openhands.yaml` if a specific install needs different behavior, but no change there is required to pick up the new default.

This PR was authored by an AI agent (OpenHands) on behalf of the user.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/04cddbfc-4861-4d9d-ac2e-e77ce6c822e4)