### PR TITLE
feat(dns): add a simple single-wildcard hostname layout

### DIFF
--- a/.agents/skills/local-kind-install.md
+++ b/.agents/skills/local-kind-install.md
@@ -47,11 +47,18 @@ The kubeconfig is the default context after `kind create cluster`.
   `scripts/create_github_app` register the `/realms/allhands/...` callback.
   Realm provisioning re-runs on every app-pod restart and re-templates
   redirect URIs from `WEB_HOST`; manual `kcadm` edits do not survive restarts.
-- **Hostname layout is `app.<base>` / `auth.app.<base>`** — assumed by the
-  GitHub App script and derived by the chart (`auth.<ingress.host>`).
+- **Hostname layout is flat**: `app.<base>`, `auth.<base>`,
+  `runtime-api.<base>`, and each sandbox at `{id}-runtimes.<base>`, so one
+  `*.<base>` cert and DNS record cover everything. `AUTH_WEB_HOST` follows
+  `keycloak.ingress.hostname` when it is set, and only falls back to
+  `auth.<ingress.host>` when it is not. The GitHub App script takes
+  `--dns-layout` (default `flat`) to build a matching OAuth callback, which
+  must agree with the installer's Hostname Configuration Mode.
 - **`RUNTIME_DISABLE_SSL` defaults to `"true"` in the chart**; the template
-  sets it `"false"` so sandbox URLs are https. `RUNTIME_BASE_URL` must match
-  `RUNTIME_URL_PATTERN`.
+  sets it `"false"` so sandbox URLs are https. `RUNTIME_BASE_URL` and
+  `RUNTIME_URL_SEPARATOR` must together match `RUNTIME_URL_PATTERN` — the
+  runtime-api names each sandbox ingress `{id}{separator}{base}`, and the app
+  addresses it via the pattern.
 - **Memory**: ~16 GB Docker VM; each conversation spawns a 3 Gi sandbox that
   is never reaped. `Insufficient memory` → delete stale
   `runtime-<id>` deployments in the `openhands` namespace.
@@ -62,7 +69,7 @@ The kubeconfig is the default context after `kind create cluster`.
 
 - `https://app.$BASE_DOMAIN` serves the login page (200, trusted cert).
 - Login with the GitHub App completes.
-- A conversation gets a `runtime-*` pod, its ingress under
-  `*.runtime.$BASE_DOMAIN`, and an agent reply.
+- A conversation gets a `runtime-*` pod, its ingress at
+  `<id>-runtimes.$BASE_DOMAIN`, and an agent reply.
 - Troubleshoot: `support-bundle --load-cluster-specs -n openhands` collects,
   `support-bundle upload <archive>` sends it to the Vendor Portal.

--- a/.agents/skills/local-kind-install.md
+++ b/.agents/skills/local-kind-install.md
@@ -48,7 +48,7 @@ The kubeconfig is the default context after `kind create cluster`.
   Realm provisioning re-runs on every app-pod restart and re-templates
   redirect URIs from `WEB_HOST`; manual `kcadm` edits do not survive restarts.
 - **Hostname layout is flat**: `app.<base>`, `auth.<base>`,
-  `runtime-api.<base>`, and each sandbox at `{id}-runtimes.<base>`, so one
+  `runtime-api.<base>`, and each sandbox at `{id}-runtime.<base>`, so one
   `*.<base>` cert and DNS record cover everything. `AUTH_WEB_HOST` follows
   `keycloak.ingress.hostname` when it is set, and only falls back to
   `auth.<ingress.host>` when it is not. The GitHub App script takes
@@ -70,6 +70,6 @@ The kubeconfig is the default context after `kind create cluster`.
 - `https://app.$BASE_DOMAIN` serves the login page (200, trusted cert).
 - Login with the GitHub App completes.
 - A conversation gets a `runtime-*` pod, its ingress at
-  `<id>-runtimes.$BASE_DOMAIN`, and an agent reply.
+  `<id>-runtime.$BASE_DOMAIN`, and an agent reply.
 - Troubleshoot: `support-bundle --load-cluster-specs -n openhands` collects,
   `support-bundle upload <archive>` sends it to the Vendor Portal.

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -374,7 +374,7 @@ keycloak:
 runtime-api:
   ingress:
     enabled: true
-    hostname: runtimes.openhands.example.com
+    hostname: runtime.openhands.example.com
 litellm-helm:
   ingress:
     enabled: true

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -105,9 +105,9 @@ runtime-api:
     # Value should match your Issuer/ClusterIssuer and uncomment if you're using cert-manager for certificates
     # cert-manager.io/cluster-issuer: letsencrypt
   env:
-    RUNTIME_BASE_URL: "runtimes.example.com"
+    RUNTIME_BASE_URL: "runtime.example.com"
     # Dash keeps each sandbox one label under the base domain
-    # ({id}-runtimes.example.com), so one *.example.com wildcard covers them.
+    # ({id}-runtime.example.com), so one *.example.com wildcard covers them.
     # Use "." to nest sandboxes under RUNTIME_BASE_URL instead.
     RUNTIME_URL_SEPARATOR: "-"
     # Set to storage class you want to use.

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -34,7 +34,7 @@ keycloak:
   enabled: true
   ingress:
     enabled: false
-    hostname: "auth.app.example.com"
+    hostname: "auth.example.com"
     annotations: {}
     # Value should match your Issuer/ClusterIssuer and uncomment if you're using cert-manager for certificates
     # cert-manager.io/cluster-issuer: letsencrypt
@@ -105,7 +105,11 @@ runtime-api:
     # Value should match your Issuer/ClusterIssuer and uncomment if you're using cert-manager for certificates
     # cert-manager.io/cluster-issuer: letsencrypt
   env:
-    RUNTIME_BASE_URL: "runtime.example.com"
+    RUNTIME_BASE_URL: "runtimes.example.com"
+    # Dash keeps each sandbox one label under the base domain
+    # ({id}-runtimes.example.com), so one *.example.com wildcard covers them.
+    # Use "." to nest sandboxes under RUNTIME_BASE_URL instead.
+    RUNTIME_URL_SEPARATOR: "-"
     # Set to storage class you want to use.
     STORAGE_CLASS: "gp2"
 

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -390,29 +390,56 @@
       name: {{ .Values.tavily.auth.existingSecret }}
       key: tavily-api-key
 {{- end }}
+{{- /* Keycloak's public hostname. An explicitly configured keycloak ingress
+       hostname wins: that is the host the keycloak Ingress serves, and the
+       realm's frontendUrl and redirect URIs are templated from this value, so
+       the two have to agree or login fails on a redirect_uri mismatch. The
+       auth.<app host> fallback only holds for the nested DNS layout. */}}
+{{- $kcIngress := (.Values.keycloak | default dict).ingress | default dict }}
+{{- $authWebHost := "" }}
+{{- if and $kcIngress.enabled $kcIngress.hostname }}
+{{- $authWebHost = $kcIngress.hostname }}
+{{- end }}
+{{- if not $authWebHost }}
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.prefixWithBranch }}
+{{- $authWebHost = printf "%s.auth.%s" .Values.branchSanitized .Values.ingress.host }}
+{{- else }}
+{{- $authWebHost = printf "auth.%s" .Values.ingress.host }}
+{{- end }}
+{{- else }}
+{{- $authWebHost = "keycloak" }}
+{{- end }}
+{{- end }}
 {{- if .Values.ingress.enabled }}
 {{- if .Values.ingress.prefixWithBranch }}
 - name: WEB_HOST
   value: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
-- name: AUTH_WEB_HOST
-  value: {{ .Values.branchSanitized }}.auth.{{ .Values.ingress.host }}
 - name: MCP_HOST
   value: {{ .Values.branchSanitized }}.{{ .Values.ingress.host }}
 {{- else }}
 - name: WEB_HOST
   value: {{ .Values.ingress.host }}
-- name: AUTH_WEB_HOST
-  value: auth.{{ .Values.ingress.host }}
 - name: MCP_HOST
   value: {{ .Values.ingress.host }}
 {{- end }}
 {{- else }}
 - name: WEB_HOST
   value: {{ .Values.ingress.host }}
-- name: AUTH_WEB_HOST
-  value: keycloak
 - name: MCP_HOST
   value: {{ .Values.ingress.host }}
+{{- end }}
+- name: AUTH_WEB_HOST
+  value: {{ $authWebHost }}
+{{- if .Values.ingress.enabled }}
+{{- /* The frontend builds its Keycloak redirect from AUTH_URL when it is set,
+       and otherwise prepends "auth." to whatever host the browser is on --
+       which yields auth.app.<base> on the flat layout, a hostname nothing
+       serves. Only emitted when an ingress exists, because without one
+       AUTH_WEB_HOST is the in-cluster service name and no browser can reach
+       it. See generate-auth-url.ts in the enterprise repo. */}}
+- name: AUTH_URL
+  value: https://{{ $authWebHost }}
 {{- end }}
 
 {{- if .Values.slack.enabled }}

--- a/charts/openhands/templates/troubleshoot/_tls-hostname.tpl
+++ b/charts/openhands/templates/troubleshoot/_tls-hostname.tpl
@@ -140,8 +140,8 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
               # wildcard DNS record (probed via a synthetic sandbox name).
               # With the "-" separator each sandbox is a sibling of {base} rather
               # than a child, so the covering wildcard is one label up: sandbox
-              # {id}-runtimes.example.com is matched by *.example.com, never by
-              # *.runtimes.example.com.
+              # {id}-runtime.example.com is matched by *.example.com, never by
+              # *.runtime.example.com.
               if [ "$ROUTING" = "path" ]; then
                 check_san RTBASE "$H_RTBASE"
                 check_dns RTBASE "$H_RTBASE"

--- a/charts/openhands/templates/troubleshoot/_tls-hostname.tpl
+++ b/charts/openhands/templates/troubleshoot/_tls-hostname.tpl
@@ -19,6 +19,11 @@ safely. Value paths:
   analyticsHost .......... laminar.frontend.ingress.hostname
   routingMode ............ runtime-api.env.RUNTIME_ROUTING_MODE ("path" => path
                            routing; empty => subdomain, the default)
+  rtSeparator ............ runtime-api.env.RUNTIME_URL_SEPARATOR, how a sandbox
+                           id joins rtBaseHost in subdomain routing. "-" (flat)
+                           keeps sandboxes siblings of the base, so the wildcard
+                           lives one level up; "." (nested, the runtime-api's own
+                           default) puts them under it.
   analyticsEnabled ....... laminar.enabled
   probeImage ............. proxy base of image.repository + docker.io/alpine/openssl,
                            so the pull uses the proxy (and the pull secret KOTS
@@ -44,6 +49,7 @@ rtApiHost: {{ ($rtApi.ingress | default dict).host | default "" | quote }}
 rtBaseHost: {{ $rtApiEnv.RUNTIME_BASE_URL | default "" | quote }}
 analyticsHost: {{ $lamFrontIng.hostname | default "" | quote }}
 routingMode: {{ $rtApiEnv.RUNTIME_ROUTING_MODE | default "" | quote }}
+rtSeparator: {{ $rtApiEnv.RUNTIME_URL_SEPARATOR | default "." | quote }}
 analyticsEnabled: {{ $lam.enabled | default false }}
 probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/openhands/enterprise-server" $repo) | quote }}
 {{- end -}}
@@ -130,14 +136,23 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
 
               # Runtime base: path routing serves {base}/{id}, needing the exact
               # "{base}" SAN and "{base}" to resolve. Subdomain routing (default)
-              # serves {id}.{base}, needing a literal "*.{base}" SAN and a
-              # wildcard DNS record (probed via a synthetic subdomain).
+              # serves {id}{sep}{base}, needing a literal wildcard SAN and a
+              # wildcard DNS record (probed via a synthetic sandbox name).
+              # With the "-" separator each sandbox is a sibling of {base} rather
+              # than a child, so the covering wildcard is one label up: sandbox
+              # {id}-runtimes.example.com is matched by *.example.com, never by
+              # *.runtimes.example.com.
               if [ "$ROUTING" = "path" ]; then
                 check_san RTBASE "$H_RTBASE"
                 check_dns RTBASE "$H_RTBASE"
               else
-                if has_literal "*.$H_RTBASE"; then echo "SAN_RTBASE=OK"; else echo "SAN_RTBASE=FAIL"; fi
-                check_dns RTBASE "dns-preflight-probe.$H_RTBASE"
+                if [ "$SEPARATOR" = "-" ]; then
+                  _wild="*.${H_RTBASE#*.}"
+                else
+                  _wild="*.$H_RTBASE"
+                fi
+                if has_literal "$_wild"; then echo "SAN_RTBASE=OK"; else echo "SAN_RTBASE=FAIL"; fi
+                check_dns RTBASE "dns-preflight-probe${SEPARATOR}$H_RTBASE"
               fi
 
               # Analytics ingress only exists when analytics is enabled; the
@@ -150,6 +165,8 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
               value: {{ $p.cert | quote }}
             - name: ROUTING
               value: {{ $p.routingMode | quote }}
+            - name: SEPARATOR
+              value: {{ $p.rtSeparator | quote }}
             - name: ANALYTICS_ON
               value: {{ if $p.analyticsEnabled }}"1"{{ else }}"0"{{ end }}
             - name: H_APP
@@ -168,6 +185,14 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
 
 {{- define "troubleshoot.analyzers.tlsHostname" -}}
 {{- $p := include "troubleshoot.tlsHostname.vars" . | fromYaml -}}
+{{- /* Mirror of the collector's wildcard choice, for the warning text: the "-"
+       separator makes each sandbox a sibling of the runtime base, so the
+       covering wildcard sits one label above it. */ -}}
+{{- $sandboxExample := printf "{id}%s%s" $p.rtSeparator $p.rtBaseHost -}}
+{{- $sandboxWildcard := printf "*.%s" $p.rtBaseHost -}}
+{{- if eq $p.rtSeparator "-" -}}
+{{- $sandboxWildcard = printf "*.%s" (splitList "." $p.rtBaseHost | rest | join ".") -}}
+{{- end -}}
 # The runPod log is keyed by <collectorName>/<podName>.log (pod name == collector
 # name). All outcomes are pass/warn — non-blocking.
 # --- Application ---
@@ -276,7 +301,7 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
           {{- if eq $p.routingMode "path" }}
           message: 'The TLS certificate is missing the SAN required for sandbox runtimes: an exact "{{ $p.rtBaseHost }}" entry — path routing serves sandboxes under {{ $p.rtBaseHost }}/{id}. Sandboxes will fail to start until the certificate includes it.'
           {{- else }}
-          message: 'The TLS certificate is missing the SAN required for sandbox runtimes: a wildcard "*.{{ $p.rtBaseHost }}" — subdomain routing serves each sandbox at {id}.{{ $p.rtBaseHost }}. Sandboxes will fail to start until the certificate includes it.'
+          message: 'The TLS certificate is missing the SAN required for sandbox runtimes: a wildcard "{{ $sandboxWildcard }}" — subdomain routing serves each sandbox at {{ $sandboxExample }}. Sandboxes will fail to start until the certificate includes it.'
           {{- end }}
 - textAnalyze:
     checkName: "Sandbox runtime domain resolves in DNS"
@@ -291,7 +316,7 @@ probeImage: {{ printf "%s/docker.io/alpine/openssl:3.5.6" (trimSuffix "/ghcr.io/
           {{- if eq $p.routingMode "path" }}
           message: '{{ $p.rtBaseHost }} did not resolve from inside the cluster. Create a DNS record pointing it at the ingress.'
           {{- else }}
-          message: 'A wildcard DNS record "*.{{ $p.rtBaseHost }}" did not resolve (tested via a synthetic subdomain). Create a wildcard A/AAAA record so each {id}.{{ $p.rtBaseHost }} sandbox resolves.'
+          message: 'A wildcard DNS record "{{ $sandboxWildcard }}" did not resolve (tested via a synthetic sandbox name). Create a wildcard A/AAAA record so each {{ $sandboxExample }} sandbox resolves.'
           {{- end }}
 {{- if $p.analyticsEnabled }}
 # --- Analytics (Laminar) — only present/checked when analytics is enabled ---

--- a/charts/openhands/tests/auth_web_host_test.yaml
+++ b/charts/openhands/tests/auth_web_host_test.yaml
@@ -1,0 +1,140 @@
+suite: AUTH_WEB_HOST and AUTH_URL follow the keycloak ingress hostname
+# AUTH_WEB_HOST is templated into the Keycloak realm's frontendUrl and redirect
+# URIs on every app-pod restart, so it has to name the host the keycloak Ingress
+# actually serves. Deriving auth.<app host> only holds on the nested DNS layout;
+# on the flat layout Keycloak sits at auth.<base domain> instead.
+#
+# AUTH_URL is the same host as a URL, for the frontend. Without it the frontend
+# prepends "auth." to the browser's host, producing auth.app.<base> on the flat
+# layout. The two must always agree, so every case here asserts both.
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+tests:
+  - it: uses the configured keycloak hostname on the flat layout
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      keycloak.ingress.enabled: true
+      keycloak.ingress.hostname: auth.example.com
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: auth.example.com
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_URL
+            value: https://auth.example.com
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEB_HOST
+            value: app.example.com
+
+  - it: uses the configured keycloak hostname on the nested layout
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      keycloak.ingress.enabled: true
+      keycloak.ingress.hostname: auth.app.example.com
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: auth.app.example.com
+      # Legacy installs must keep the hostname the frontend already derived on
+      # its own, so switching to AUTH_URL cannot move their login redirect.
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_URL
+            value: https://auth.app.example.com
+
+  - it: falls back to auth.<app host> when no keycloak hostname is set
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      keycloak.ingress.enabled: false
+      keycloak.ingress.hostname: null
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: auth.app.example.com
+
+  - it: ignores the keycloak hostname when its ingress is disabled
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      keycloak.ingress.enabled: false
+      keycloak.ingress.hostname: auth.example.com
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: auth.app.example.com
+
+  - it: prefixes the branch onto the fallback but not an explicit hostname
+    set:
+      enabled: true
+      ingress.enabled: true
+      ingress.host: app.example.com
+      ingress.prefixWithBranch: true
+      branchSanitized: mybranch
+      keycloak.ingress.enabled: false
+      keycloak.ingress.hostname: null
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: mybranch.auth.app.example.com
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_URL
+            value: https://mybranch.auth.app.example.com
+
+  - it: keeps the in-cluster keycloak host when no ingress is configured at all
+    set:
+      enabled: true
+      ingress.enabled: false
+      ingress.host: app.example.com
+      keycloak.ingress.enabled: false
+      keycloak.ingress.hostname: null
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_WEB_HOST
+            value: keycloak
+      # No ingress means no browser-reachable auth host, so AUTH_URL must be
+      # absent rather than pointing the frontend at https://keycloak.
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: AUTH_URL

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -87,7 +87,7 @@ env:
   # RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR pair, which is what names each
   # sandbox ingress. The dash separator keeps sandboxes one label under the base
   # domain so a single wildcard certificate covers them.
-  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtimes.example.com"
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.example.com"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
@@ -911,7 +911,7 @@ runtime-api:
     # REQUIRED: the base each sandbox hostname is built from, as
     # {id}{RUNTIME_URL_SEPARATOR}{RUNTIME_BASE_URL}. Must agree with the app's
     # env.RUNTIME_URL_PATTERN above.
-    # RUNTIME_BASE_URL: "runtimes.example.com"
+    # RUNTIME_BASE_URL: "runtime.example.com"
     # Joins the sandbox id to the base. "-" (the flat layout) keeps sandboxes one
     # label under the base domain, so a single wildcard certificate covers them;
     # "." nests them under RUNTIME_BASE_URL and needs *.RUNTIME_BASE_URL instead.

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -83,7 +83,11 @@ securityContext:
 env:
   DISABLE_WAITLIST: "true"
   SANDBOX_REMOTE_RUNTIME_API_TIMEOUT: "60"
-  RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.app.example.com"
+  # How the app addresses a sandbox. Must agree with the runtime-api's
+  # RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR pair, which is what names each
+  # sandbox ingress. The dash separator keeps sandboxes one label under the base
+  # domain so a single wildcard certificate covers them.
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtimes.example.com"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
@@ -436,7 +440,7 @@ keycloak:
   ingress:
     enabled: false
     # REQUIRED: Update to a hostname in a DNS domain you own
-    # hostname: auth.app.example.com
+    # hostname: auth.example.com
     servicePort: 80
     tls: true
     annotations: {}
@@ -904,8 +908,15 @@ runtime-api:
     DB_USER: postgres
     DB_NAME: runtime_api_db
     RUNTIME_CLASS: ""
-    # REQUIRED: Update to match the host set in the ingress section above
-    # RUNTIME_BASE_URL: "runtime.example.com"
+    # REQUIRED: the base each sandbox hostname is built from, as
+    # {id}{RUNTIME_URL_SEPARATOR}{RUNTIME_BASE_URL}. Must agree with the app's
+    # env.RUNTIME_URL_PATTERN above.
+    # RUNTIME_BASE_URL: "runtimes.example.com"
+    # Joins the sandbox id to the base. "-" (the flat layout) keeps sandboxes one
+    # label under the base domain, so a single wildcard certificate covers them;
+    # "." nests them under RUNTIME_BASE_URL and needs *.RUNTIME_BASE_URL instead.
+    # The runtime-api defaults to "." when this is unset.
+    RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "true"
     MEMORY_REQUEST: "3072Mi"
     MEMORY_LIMIT: "3072Mi"

--- a/local-kind/README.md
+++ b/local-kind/README.md
@@ -21,17 +21,18 @@ Pick a base, e.g. `oh.example.com`, and create these DNS records:
 | Record (A) | Value |
 |---|---|
 | `*.oh.example.com` | `127.0.0.1` |
-| `*.app.oh.example.com` | `127.0.0.1` |
-| `*.runtime.oh.example.com` | `127.0.0.1` |
 
-Issue one certificate covering all three wildcards via DNS-01, e.g. with
+Every hostname sits one label under the base domain (`app.`, `auth.`,
+`runtime-api.`, and each sandbox at `{id}-runtimes.`), so that single wildcard
+covers the whole install.
+
+Issue one certificate for that wildcard via DNS-01, e.g. with
 [acme.sh](https://github.com/acmesh-official/acme.sh) and your DNS provider's
 API:
 
 ```bash
 acme.sh --issue --server letsencrypt --dns dns_<provider> \
-  -d 'oh.example.com' -d '*.oh.example.com' \
-  -d '*.app.oh.example.com' -d '*.runtime.oh.example.com'
+  -d 'oh.example.com' -d '*.oh.example.com'
 ```
 
 Create a GitHub App for login (its callbacks embed the base domain):

--- a/local-kind/README.md
+++ b/local-kind/README.md
@@ -23,7 +23,7 @@ Pick a base, e.g. `oh.example.com`, and create these DNS records:
 | `*.oh.example.com` | `127.0.0.1` |
 
 Every hostname sits one label under the base domain (`app.`, `auth.`,
-`runtime-api.`, and each sandbox at `{id}-runtimes.`), so that single wildcard
+`runtime-api.`, and each sandbox at `{id}-runtime.`), so that single wildcard
 covers the whole install.
 
 Issue one certificate for that wildcard via DNS-01, e.g. with

--- a/local-kind/create-cluster.sh
+++ b/local-kind/create-cluster.sh
@@ -2,9 +2,9 @@
 # Create the local KinD cluster with ingress, TLS, and in-cluster DNS wired up.
 #
 # Required env:
-#   BASE_DOMAIN    e.g. oh.example.com — DNS for app.$BASE_DOMAIN,
-#                  auth.app.$BASE_DOMAIN, runtime-api.$BASE_DOMAIN and
-#                  *.runtime.$BASE_DOMAIN must resolve to 127.0.0.1
+#   BASE_DOMAIN    e.g. oh.example.com — every hostname is one label under it
+#                  (app., auth., runtime-api., and {id}-runtimes. per sandbox),
+#                  so *.$BASE_DOMAIN must resolve to 127.0.0.1
 #   TLS_CERT_FILE  full-chain certificate covering all hostnames above
 #   TLS_KEY_FILE   matching private key
 set -euo pipefail
@@ -13,7 +13,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cluster="${KIND_CLUSTER:-openhands-local-kind}"
 
 : "${BASE_DOMAIN:?set BASE_DOMAIN (e.g. oh.example.com)}"
-: "${TLS_CERT_FILE:?set TLS_CERT_FILE (full chain covering *.$BASE_DOMAIN, *.app.$BASE_DOMAIN, *.runtime.$BASE_DOMAIN)}"
+: "${TLS_CERT_FILE:?set TLS_CERT_FILE (full chain covering *.$BASE_DOMAIN)}"
 : "${TLS_KEY_FILE:?set TLS_KEY_FILE}"
 
 kind create cluster --name "$cluster" --config "$script_dir/kind-config.yaml" --wait 120s

--- a/local-kind/create-cluster.sh
+++ b/local-kind/create-cluster.sh
@@ -3,7 +3,7 @@
 #
 # Required env:
 #   BASE_DOMAIN    e.g. oh.example.com — every hostname is one label under it
-#                  (app., auth., runtime-api., and {id}-runtimes. per sandbox),
+#                  (app., auth., runtime-api., and {id}-runtime. per sandbox),
 #                  so *.$BASE_DOMAIN must resolve to 127.0.0.1
 #   TLS_CERT_FILE  full-chain certificate covering all hostnames above
 #   TLS_KEY_FILE   matching private key

--- a/local-kind/values.yaml.tmpl
+++ b/local-kind/values.yaml.tmpl
@@ -26,7 +26,7 @@ sandbox:
 env:
   # Must agree with the runtime-api's RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR
   # pair below, which is what actually names each sandbox ingress.
-  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtimes.${BASE_DOMAIN}"
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.${BASE_DOMAIN}"
   LITELLM_DEFAULT_MODEL: litellm_proxy/${LLM_MODEL}
 
 runtime-api:
@@ -35,9 +35,9 @@ runtime-api:
     host: runtime-api.${BASE_DOMAIN}
     tls: false
   env:
-    RUNTIME_BASE_URL: runtimes.${BASE_DOMAIN}
+    RUNTIME_BASE_URL: runtime.${BASE_DOMAIN}
     # Dash separator keeps each sandbox one label under ${BASE_DOMAIN}
-    # ({id}-runtimes.${BASE_DOMAIN}), so a single *.${BASE_DOMAIN} wildcard
+    # ({id}-runtime.${BASE_DOMAIN}), so a single *.${BASE_DOMAIN} wildcard
     # covers them.
     RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "false"

--- a/local-kind/values.yaml.tmpl
+++ b/local-kind/values.yaml.tmpl
@@ -15,7 +15,7 @@ github:
 keycloak:
   ingress:
     enabled: true
-    hostname: auth.app.${BASE_DOMAIN}
+    hostname: auth.${BASE_DOMAIN}
     tls: false
 
 sandbox:
@@ -24,7 +24,9 @@ sandbox:
   apiHostname: http://openhands-runtime-api:5000
 
 env:
-  RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.${BASE_DOMAIN}"
+  # Must agree with the runtime-api's RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR
+  # pair below, which is what actually names each sandbox ingress.
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtimes.${BASE_DOMAIN}"
   LITELLM_DEFAULT_MODEL: litellm_proxy/${LLM_MODEL}
 
 runtime-api:
@@ -33,7 +35,11 @@ runtime-api:
     host: runtime-api.${BASE_DOMAIN}
     tls: false
   env:
-    RUNTIME_BASE_URL: runtime.${BASE_DOMAIN}
+    RUNTIME_BASE_URL: runtimes.${BASE_DOMAIN}
+    # Dash separator keeps each sandbox one label under ${BASE_DOMAIN}
+    # ({id}-runtimes.${BASE_DOMAIN}), so a single *.${BASE_DOMAIN} wildcard
+    # covers them.
+    RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "false"
     STORAGE_CLASS: standard
 

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -205,46 +205,53 @@ spec:
         # between is hidden, so they appear directly under Base Domain.
         #
         # Declared after the computed items on purpose: these read them, and
-        # resolving a `default:` that points at a later item is not something we
-        # rely on. `default:` and not `value:` so editing base_domain or the mode
-        # re-renders them.
+        # resolving a template that points at a later item is not something we
+        # rely on.
+        #
+        # `value:` and not `default:`, because only `value:` populates the input
+        # box -- a `default:` on a readonly field leaves the box empty and prints
+        # the text underneath it. The cost is that `value:` is stored on first
+        # render and then never re-evaluated, so each is guarded on base_domain
+        # being set: while it is empty the guard renders nothing, and an empty
+        # stored value is not treated as user input, so the item keeps
+        # re-rendering until there is a real hostname to pin.
         - name: derived_app_hostname
           title: Application Hostname
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{{repl ConfigOption "computed_app_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_app_hostname" }}{{repl end }}'
         - name: derived_analytics_hostname
           title: Analytics Hostname
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{{repl ConfigOption "computed_analytics_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_analytics_hostname" }}{{repl end }}'
         - name: derived_auth_hostname
           title: Authentication Hostname
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{{repl ConfigOption "computed_auth_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_auth_hostname" }}{{repl end }}'
         - name: derived_llm_proxy_hostname
           title: LLM Proxy Hostname
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{{repl ConfigOption "computed_llm_proxy_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_llm_proxy_hostname" }}{{repl end }}'
         - name: derived_runtime_api_hostname
           title: Runtime API Hostname
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{{repl ConfigOption "computed_runtime_api_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_runtime_api_hostname" }}{{repl end }}'
         - name: derived_sandbox_hostname
           title: Sandbox Hostnames
           help_text: Each sandbox is served on its own hostname in this form.
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          default: '{id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}'
+          value: '{{repl if ConfigOption "base_domain" }}{id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}{{repl end }}'
         - name: additional_cors_origins
           title: Additional Permitted CORS Origins
           help_text: >-

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -158,17 +158,22 @@ spec:
         # this is never itself a hostname -- the runtime-api joins the sandbox
         # ID onto it with computed_runtime_hostname_separator below. In path
         # routing it is the single shared host every sandbox is served under.
+        #
+        # Simple and Legacy share the one `runtime.<base_domain>` base, so there
+        # is no wildcard branch here. What separates the two is the separator
+        # below, which decides whether a sandbox is a sibling of that base or a
+        # child of it.
         - name: computed_runtime_base_hostname
           title: Computed Runtime Base Hostname
           type: text
           hidden: true
-          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "runtime_base_hostname" }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}runtimes.{{repl ConfigOption "base_domain" }}{{repl else }}runtime.{{repl ConfigOption "base_domain" }}{{repl end }}'
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "runtime_base_hostname" }}{{repl else }}runtime.{{repl ConfigOption "base_domain" }}{{repl end }}'
         # Consumed as the runtime-api's RUNTIME_URL_SEPARATOR. A dash keeps
         # sandboxes one label deep; the runtime-api treats "/" as a switch into
         # path routing, so only "-" and "." are valid here.
         #
         # Only the Simple layout uses a dash, because there we choose the base
-        # (`runtimes.<base_domain>`) and can guarantee the sandboxes still land
+        # (`runtime.<base_domain>`) and can guarantee the sandboxes still land
         # under the single `*.<base_domain>` wildcard. Legacy and Manual nest
         # with a dot: in Manual the base is whatever was entered, so each sandbox
         # is a child of it.
@@ -180,8 +185,8 @@ spec:
         # The one wildcard SAN a certificate must carry literally for sandboxes.
         # A "-" separator makes each sandbox a sibling of the runtime base rather
         # than a child, so the covering wildcard sits one label above it:
-        # {id}-runtimes.example.com is matched by *.example.com, never by
-        # *.runtimes.example.com. Mirrors the chart preflight's has_literal check.
+        # {id}-runtime.example.com is matched by *.example.com, never by
+        # *.runtime.example.com. Mirrors the chart preflight's has_literal check.
         - name: computed_sandbox_wildcard
           title: Computed Sandbox Wildcard SAN
           type: text
@@ -1144,7 +1149,7 @@ spec:
           title: Sandbox Routing Mode
           help_text: |
             How sandbox URLs are constructed.
-            Subdomain gives each sandbox its own hostname. On the flat DNS layout that is `{id}-runtimes.<base domain>`, covered by a `*.<base domain>` SAN; on the nested layout it is `{id}.{runtime_base}`, which needs a `*.{runtime_base}` SAN.
+            Subdomain gives each sandbox its own hostname. On the flat DNS layout that is `{id}-runtime.<base domain>`, covered by a `*.<base domain>` SAN; on the nested layout it is `{id}.{runtime_base}`, which needs a `*.{runtime_base}` SAN.
             Path-based routes every sandbox at `{runtime_base}/{id}`. The uploaded TLS cert must have a SAN for `{runtime_base}`.
           type: select_one
           default: "subdomain"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -215,43 +215,51 @@ spec:
         # being set: while it is empty the guard renders nothing, and an empty
         # stored value is not treated as user input, so the item keeps
         # re-rendering until there is a real hostname to pin.
+        # Titles and help_text are copied verbatim from the editable items above
+        # so a field reads the same in every mode, and switching modes only
+        # changes whether it accepts input.
         - name: derived_app_hostname
           title: Application Hostname
+          help_text: The hostname where OpenHands will be accessible
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_app_hostname" }}{{repl end }}'
         - name: derived_analytics_hostname
           title: Analytics Hostname
+          help_text: The hostname for the Analytics service
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_analytics_hostname" }}{{repl end }}'
         - name: derived_auth_hostname
           title: Authentication Hostname
+          help_text: The hostname for Keycloak authentication service
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_auth_hostname" }}{{repl end }}'
         - name: derived_llm_proxy_hostname
           title: LLM Proxy Hostname
+          help_text: The hostname for the LiteLLM proxy service
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_llm_proxy_hostname" }}{{repl end }}'
         - name: derived_runtime_api_hostname
           title: Runtime API Hostname
+          help_text: The hostname for the Runtime API service
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_runtime_api_hostname" }}{{repl end }}'
-        - name: derived_sandbox_hostname
-          title: Sandbox Hostnames
-          help_text: Each sandbox is served on its own hostname in this form.
+        - name: derived_runtime_base_hostname
+          title: Runtime Base Hostname
+          help_text: The base hostname for runtime containers
           type: text
           readonly: true
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
-          value: '{{repl if ConfigOption "base_domain" }}{id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}{{repl end }}'
+          value: '{{repl if ConfigOption "base_domain" }}{{repl ConfigOption "computed_runtime_base_hostname" }}{{repl end }}'
         - name: additional_cors_origins
           title: Additional Permitted CORS Origins
           help_text: >-

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -10,21 +10,67 @@ spec:
       items:
         - name: hostname_mode
           title: Hostname Configuration Mode
-          help_text: Choose how to configure hostnames for OpenHands services
+          # One source line per bullet: KOTS renders help_text markdown with
+          # newlines as line breaks, so wrapping a bullet would break the
+          # sentence mid-flow instead of letting it reflow to the panel width.
+          #
+          # The bullet is a literal "•" because markdown list syntax renders no
+          # visible marker in the Admin Console -- a leading "- " is consumed and
+          # nothing takes its place. Inline markdown (bold, backticks) does work.
+          #
+          # The certificate item lists the SANs each layout requires, so these
+          # only have to say how the layouts differ. The Legacy deprecation
+          # notice lives in the label item below, because help_text cannot
+          # reference the item it belongs to -- KOTS lints that as
+          # config-option-is-circular.
+          help_text: |
+            • **Simple** — every hostname sits one subdomain under the base domain.
+            • **Manual** — customize each host name.
+            • **Legacy** — nests Keycloak and sandboxes deeper, at `auth.app.<base>` and `*.runtime.<base>`.
           type: select_one
-          default: "derive"
+          # Option *names* below are stored verbatim in each install's
+          # ConfigValues, so renaming one orphans the stored value of every
+          # install that picked it. Titles are free to change; that is why none
+          # of `wildcard`, `derive` or `custom` matches the title it renders as
+          # (Simple, Legacy, Manual).
+          #
+          # Deliberately `value:` rather than `default:`. KOTS re-renders
+          # `default:` on every config change, so changing a default reaches
+          # installs that never edited the field -- that would move an existing
+          # install's Keycloak to a hostname its certificate does not cover and
+          # re-template the realm's redirect URIs on the next app-pod restart.
+          # A `value:` is written to ConfigValues the first time it renders and
+          # is never overwritten afterwards, and Sequence is 0 only on a fresh
+          # install, so new installs pin `wildcard` while upgrades pin `derive`.
+          # Installs that had explicitly chosen a mode keep it either way.
+          value: '{{repl if eq Sequence 0 }}wildcard{{repl else }}derive{{repl end }}'
           items:
-            - name: "derive"
-              title: "Derive hostnames from domain (recommended)"
+            - name: "wildcard"
+              title: "Simple (default)"
             - name: "custom"
-              title: "Enter all hostnames manually"
+              title: "Manual"
+            - name: "derive"
+              title: "Legacy"
+        # Shown only while Legacy is selected. A `label` renders as text with no
+        # input, and gating a separate item on `when:` is the supported way to
+        # surface a message for one selection -- see the help_text comment above
+        # for why this cannot live on hostname_mode itself.
+        #
+        # The whole message is the title: a label renders its title only, and
+        # ignores help_text entirely.
+        - name: legacy_hostname_mode_notice
+          title: "Legacy is deprecated. Switching to Simple moves Keycloak and the sandbox domain, so update the certificate and DNS records to match first."
+          type: label
+          when: 'repl{{ ConfigOptionEquals "hostname_mode" "derive" }}'
         # Workaround for not being able to template the value of `readonly`
         - name: base_domain
           title: Base Domain
           help_text: The base domain for OpenHands services (e.g., example.com)
           type: text
           readonly: false
-          when: 'repl{{ ConfigOptionEquals "hostname_mode" "derive" }}'
+          # Needed by every mode that derives hostnames, so gate on "not manual"
+          # rather than naming each derived mode.
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           required: true
         - name: app_hostname
           title: Application Hostname
@@ -44,7 +90,7 @@ spec:
           title: Authentication Hostname
           help_text: The hostname for Keycloak authentication service
           type: text
-          default: "auth.app.example.com"
+          default: "auth.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
           required: true
         - name: llm_proxy_hostname
@@ -64,8 +110,141 @@ spec:
           title: Runtime Base Hostname
           help_text: The base hostname for runtime containers
           type: text
-          default: "runtime.example.com"
+          default: "runtimes.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+        - name: runtime_hostname_style
+          title: Sandbox Hostname Style
+          # Shows both options against the runtime base hostname entered above,
+          # rather than describing the layouts abstractly. Reads that item and
+          # not its own value: help_text cannot reference the item it belongs to.
+          # The certificate item states the SAN each choice requires.
+          help_text: |
+            How each sandbox ID joins the runtime base hostname.
+            • **Flat** — `{id}-{{repl ConfigOption "runtime_base_hostname" }}`
+            • **Nested** — `{id}.{{repl ConfigOption "runtime_base_hostname" }}`
+          type: select_one
+          default: "flat"
+          when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+          items:
+            - name: "flat"
+              title: "Flat - join with a dash"
+            - name: "nested"
+              title: "Nested - join with a dot"
+
+        # Computed hostnames. Every HelmChart CR reads these instead of
+        # re-deriving prefixes, so the DNS layout is defined once, here.
+        #
+        # These are hidden and carry no user input, so KOTS applies the
+        # `default:` -- and it re-renders defaults on every config change, so
+        # editing base_domain or hostname_mode flows through to all of them. Do
+        # not switch these to `value:`: a value is pinned on first render and
+        # would then ignore later base_domain edits.
+        #
+        # Each resolves in the same order: a manually entered hostname wins,
+        # then the wildcard layout, and anything else falls back to the legacy
+        # layout. Falling back to legacy is deliberate -- an install whose
+        # hostname_mode renders empty or unrecognised must keep the layout its
+        # certificate was issued for.
+        - name: computed_app_hostname
+          title: Computed Application Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "app_hostname" }}{{repl else }}app.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        - name: computed_auth_hostname
+          title: Computed Authentication Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "auth_hostname" }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}auth.{{repl ConfigOption "base_domain" }}{{repl else }}auth.app.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        - name: computed_analytics_hostname
+          title: Computed Analytics Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "analytics_hostname" }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}analytics.{{repl ConfigOption "base_domain" }}{{repl else }}analytics.app.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        - name: computed_llm_proxy_hostname
+          title: Computed LLM Proxy Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "llm_proxy_hostname" }}{{repl else }}llm-proxy.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        - name: computed_runtime_api_hostname
+          title: Computed Runtime API Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "runtime_api_hostname" }}{{repl else }}runtime-api.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        # The base that sandbox hostnames are built from. In subdomain routing
+        # this is never itself a hostname -- the runtime-api joins the sandbox
+        # ID onto it with computed_runtime_hostname_separator below. In path
+        # routing it is the single shared host every sandbox is served under.
+        - name: computed_runtime_base_hostname
+          title: Computed Runtime Base Hostname
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl ConfigOption "runtime_base_hostname" }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}runtimes.{{repl ConfigOption "base_domain" }}{{repl else }}runtime.{{repl ConfigOption "base_domain" }}{{repl end }}'
+        # Consumed as the runtime-api's RUNTIME_URL_SEPARATOR. A dash keeps
+        # sandboxes one label deep; the runtime-api treats "/" as a switch into
+        # path routing, so only "-" and "." are valid here.
+        - name: computed_runtime_hostname_separator
+          title: Computed Sandbox Hostname Separator
+          type: text
+          hidden: true
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl if ConfigOptionEquals "runtime_hostname_style" "flat" }}-{{repl else }}.{{repl end }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}-{{repl else }}.{{repl end }}'
+        # The one wildcard SAN a certificate must carry literally for sandboxes.
+        # A "-" separator makes each sandbox a sibling of the runtime base rather
+        # than a child, so the covering wildcard sits one label above it:
+        # {id}-runtimes.example.com is matched by *.example.com, never by
+        # *.runtimes.example.com. Mirrors the chart preflight's has_literal check.
+        - name: computed_sandbox_wildcard
+          title: Computed Sandbox Wildcard SAN
+          type: text
+          hidden: true
+          default: '{{repl if eq (ConfigOption "computed_runtime_hostname_separator") "-" }}*.{{repl splitList "." (ConfigOption "computed_runtime_base_hostname") | rest | join "." }}{{repl else }}*.{{repl ConfigOption "computed_runtime_base_hostname" }}{{repl end }}'
+        # Read-only view of the hostnames a derived layout produces, so the
+        # Simple and Legacy modes show the same fields Manual does instead of
+        # leaving the result implicit. `readonly` cannot be templated, so these
+        # are separate items from the editable ones above rather than the same
+        # fields toggled -- only one set is ever visible, and everything declared
+        # between is hidden, so they appear directly under Base Domain.
+        #
+        # Declared after the computed items on purpose: these read them, and
+        # resolving a `default:` that points at a later item is not something we
+        # rely on. `default:` and not `value:` so editing base_domain or the mode
+        # re-renders them.
+        - name: derived_app_hostname
+          title: Application Hostname
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{{repl ConfigOption "computed_app_hostname" }}'
+        - name: derived_analytics_hostname
+          title: Analytics Hostname
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{{repl ConfigOption "computed_analytics_hostname" }}'
+        - name: derived_auth_hostname
+          title: Authentication Hostname
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{{repl ConfigOption "computed_auth_hostname" }}'
+        - name: derived_llm_proxy_hostname
+          title: LLM Proxy Hostname
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{{repl ConfigOption "computed_llm_proxy_hostname" }}'
+        - name: derived_runtime_api_hostname
+          title: Runtime API Hostname
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{{repl ConfigOption "computed_runtime_api_hostname" }}'
+        - name: derived_sandbox_hostname
+          title: Sandbox Hostnames
+          help_text: Each sandbox is served on its own hostname in this form.
+          type: text
+          readonly: true
+          when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
+          default: '{id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}'
         - name: additional_cors_origins
           title: Additional Permitted CORS Origins
           help_text: >-
@@ -88,7 +267,21 @@ spec:
       items:
         - name: tls_certificate
           title: TLS Certificate
-          help_text: Upload your TLS certificate file (.crt or .pem)
+          # help_text supports Go templates and the Admin Console re-renders it
+          # on every config change, so this list tracks the hostnames chosen
+          # above instead of restating them. One source line per bullet, since
+          # newlines render as line breaks. A Go comment cannot appear inside
+          # the block scalar: `{{repl` allows no space before one.
+          help_text: |
+            Upload your TLS certificate file (.crt or .pem).
+            {{repl if ConfigOptionEquals "hostname_mode" "wildcard" }}Use a single wildcard SAN:
+            • `{{repl ConfigOption "computed_sandbox_wildcard" }}`{{repl else }}It must cover:
+            • `{{repl ConfigOption "computed_app_hostname" }}`
+            • `{{repl ConfigOption "computed_auth_hostname" }}`
+            • `{{repl ConfigOption "computed_llm_proxy_hostname" }}`
+            • `{{repl ConfigOption "computed_runtime_api_hostname" }}`
+            • `{{repl ConfigOption "computed_analytics_hostname" }}`
+            • `{{repl ConfigOption "computed_sandbox_wildcard" }}`{{repl end }}
           type: file
           required: true
           # Validation runs against the base64-decoded file contents, so we can
@@ -946,7 +1139,7 @@ spec:
           title: Sandbox Routing Mode
           help_text: |
             How sandbox URLs are constructed.
-            Subdomain routes each sandbox at `{id}.{runtime_base}`. The uploaded TLS cert must have a SAN for `*.{runtime_base}`.
+            Subdomain gives each sandbox its own hostname. On the flat DNS layout that is `{id}-runtimes.<base domain>`, covered by a `*.<base domain>` SAN; on the nested layout it is `{id}.{runtime_base}`, which needs a `*.{runtime_base}` SAN.
             Path-based routes every sandbox at `{runtime_base}/{id}`. The uploaded TLS cert must have a SAN for `{runtime_base}`.
           type: select_one
           default: "subdomain"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -72,46 +72,48 @@ spec:
           # rather than naming each derived mode.
           when: 'repl{{ ne (ConfigOption "hostname_mode") "custom" }}'
           required: true
+        # No defaults: an example.com placeholder is never a usable hostname, and
+        # as a `default:` it would be silently accepted as if it were entered.
+        # Every one is required -- the install serves all of these, so there is no
+        # configuration where leaving one blank is valid. `required` is not
+        # enforced while an item is hidden by `when:`, so the derived layouts are
+        # unaffected by this.
         - name: app_hostname
           title: Application Hostname
           help_text: The hostname where OpenHands will be accessible
           type: text
-          default: "app.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
           required: true
         - name: analytics_hostname
           title: Analytics Hostname
           help_text: The hostname for the Analytics service
           type: text
-          default: "analytics.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
           required: true
         - name: auth_hostname
           title: Authentication Hostname
           help_text: The hostname for Keycloak authentication service
           type: text
-          default: "auth.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
           required: true
         - name: llm_proxy_hostname
           title: LLM Proxy Hostname
           help_text: The hostname for the LiteLLM proxy service
           type: text
-          default: "llm-proxy.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
           required: true
         - name: runtime_api_hostname
           title: Runtime API Hostname
           help_text: The hostname for the Runtime API service
           type: text
-          default: "runtime-api.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+          required: true
         - name: runtime_base_hostname
           title: Runtime Base Hostname
           help_text: The base hostname for runtime containers
           type: text
-          default: "runtimes.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
+          required: true
 
         # Computed hostnames. Every HelmChart CR reads these instead of
         # re-deriving prefixes, so the DNS layout is defined once, here.

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -112,24 +112,6 @@ spec:
           type: text
           default: "runtimes.example.com"
           when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
-        - name: runtime_hostname_style
-          title: Sandbox Hostname Style
-          # Shows both options against the runtime base hostname entered above,
-          # rather than describing the layouts abstractly. Reads that item and
-          # not its own value: help_text cannot reference the item it belongs to.
-          # The certificate item states the SAN each choice requires.
-          help_text: |
-            How each sandbox ID joins the runtime base hostname.
-            • **Flat** — `{id}-{{repl ConfigOption "runtime_base_hostname" }}`
-            • **Nested** — `{id}.{{repl ConfigOption "runtime_base_hostname" }}`
-          type: select_one
-          default: "flat"
-          when: 'repl{{ ConfigOptionEquals "hostname_mode" "custom" }}'
-          items:
-            - name: "flat"
-              title: "Flat - join with a dash"
-            - name: "nested"
-              title: "Nested - join with a dot"
 
         # Computed hostnames. Every HelmChart CR reads these instead of
         # re-deriving prefixes, so the DNS layout is defined once, here.
@@ -182,11 +164,17 @@ spec:
         # Consumed as the runtime-api's RUNTIME_URL_SEPARATOR. A dash keeps
         # sandboxes one label deep; the runtime-api treats "/" as a switch into
         # path routing, so only "-" and "." are valid here.
+        #
+        # Only the Simple layout uses a dash, because there we choose the base
+        # (`runtimes.<base_domain>`) and can guarantee the sandboxes still land
+        # under the single `*.<base_domain>` wildcard. Legacy and Manual nest
+        # with a dot: in Manual the base is whatever was entered, so each sandbox
+        # is a child of it.
         - name: computed_runtime_hostname_separator
           title: Computed Sandbox Hostname Separator
           type: text
           hidden: true
-          default: '{{repl if ConfigOptionEquals "hostname_mode" "custom" }}{{repl if ConfigOptionEquals "runtime_hostname_style" "flat" }}-{{repl else }}.{{repl end }}{{repl else if ConfigOptionEquals "hostname_mode" "wildcard" }}-{{repl else }}.{{repl end }}'
+          default: '{{repl if ConfigOptionEquals "hostname_mode" "wildcard" }}-{{repl else }}.{{repl end }}'
         # The one wildcard SAN a certificate must carry literally for sandboxes.
         # A "-" separator makes each sandbox a sibling of the runtime base rather
         # than a child, so the covering wildcard sits one label above it:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -321,7 +321,7 @@ spec:
         DB_NAME: "runtime_api_db"
         RUNTIME_BASE_URL: '{{repl ConfigOption "computed_runtime_base_hostname" }}'
         # Joins the sandbox ID to RUNTIME_BASE_URL. "-" keeps each sandbox one
-        # label deep ({id}-runtimes.<base>) so a single *.<base> wildcard covers
+        # label deep ({id}-runtime.<base>) so a single *.<base> wildcard covers
         # it; "." nests it under the runtime base. The path-routing block below
         # overrides this to "/", which the runtime-api reads as path mode.
         RUNTIME_URL_SEPARATOR: '{{repl ConfigOption "computed_runtime_hostname_separator" }}'
@@ -717,7 +717,7 @@ spec:
     #
     # A NO_PROXY entry matches a host and its subdomains, so the runtime base
     # covers nested sandboxes ({id}.runtime.<base>) but not flat ones
-    # ({id}-runtimes.<base>), which are siblings of the base rather than
+    # ({id}-runtime.<base>), which are siblings of the base rather than
     # children. For the dash separator, bypass the base's parent domain instead.
     # In derive mode that parent is base_domain, already added below, so the
     # extra entry only ever appears in custom mode.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -62,7 +62,13 @@ spec:
       # Replicated installs expose Laminar at the analytics hostname. Set it
       # unconditionally (not gated on analytics_enabled) so the Keycloak realm
       # redirect URIs stay on the analytics domain either way.
-      LAMINAR_WEB_HOST: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+      LAMINAR_WEB_HOST: '{{repl ConfigOption "computed_analytics_hostname" }}'
+      # How the app addresses a sandbox. Must agree with the RUNTIME_BASE_URL /
+      # RUNTIME_URL_SEPARATOR pair given to the runtime-api below, which is what
+      # actually creates each sandbox ingress. The chart default hardcodes
+      # example.com, so this has to be set explicitly. The path-routing block
+      # further down replaces it with the <base>/{runtime_id} form.
+      RUNTIME_URL_PATTERN: 'https://{runtime_id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}'
       # OH_AGENT_SERVER_ENV is assembled by the chart from
       # spec.values.global.agentServerEnv, not hand-written here.
       OPENHANDS_DEFAULT_ORG_ENABLED: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'
@@ -88,7 +94,7 @@ spec:
 
     ingress:
       enabled: true
-      host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
+      host: '{{repl ConfigOption "computed_app_hostname" }}'
       class: traefik
       annotations:
         nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
@@ -124,13 +130,13 @@ spec:
       ingress:
         enabled: true
         ingressClassName: traefik
-        hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+        hostname: '{{repl ConfigOption "computed_auth_hostname" }}'
         tls: true
         annotations:
-          nginx.ingress.kubernetes.io/upstream-vhost: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+          nginx.ingress.kubernetes.io/upstream-vhost: '{{repl ConfigOption "computed_auth_hostname" }}'
           nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
         secrets:
-          - name: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}-tls'
+          - name: '{{repl ConfigOption "computed_auth_hostname" }}-tls'
             key: |
               {{repl ConfigOptionData "tls_private_key" | nindent 14}}
             certificate: |
@@ -231,14 +237,14 @@ spec:
         enabled: true
         className: traefik
         hosts:
-          - host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}llm-proxy.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "llm_proxy_hostname"}}{{repl end}}'
+          - host: '{{repl ConfigOption "computed_llm_proxy_hostname" }}'
             paths:
               - path: /
                 pathType: Prefix
         tls:
           - secretName: openhands-tls
             hosts:
-              - '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}llm-proxy.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "llm_proxy_hostname"}}{{repl end}}'
+              - '{{repl ConfigOption "computed_llm_proxy_hostname" }}'
       proxy_config:
         environment_variables:
           OR_APP_NAME: "OpenHands"
@@ -286,7 +292,7 @@ spec:
       ingress:
         enabled: true
         className: traefik
-        host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime-api.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_api_hostname"}}{{repl end}}'
+        host: '{{repl ConfigOption "computed_runtime_api_hostname" }}'
         tls: true
         tlsSecretName: openhands-tls
         # Suppress the chart's default letsencrypt annotation: Replicated
@@ -313,8 +319,13 @@ spec:
         PGSSLMODE: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
-        RUNTIME_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
-        RUNTIME_API_BASE_URL: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
+        RUNTIME_BASE_URL: '{{repl ConfigOption "computed_runtime_base_hostname" }}'
+        # Joins the sandbox ID to RUNTIME_BASE_URL. "-" keeps each sandbox one
+        # label deep ({id}-runtimes.<base>) so a single *.<base> wildcard covers
+        # it; "." nests it under the runtime base. The path-routing block below
+        # overrides this to "/", which the runtime-api reads as path mode.
+        RUNTIME_URL_SEPARATOR: '{{repl ConfigOption "computed_runtime_hostname_separator" }}'
+        RUNTIME_API_BASE_URL: 'https://{{repl ConfigOption "computed_runtime_base_hostname" }}'
         RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_server") "") (ne (ConfigOption "custom_sandbox_image_registry_username") "") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"
@@ -369,12 +380,12 @@ spec:
             environment:
               LOG_JSON: "1"
               LOG_JSON_LEVEL_KEY: "severity"
-              OH_ALLOW_CORS_ORIGINS_0: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
+              OH_ALLOW_CORS_ORIGINS_0: 'https://{{repl ConfigOption "computed_app_hostname" }}'
               OH_BASH_EVENTS_DIR: "/workspace/bash_events"
               OH_CONVERSATIONS_PATH: "/workspace/conversations"
               OH_ENABLE_VNC: "0"
               OH_VSCODE_PORT: "60001"
-              OH_WEBHOOKS_0_BASE_URL: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}/api/v1/webhooks'
+              OH_WEBHOOKS_0_BASE_URL: 'https://{{repl ConfigOption "computed_app_hostname" }}/api/v1/webhooks'
               OPENVSCODE_SERVER_ROOT: "/openhands/.openvscode-server"
               VSCODE_PORT: "60001"
               WORKER_1: "12000"
@@ -503,7 +514,7 @@ spec:
       recursiveMerge: true
       values:
         env:
-          PERMITTED_CORS_ORIGINS: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}},{{repl ConfigOption "additional_cors_origins" | trim }}'
+          PERMITTED_CORS_ORIGINS: 'https://{{repl ConfigOption "computed_app_hostname" }},{{repl ConfigOption "additional_cors_origins" | trim }}'
     - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
       recursiveMerge: true
       values:
@@ -630,8 +641,8 @@ spec:
             repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/automation'
           imagePullSecrets:
             - name: '{{repl ImagePullSecretName }}'
-          openhandsApiUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
-          automationBaseUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+          openhandsApiUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
+          automationBaseUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           filestore:
             type: local
           env:
@@ -703,21 +714,31 @@ spec:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/kubectl'
     # Compute NO_PROXY variable, then evaluate proxy_enabled gate.
     # Assignments produce no output; the when value resolves to just the boolean.
+    #
+    # A NO_PROXY entry matches a host and its subdomains, so the runtime base
+    # covers nested sandboxes ({id}.runtime.<base>) but not flat ones
+    # ({id}-runtimes.<base>), which are siblings of the base rather than
+    # children. For the dash separator, bypass the base's parent domain instead.
+    # In derive mode that parent is base_domain, already added below, so the
+    # extra entry only ever appears in custom mode.
     - when: >-
-        {{repl $derive := ConfigOptionEquals "hostname_mode" "derive" }}
         {{repl $bd := ConfigOption "base_domain" }}
-        {{repl $appDomain := $derive | ternary (printf "app.%s" $bd) (ConfigOption "app_hostname") }}
-        {{repl $authDomain := $derive | ternary (printf "auth.app.%s" $bd) (ConfigOption "auth_hostname") }}
-        {{repl $llmDomain := $derive | ternary (printf "llm-proxy.%s" $bd) (ConfigOption "llm_proxy_hostname") }}
-        {{repl $runtimeApiDomain := $derive | ternary (printf "runtime-api.%s" $bd) (ConfigOption "runtime_api_hostname") }}
-        {{repl $runtimeBaseDomain := $derive | ternary (printf "runtime.%s" $bd) (ConfigOption "runtime_base_hostname") }}
+        {{repl $appDomain := ConfigOption "computed_app_hostname" }}
+        {{repl $authDomain := ConfigOption "computed_auth_hostname" }}
+        {{repl $analyticsDomain := ConfigOption "computed_analytics_hostname" }}
+        {{repl $llmDomain := ConfigOption "computed_llm_proxy_hostname" }}
+        {{repl $runtimeApiDomain := ConfigOption "computed_runtime_api_hostname" }}
+        {{repl $runtimeBaseDomain := ConfigOption "computed_runtime_base_hostname" }}
+        {{repl $runtimeSeparator := ConfigOption "computed_runtime_hostname_separator" }}
         {{repl $computedNoProxy := "127.0.0.1,cluster.local,keycloak,keycloak-headless,kubernetes,localhost,oh-main-lite-llm,oh-main-runtime-api,openhands-integrations-service,openhands-litellm,openhands-mcp-service,openhands-minio,openhands-runtime-api,openhands-service,svc" }}
         {{repl if ne $bd "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $bd }}{{repl end }}
         {{repl if ne $appDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $appDomain }}{{repl end }}
         {{repl if ne $authDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $authDomain }}{{repl end }}
+        {{repl if ne $analyticsDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $analyticsDomain }}{{repl end }}
         {{repl if ne $llmDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $llmDomain }}{{repl end }}
         {{repl if ne $runtimeApiDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $runtimeApiDomain }}{{repl end }}
         {{repl if ne $runtimeBaseDomain "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $runtimeBaseDomain }}{{repl end }}
+        {{repl if eq $runtimeSeparator "-" }}{{repl $runtimeParent := splitList "." $runtimeBaseDomain | rest | join "." }}{{repl if and (ne $runtimeParent "") (ne $runtimeParent $bd) }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy $runtimeParent }}{{repl end }}{{repl end }}
         {{repl if ConfigOptionEquals "analytics_enabled" "1" }}{{repl $computedNoProxy = printf "%s,laminar-app-server-service,laminar-clickhouse,laminar-frontend,laminar-postgres,laminar-query-engine,laminar-quickwit-control-plane,laminar-quickwit-indexer,laminar-quickwit-janitor,laminar-quickwit-metastore,laminar-quickwit-searcher,laminar-rabbitmq,laminar-redis" $computedNoProxy }}{{repl end }}
         {{repl if ne (ConfigOption "no_proxy") "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy (ConfigOption "no_proxy") }}{{repl end }}
         {{repl ConfigOptionEquals "proxy_enabled" "1" }}
@@ -961,7 +982,7 @@ spec:
       values:
         env:
           RUNTIME_ROUTING_MODE: "path"
-          RUNTIME_URL_PATTERN: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}/{runtime_id}'
+          RUNTIME_URL_PATTERN: 'https://{{repl ConfigOption "computed_runtime_base_hostname" }}/{runtime_id}'
         runtime-api:
           env:
             RUNTIME_ROUTING_MODE: "path"
@@ -973,7 +994,7 @@ spec:
             enabled: false
           sandboxGateway:
             enabled: true
-            hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}runtime.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "runtime_base_hostname"}}{{repl end}}'
+            hostname: '{{repl ConfigOption "computed_runtime_base_hostname" }}'
             tlsSecretName: openhands-tls
     - when: '{{repl ConfigOptionEquals "analytics_enabled" "1" }}'
       recursiveMerge: true
@@ -1039,7 +1060,7 @@ spec:
                     name: keycloak-realm
                     key: client-secret
               - name: AUTH_KEYCLOAK_ISSUER
-                value: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://auth.app.{{repl ConfigOption "base_domain"}}/realms/allhands{{repl else}}https://{{repl ConfigOption "auth_hostname"}}/realms/allhands{{repl end}}'
+                value: 'https://{{repl ConfigOption "computed_auth_hostname" }}/realms/allhands'
               # caBundle wiring (appended to the existing list — recursiveMerge
               # REPLACES arrays, so these must live alongside the Keycloak vars).
               # Next.js is Node, which honors NODE_EXTRA_CA_CERTS, not SSL_CERT_FILE;
@@ -1058,18 +1079,18 @@ spec:
                 readOnly: true
             ingress:
               enabled: true
-              hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+              hostname: '{{repl ConfigOption "computed_analytics_hostname" }}'
               className: "traefik"
               tls:
                 enabled: true
                 secretName: "openhands-tls"
                 clusterIssuer: "" # leave empty — cert-manager not needed
             env:
-              nextauthUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
-              nextPublicUrl: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+              nextauthUrl: 'https://{{repl ConfigOption "computed_analytics_hostname" }}'
+              nextPublicUrl: 'https://{{repl ConfigOption "computed_analytics_hostname" }}'
           apiIngress:
             enabled: true
-            hostname: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}analytics.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "analytics_hostname"}}{{repl end}}'
+            hostname: '{{repl ConfigOption "computed_analytics_hostname" }}'
             className: "traefik"
             tls:
               enabled: true
@@ -1106,17 +1127,17 @@ spec:
           # otherwise outbound HTTPS fails TLS verification.
           caBundle:
             enabled: true
-          appUrl: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}/plugins'
+          appUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}/plugins'
           # OpenHands API host (same host as appUrl, without the /plugins path).
           # The curl template appends /api/v1/app-conversations to this base.
-          curlApiUrl: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
+          curlApiUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           appEnv:
             MARKETPLACE_SOURCE: '{{repl ConfigOption "plugin_directory_marketplace_source"}}'
           database:
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}oh-main-postgresql{{repl end}}'
             port: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_port"}}{{repl else}}5432{{repl end}}'
           oidc:
-            issuerUrl: 'https://{{repl if ConfigOptionEquals "hostname_mode" "derive"}}auth.app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "auth_hostname"}}{{repl end}}'
+            issuerUrl: 'https://{{repl ConfigOption "computed_auth_hostname" }}'
           client:
             image:
               repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/plugin-directory-client'
@@ -1141,7 +1162,7 @@ spec:
             - name: '{{repl ImagePullSecretName }}'
           ingress:
             enabled: true
-            host: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}app.{{repl ConfigOption "base_domain"}}{{repl else}}{{repl ConfigOption "app_hostname"}}{{repl end}}'
+            host: '{{repl ConfigOption "computed_app_hostname" }}'
             className: traefik
             path: /canvas
             tls:
@@ -1150,7 +1171,7 @@ spec:
           staticServer:
             basePath: /canvas
             authRequired: false
-            lockToCloud: '{{repl if ConfigOptionEquals "hostname_mode" "derive"}}https://app.{{repl ConfigOption "base_domain"}}{{repl else}}https://{{repl ConfigOption "app_hostname"}}{{repl end}}'
+            lockToCloud: 'https://{{repl ConfigOption "computed_app_hostname" }}'
 
   builder:
     keycloak:

--- a/scripts/create_github_app/README.md
+++ b/scripts/create_github_app/README.md
@@ -20,6 +20,7 @@ Create a GitHub App configured for the Replicated self-hosted install of OpenHan
 | Option | Description |
 |--------|-------------|
 | `--base-domain` | **(Required)** Base domain for your OHE installation (e.g., `mycompany.com`) |
+| `--dns-layout` | `flat` (default) puts Keycloak at `auth.<base-domain>`; `nested` puts it at `auth.app.<base-domain>`. Must match the installer's Hostname Configuration Mode (Simple vs Legacy) |
 | `--app-name` | Custom name for the GitHub App (default: `openhands-<random>`) |
 | `--org` | GitHub organization to create the app in (default: your personal account) |
 | `--callback-port` | Local port for the app-creation callback server (default: `9876`) |
@@ -78,6 +79,7 @@ The app is configured with:
 
 - **Homepage URL**: `https://app.<base-domain>`
 - **Redirect URL** (for app creation): `http://localhost:9876/callback` (local callback server)
-- **Callback URL** (for OAuth): `https://auth.app.<base-domain>/realms/allhands/broker/github/endpoint`
+- **Callback URL** (for OAuth): `https://auth.<base-domain>/realms/allhands/broker/github/endpoint`, or
+  `https://auth.app.<base-domain>/...` with `--dns-layout nested`
 - **Webhook URL**: `https://app.<base-domain>/integration/github/events`
 - **OAuth on install**: Disabled (Keycloak handles user OAuth at login time)

--- a/scripts/create_github_app/create_github_app.py
+++ b/scripts/create_github_app/create_github_app.py
@@ -71,6 +71,15 @@ def parse_args() -> argparse.Namespace:
         help="Base domain for the GitHub App (e.g., mycompany.com).",
     )
     parser.add_argument(
+        "--dns-layout",
+        choices=("flat", "nested"),
+        default="flat",
+        help="DNS layout of the installation, matching the installer's Hostname "
+        "Configuration Mode. 'flat' (Simple) serves Keycloak at "
+        "auth.<base-domain>; 'nested' (Legacy) serves it at "
+        "auth.app.<base-domain> (default: flat).",
+    )
+    parser.add_argument(
         "--org",
         default=None,
         help="Org to create the app in (default: your personal account).",
@@ -85,19 +94,30 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def keycloak_hostname(base_domain: str, dns_layout: str = "flat") -> str:
+    """Keycloak's hostname for a given DNS layout.
+
+    The OAuth callback has to land on the host Keycloak actually serves, so this
+    must track the installer's DNS Layout setting.
+    """
+    return f"auth.{base_domain}" if dns_layout == "flat" else f"auth.app.{base_domain}"
+
+
 def build_app_manifest(
     base_domain: str,
     app_name: str | None = None,
     callback_port: int = DEFAULT_CALLBACK_PORT,
+    dns_layout: str = "flat",
 ) -> dict[str, Any]:
     """Build the GitHub App manifest configuration."""
     if app_name is None:
         app_name = generate_unique_app_name()
+    auth_host = keycloak_hostname(base_domain, dns_layout)
     return {
         "name": app_name,
         "url": f"https://app.{base_domain}",
         "redirect_url": f"http://localhost:{callback_port}/callback",
-        "callback_urls": [f"https://auth.app.{base_domain}/realms/allhands/broker/github/endpoint"],
+        "callback_urls": [f"https://{auth_host}/realms/allhands/broker/github/endpoint"],
         "public": False,
         "request_oauth_on_install": False,
         "default_permissions": {
@@ -151,9 +171,12 @@ def open_manifest_in_browser(
     app_name: str | None = None,
     callback_port: int = DEFAULT_CALLBACK_PORT,
     org: str | None = None,
+    dns_layout: str = "flat",
 ) -> str:
     """Write manifest HTML to temp file and open in browser. Returns file path."""
-    manifest = build_app_manifest(base_domain, app_name, callback_port=callback_port)
+    manifest = build_app_manifest(
+        base_domain, app_name, callback_port=callback_port, dns_layout=dns_layout
+    )
     html = generate_manifest_html(manifest, org=org)
     with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
         f.write(html)
@@ -325,9 +348,10 @@ def create_github_app(
     base_domain: str,
     github_client: GithubClient,
     app_name: str | None = None,
+    dns_layout: str = "flat",
 ) -> dict:
     """Create a GitHub App using the provided client."""
-    manifest = build_app_manifest(base_domain, app_name)
+    manifest = build_app_manifest(base_domain, app_name, dns_layout=dns_layout)
     return github_client.create_app_from_manifest(manifest)
 
 
@@ -338,6 +362,7 @@ def main(
     app_name: str | None = None,
     callback_port: int = DEFAULT_CALLBACK_PORT,
     org: str | None = None,
+    dns_layout: str = "flat",
 ) -> None:
     """Main entry point for creating a GitHub App."""
     if app_name is None:
@@ -363,6 +388,7 @@ def main(
             app_name,
             callback_port=callback_port,
             org=org,
+            dns_layout=dns_layout,
         )
 
         # Wait for the code to be received via callback
@@ -440,4 +466,5 @@ if __name__ == "__main__":
         app_name=args.app_name,
         callback_port=args.callback_port,
         org=args.org,
+        dns_layout=args.dns_layout,
     )

--- a/scripts/create_github_app/test_create_github_app.py
+++ b/scripts/create_github_app/test_create_github_app.py
@@ -199,9 +199,14 @@ class TestBuildAppManifest:
         manifest = build_app_manifest(base_domain="mycompany.com")
         assert manifest["url"] == "https://app.mycompany.com"
 
-    def test_manifest_callback_url_format(self):
-        """Test that callback URL is https://auth.app.BASE_DOMAIN/realms/allhands/broker/github/endpoint."""
+    def test_manifest_callback_url_defaults_to_flat_layout(self):
+        """Test that the callback URL targets auth.BASE_DOMAIN by default."""
         manifest = build_app_manifest(base_domain="mycompany.com")
+        assert manifest["callback_urls"][0] == "https://auth.mycompany.com/realms/allhands/broker/github/endpoint"
+
+    def test_manifest_callback_url_nested_layout(self):
+        """Test that the nested layout targets auth.app.BASE_DOMAIN."""
+        manifest = build_app_manifest(base_domain="mycompany.com", dns_layout="nested")
         assert manifest["callback_urls"][0] == "https://auth.app.mycompany.com/realms/allhands/broker/github/endpoint"
 
     @pytest.mark.parametrize(
@@ -906,7 +911,20 @@ class TestMainWithCallbackServer:
             "my-app",
             callback_port=18080,
             org="OpenHands",
+            dns_layout="flat",
         )
+
+    def test_main_forwards_dns_layout_to_browser_manifest(self):
+        """Test that a nested-layout install builds its callback for auth.app.<base>."""
+        with mock_main_dependencies({"id": 123}) as mocks:
+            main(
+                base_domain="example.com",
+                dry_run=False,
+                app_name="my-app",
+                dns_layout="nested",
+            )
+
+        assert mocks["open_browser"].call_args.kwargs["dns_layout"] == "nested"
 
     def test_main_deletes_temp_manifest_file_after_flow(self, tmp_path):
         """Test that the temporary manifest page is removed once it has been loaded."""

--- a/scripts/test_laminar_api_ingress.py
+++ b/scripts/test_laminar_api_ingress.py
@@ -30,8 +30,7 @@ def test_replicated_enables_laminar_api_ingress_on_analytics_host() -> None:
 
     assert "apiIngress:" in values
     assert "enabled: true" in values
-    assert "analytics.app.{{repl ConfigOption \"base_domain\"}}" in values
-    assert "{{repl ConfigOption \"analytics_hostname\"}}" in values
+    assert "hostname: '{{repl ConfigOption \"computed_analytics_hostname\" }}'" in values
     assert "appServer:\n            loadBalancer:\n              enabled: false" in values
     assert "appServer:\n            loadBalancer:\n              enabled: false\n            ingress:" not in values
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -100,9 +100,9 @@ Simply omit `route53_zone_id` from your `terraform.tfvars`.
 > **Note:** Automatic TLS certificate provisioning uses Route 53 DNS challenges. If you are not using Route 53, you will also need to [bring your own TLS certificates](#manual-tls-certificate-provisioning).
 
 Create A records pointing to the instance's Elastic IP. With the installer's
-default Simple mode, every hostname is a single label under your base
-domain, so two records cover the whole install:
-- `<your-domain>`
+default Simple mode, every hostname is a single label under your base domain,
+so one record covers the whole install, the admin console at
+`admin.<your-domain>:30000` included:
 - `*.<your-domain>`
 
 If you set `hostname_mode = "legacy"` to match an install on the installer's
@@ -132,9 +132,8 @@ user_private_key_path = "/path/to/private-key.pem"
 user_ca_path          = "/path/to/ca.pem"
 ```
 
-With the default Simple mode, the certificate SANs only need the base
-domain and one wildcard:
-- `<your-domain>`
+With the default Simple mode, the certificate needs one wildcard name and
+nothing else:
 - `*.<your-domain>`
 
 If you set `hostname_mode = "legacy"`, the SANs must cover each name

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -99,9 +99,17 @@ Simply omit `route53_zone_id` from your `terraform.tfvars`.
 
 > **Note:** Automatic TLS certificate provisioning uses Route 53 DNS challenges. If you are not using Route 53, you will also need to [bring your own TLS certificates](#manual-tls-certificate-provisioning).
 
-Create A records pointing to the instance's Elastic IP for the following domains:
+Create A records pointing to the instance's Elastic IP. With the installer's
+default Simple mode, every hostname is a single label under your base
+domain, so two records cover the whole install:
+- `<your-domain>`
+- `*.<your-domain>`
+
+If you set `hostname_mode = "legacy"` to match an install on the installer's
+Legacy mode, create these instead:
 - `<your-domain>`
 - `app.<your-domain>`
+- `analytics.app.<your-domain>`
 - `auth.app.<your-domain>`
 - `llm-proxy.<your-domain>`
 - `runtime-api.<your-domain>`
@@ -124,9 +132,16 @@ user_private_key_path = "/path/to/private-key.pem"
 user_ca_path          = "/path/to/ca.pem"
 ```
 
-The certificate SANs must cover the base domain and all subdomains:
+With the default Simple mode, the certificate SANs only need the base
+domain and one wildcard:
+- `<your-domain>`
+- `*.<your-domain>`
+
+If you set `hostname_mode = "legacy"`, the SANs must cover each name
+individually, including a second wildcard for sandbox runtimes:
 - `<your-domain>`
 - `app.<your-domain>`
+- `analytics.app.<your-domain>`
 - `auth.app.<your-domain>`
 - `llm-proxy.<your-domain>`
 - `runtime-api.<your-domain>`

--- a/terraform/aws/cert.tf
+++ b/terraform/aws/cert.tf
@@ -21,7 +21,7 @@ resource "acme_certificate" "cert" {
   common_name     = var.base_domain
 
   # The wildcard layout collapses to a single SAN: every service hostname and
-  # every {id}-runtimes sandbox sits one label under base_domain.
+  # every {id}-runtime sandbox sits one label under base_domain.
   subject_alternative_names = var.hostname_mode == "wildcard" ? [
     "*.${var.base_domain}",
     ] : [

--- a/terraform/aws/cert.tf
+++ b/terraform/aws/cert.tf
@@ -18,13 +18,14 @@ resource "acme_certificate" "cert" {
   count = var.provision_cert ? 1 : 0
 
   account_key_pem = acme_registration.reg[0].account_key_pem
-  common_name     = var.base_domain
 
-  # The wildcard layout collapses to a single SAN: every service hostname and
-  # every {id}-runtime sandbox sits one label under base_domain.
-  subject_alternative_names = var.hostname_mode == "wildcard" ? [
-    "*.${var.base_domain}",
-    ] : [
+  # The wildcard layout collapses to a single name: every service hostname, the
+  # admin console and every {id}-runtime sandbox sits one label under
+  # base_domain, so the wildcard is the common name and there is nothing left to
+  # list as a SAN. Legacy names the apex and enumerates the rest.
+  common_name = var.hostname_mode == "wildcard" ? "*.${var.base_domain}" : var.base_domain
+
+  subject_alternative_names = var.hostname_mode == "wildcard" ? [] : [
     "app.${var.base_domain}",
     "analytics.app.${var.base_domain}",
     "auth.app.${var.base_domain}",

--- a/terraform/aws/cert.tf
+++ b/terraform/aws/cert.tf
@@ -20,7 +20,11 @@ resource "acme_certificate" "cert" {
   account_key_pem = acme_registration.reg[0].account_key_pem
   common_name     = var.base_domain
 
-  subject_alternative_names = [
+  # The wildcard layout collapses to a single SAN: every service hostname and
+  # every {id}-runtimes sandbox sits one label under base_domain.
+  subject_alternative_names = var.hostname_mode == "wildcard" ? [
+    "*.${var.base_domain}",
+    ] : [
     "app.${var.base_domain}",
     "analytics.app.${var.base_domain}",
     "auth.app.${var.base_domain}",

--- a/terraform/aws/dns.tf
+++ b/terraform/aws/dns.tf
@@ -4,11 +4,12 @@
 
 locals {
   # On the wildcard layout every hostname -- app, auth, analytics, llm-proxy,
-  # runtime-api and each {id}-runtime sandbox -- is a single label under
-  # base_domain, so one wildcard record covers all of them. The legacy layout
+  # runtime-api, the admin console at admin., and each {id}-runtime sandbox --
+  # is a single label under base_domain, so one wildcard record covers all of
+  # them. Nothing answers at the apex, and a wildcard matches exactly one label
+  # rather than the domain itself, so the apex gets no record. The legacy layout
   # needs each name called out, plus its own sandbox wildcard a level deeper.
   dns_records = var.hostname_mode == "wildcard" ? {
-    base     = var.base_domain
     wildcard = "*.${var.base_domain}"
     } : {
     base         = var.base_domain

--- a/terraform/aws/dns.tf
+++ b/terraform/aws/dns.tf
@@ -3,7 +3,14 @@
 # -----------------------------------------------------------------------------
 
 locals {
-  dns_records = {
+  # On the wildcard layout every hostname -- app, auth, analytics, llm-proxy,
+  # runtime-api and each {id}-runtimes sandbox -- is a single label under
+  # base_domain, so one wildcard record covers all of them. The legacy layout
+  # needs each name called out, plus its own sandbox wildcard a level deeper.
+  dns_records = var.hostname_mode == "wildcard" ? {
+    base     = var.base_domain
+    wildcard = "*.${var.base_domain}"
+    } : {
     base         = var.base_domain
     app          = "app.${var.base_domain}"
     analytics    = "analytics.app.${var.base_domain}"

--- a/terraform/aws/dns.tf
+++ b/terraform/aws/dns.tf
@@ -4,7 +4,7 @@
 
 locals {
   # On the wildcard layout every hostname -- app, auth, analytics, llm-proxy,
-  # runtime-api and each {id}-runtimes sandbox -- is a single label under
+  # runtime-api and each {id}-runtime sandbox -- is a single label under
   # base_domain, so one wildcard record covers all of them. The legacy layout
   # needs each name called out, plus its own sandbox wildcard a level deeper.
   dns_records = var.hostname_mode == "wildcard" ? {

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -15,17 +15,12 @@ output "ssh_key_file" {
 
 output "admin_console_url" {
   description = "Replicated Admin Console URL"
-  value       = "https://${var.base_domain}:30000"
+  value       = "https://admin.${var.base_domain}:30000"
 }
 
 output "app_url" {
   description = "OpenHands application URL"
   value       = "https://app.${var.base_domain}"
-}
-
-output "base_url" {
-  description = "OpenHands base URL"
-  value       = "https://${var.base_domain}"
 }
 
 output "certificate_file" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -93,6 +93,30 @@ variable "base_domain" {
   type        = string
 }
 
+variable "hostname_mode" {
+  description = <<-EOT
+    Which hostname layout to provision DNS records and a certificate for.
+    Mirrors the installer's Hostname Configuration Mode setting: "wildcard" is
+    the mode shown there as Simple, and "legacy" the one shown as Legacy.
+    "wildcard" keeps every hostname one label below base_domain, so a single
+    *.base_domain record and wildcard certificate serve the whole install.
+    "legacy" is the original layout, which puts Keycloak at auth.app.<base>,
+    analytics at analytics.app.<base>, and sandboxes under *.runtime.<base>.
+    New installs default to wildcard; set this to legacy only to match an
+    install whose Hostname Configuration Mode is Legacy.
+    The installer's third mode, Manual, has no equivalent here -- Terraform
+    cannot know hostnames you enter by hand. For that, omit route53_zone_id and
+    set provision_cert = false, then supply your own records and certificate.
+  EOT
+  type        = string
+  default     = "wildcard"
+
+  validation {
+    condition     = contains(["wildcard", "legacy"], var.hostname_mode)
+    error_message = "hostname_mode must be either \"wildcard\" or \"legacy\"."
+  }
+}
+
 variable "dns_ttl" {
   description = "TTL in seconds for DNS A records"
   type        = number


### PR DESCRIPTION
## Description

The hostname layout grew organically and ended up two labels deep in places: keycloak at `auth.app.<base>`, analytics at `analytics.app.<base>`, sandboxes under `*.runtime.<base>`. A single `*.<base>` certificate covers none of those. A self-hosted install can't come up until someone provisions three wildcards and a matching set of DNS records.

That nesting isn't buying any isolation. Browsers scope same-site checks and cookie `Domain` attributes at the registrable domain, so `auth.app.<base>` sits inside the same boundary as `auth.<base>` does. Moving that boundary would take a separate registrable domain or a public-suffix-list entry.

So this adds a Simple layout that keeps every hostname one subdomain under the base domain, and defaults new installs to it. One `*.<base>` certificate and one wildcard DNS record then cover the whole install.

Existing installs stay on the old layout, now labeled Legacy. Their certificates were issued for the nested names, and `AUTH_WEB_HOST` templates the keycloak realm's `frontendUrl` and redirect URIs on every app-pod restart, so moving keycloak out from under them would break sign-in.

Closes PLTF-3368.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

**How existing installs get pinned.** `hostname_mode` uses `value:`. KOTS re-renders `default:` on every config change, so changing a default reaches installs that never touched the field. The value is `{{repl if eq Sequence 0 }}wildcard{{repl else }}derive{{repl end }}`, and Sequence is 0 only on a fresh install, so new installs pin Simple and upgrades pin Legacy. Anyone who explicitly picked a mode keeps it either way. This is the assumption the whole upgrade story rests on, and it comes from reading the KOTS source. The behavior isn't documented.

**Hostnames are derived in one place.** Hidden `computed_*` config items resolve each hostname once and the helm chart CRs read those, replacing roughly 25 inline mode conditionals in `openhands.yaml`. Two latent bugs were living in those conditionals: `RUNTIME_URL_PATTERN` kept the chart's `example.com` default in manual mode, and `RUNTIME_API_BASE_URL` lost its `https://` scheme.

**The keycloak redirect fix is chart-only.** The frontend builds its keycloak URL by prepending `auth.` to whatever host the browser is on, which lands on `auth.app.<base>` under the Simple layout. It already prefers an explicit `auth_url` from the web client config, and that comes from an `AUTH_URL` env var the chart never set. Setting it alongside `AUTH_WEB_HOST` is the whole fix, so there's no companion change in the enterprise repo.

**Sandboxes needed no runtime-api change.** It builds each sandbox host as `{id}{RUNTIME_URL_SEPARATOR}{RUNTIME_BASE_URL}`, and that separator is a plain env var, so `-` gives `{id}-runtime.<base>` one label deep.

**Option names are deliberately out of step with their titles.** The stored values are still `wildcard` / `derive` / `custom` while the UI reads Simple / Legacy / Manual. Names go into each install's ConfigValues verbatim, so renaming one would orphan the stored value of every install that picked it.

