### PR TITLE
feat(postgres): run embedded postgres on cloudnativepg

### DIFF
--- a/charts/infra/Chart.lock
+++ b/charts/infra/Chart.lock
@@ -5,8 +5,11 @@ dependencies:
 - name: trust-manager
   repository: oci://quay.io/jetstack/charts
   version: 0.22.1
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.29.0
 - name: crd-check
   repository: oci://ghcr.io/openhands/helm-charts
   version: 0.1.0
-digest: sha256:ee6c9e0ba7c097cc59f0dc12409169a11831b548283b77ec7f8f90a94869ebf5
-generated: "2026-05-27T10:31:04.277099-04:00"
+digest: sha256:3df62bd62b3170115674a665631839d8cb9538270171cd15efbbfbfbe3e1e443
+generated: "2026-07-28T12:32:59.090739-04:00"

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra
 description: Cluster-wide infrastructure (cert-manager, trust-manager) that the OpenHands application chart depends on
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "1.0.0"
 maintainers:
   - name: all-hands-ai
@@ -15,6 +15,10 @@ dependencies:
     version: 0.22.1
     repository: oci://quay.io/jetstack/charts
     condition: trust-manager.enabled
+  - name: cloudnative-pg
+    version: 0.29.0
+    repository: https://cloudnative-pg.github.io/charts
+    condition: cloudnative-pg.enabled
   - name: crd-check
     repository: oci://ghcr.io/openhands/helm-charts
     version: 0.1.0

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -41,6 +41,23 @@ cert-manager:
       limits:
         memory: 64Mi
 
+# CloudNativePG operator. Cluster-scoped (CRDs plus a cluster-wide controller),
+# which is why it lives here rather than in the openhands chart: the Cluster
+# resources that chart renders need this operator already installed.
+#
+# Disabled by default so the cert-manager and trust-manager releases of this
+# chart do not carry it. The Replicated infra-cnpg release turns it on.
+cloudnative-pg:
+  enabled: false
+  crds:
+    create: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      memory: 200Mi
+
 trust-manager:
   enabled: true
   # Trust-manager needs to know which namespace its default CA trust bundle

--- a/charts/openhands-secrets/templates/postgres-superuser.yaml
+++ b/charts/openhands-secrets/templates/postgres-superuser.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cnpg.enabled }}
+# Superuser credentials for the CloudNativePG cluster. Same password as
+# postgres-password, in the kubernetes.io/basic-auth form the operator requires.
+# It cannot be the same Secret: a Secret's type is immutable, so retyping the
+# existing Opaque postgres-password would fail on every install that has one.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-superuser
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # Lets the operator pick up a password change without a restart.
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: {{ .Values.config.postgres_username | b64enc | quote }}
+  password: {{ .Values.config.postgres_password | b64enc | quote }}
+{{- end }}

--- a/charts/openhands-secrets/values.yaml
+++ b/charts/openhands-secrets/values.yaml
@@ -5,6 +5,11 @@
 automation:
   enabled: false
 
+# Renders the basic-auth superuser Secret the CloudNativePG operator needs.
+# Off by default, matching cnpg.enabled in the openhands chart.
+cnpg:
+  enabled: false
+
 config:
   # Security secrets
   admin_password: ""

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -454,9 +454,11 @@ To use an external PostgreSQL database instead of deploying one with the chart:
 
 ### In-Cluster PostgreSQL with CloudNativePG
 
-As an alternative to the bundled Bitnami server, the chart can run PostgreSQL through the
-[CloudNativePG](https://cloudnative-pg.io/) operator. Bitnami remains the default; nothing changes
-until you opt in.
+[CloudNativePG](https://cloudnative-pg.io/) is the recommended way to run PostgreSQL in-cluster, and
+new installs should use it.
+
+> **The bundled Bitnami server is deprecated.** It is still the default so that existing installs
+> keep working, but it will be removed in a future release. Plan to migrate.
 
 The operator is cluster-scoped and is not installed by this chart. Install it first, into any
 namespace:
@@ -466,9 +468,8 @@ helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm install cnpg cnpg/cloudnative-pg --namespace cnpg-system --create-namespace
 ```
 
-CloudNativePG needs the postgres superuser password in a `kubernetes.io/basic-auth` Secret, holding
-the same password as the `postgres-password` Secret the application reads. Secret types are
-immutable in Kubernetes, so this has to be a second Secret rather than a change to the existing one:
+Create a `kubernetes.io/basic-auth` Secret holding the same password as the existing
+`postgres-password` Secret. It has to be a second Secret because a Secret's type cannot be changed:
 
 ```bash
 kubectl create secret generic postgres-superuser -n openhands \
@@ -487,29 +488,21 @@ cnpg:
     # storageClass: fast
 ```
 
-Consumers reach whichever in-cluster backend is active through the `oh-main-postgresql` Service, so
-no other values change. On a greenfield install, also set `databaseMigrations.createDatabases: true`
-so the services create their databases on the new, empty server.
+No other values change. On a greenfield install, also set `databaseMigrations.createDatabases: true`.
 
 #### Migrating an existing Bitnami install
 
-The chart carries a one-shot migration that copies your data over and cuts every service across in a
-single upgrade. It freezes writes while it runs: workloads scale to zero, the databases are copied,
-and Helm brings them back pointed at the new server.
+One upgrade copies every database across and repoints every service.
 
-Every database on the old server is copied, discovered at run time rather than from a fixed list, so
-databases you created yourself come across as well. That includes the `postgres` database, which is
-copied into the new server's own `postgres` database. Only `template0` and `template1` are skipped;
-if `template1` holds user tables, the migration says so in its log.
+> **This takes the application down.** Writers are scaled to zero for the length of the copy. Size
+> the maintenance window against your database.
 
-Roles are not copied. OpenHands connects as the `postgres` superuser and owns every object it
-creates, so if the old server has any other role the migration stops before touching anything and
-names them — create them on the new server, or migrate them by hand, then re-run.
+Before you start: the migration **aborts if the old server has any role other than `postgres`**.
+Create those roles on the new server yourself first, or migrate them by hand.
 
-1. Install the operator and create the `postgres-superuser` Secret as above.
+1. Install the operator and create the `postgres-superuser` Secret, as above.
 
-2. Run the migration. Leave `postgresql.enabled` alone — the old server must stay up for the copy,
-   and keeping it deployed is what makes step 4 optional rather than urgent:
+2. Run the migration. Leave `postgresql.enabled` set, so the old server stays up for the copy:
 
    ```bash
    helm upgrade openhands ... \
@@ -518,13 +511,12 @@ names them — create them on the new server, or migrate them by hand, then re-r
      --timeout 30m
    ```
 
-   The migration refuses to run, leaving everything on the old server, if it cannot verify the copy
-   table by table. It is safe to re-run: a previous attempt's data is discarded and recopied.
+   Safe to re-run. It verifies every table and aborts without touching the old server if anything
+   fails.
 
-3. Verify the application works. Your data now lives in the CloudNativePG cluster, and the Bitnami
-   server is still deployed but idle.
+3. Check that the application works.
 
-4. When you are satisfied, retire the old server and hand the cluster to Helm:
+4. Retire the old server:
 
    ```bash
    helm upgrade openhands ... \
@@ -533,17 +525,13 @@ names them — create them on the new server, or migrate them by hand, then re-r
      --set cnpg.migration.enabled=false
    ```
 
-   Dropping `cnpg.migration.enabled` puts the Cluster back under Helm's management, which restarts
-   the database pod once. Leaving it enabled is also fine: it is a no-op after the first run.
+   This restarts the database pod once.
 
-   The old server's PersistentVolumeClaim (`data-<release>-postgresql-0`) is left behind on purpose.
-   Until you delete it, re-enabling `postgresql` restores the pre-migration data. Delete it once you
-   no longer want that fallback.
+The old server's PersistentVolumeClaim (`data-<release>-postgresql-0`) is kept until you delete it,
+so the pre-migration data stays available.
 
-The CloudNativePG Cluster is annotated `helm.sh/resource-policy: keep`, so Helm never deletes it —
-deleting a Cluster would take its PersistentVolumeClaims, and the data, with it. `helm uninstall`
-therefore leaves the database standing; remove it with `kubectl delete cluster <release>-pg` when you
-really mean to.
+`helm uninstall` leaves the CloudNativePG Cluster standing, since deleting it would take the data
+with it. Remove it deliberately with `kubectl delete cluster <release>-pg`.
 
 ### Bring Your Own S3-Compatible Storage
 

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -452,6 +452,99 @@ To use an external PostgreSQL database instead of deploying one with the chart:
        DB_NAME: runtime_api_db
    ```
 
+### In-Cluster PostgreSQL with CloudNativePG
+
+As an alternative to the bundled Bitnami server, the chart can run PostgreSQL through the
+[CloudNativePG](https://cloudnative-pg.io/) operator. Bitnami remains the default; nothing changes
+until you opt in.
+
+The operator is cluster-scoped and is not installed by this chart. Install it first, into any
+namespace:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm install cnpg cnpg/cloudnative-pg --namespace cnpg-system --create-namespace
+```
+
+CloudNativePG needs the postgres superuser password in a `kubernetes.io/basic-auth` Secret, holding
+the same password as the `postgres-password` Secret the application reads. Secret types are
+immutable in Kubernetes, so this has to be a second Secret rather than a change to the existing one:
+
+```bash
+kubectl create secret generic postgres-superuser -n openhands \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=postgres \
+  --from-literal=password="$POSTGRES_PASSWORD"
+```
+
+Then enable it:
+
+```yaml
+cnpg:
+  enabled: true
+  storage:
+    size: 50Gi
+    # storageClass: fast
+```
+
+Consumers reach whichever in-cluster backend is active through the `oh-main-postgresql` Service, so
+no other values change. On a greenfield install, also set `databaseMigrations.createDatabases: true`
+so the services create their databases on the new, empty server.
+
+#### Migrating an existing Bitnami install
+
+The chart carries a one-shot migration that copies your data over and cuts every service across in a
+single upgrade. It freezes writes while it runs: workloads scale to zero, the databases are copied,
+and Helm brings them back pointed at the new server.
+
+Every database on the old server is copied, discovered at run time rather than from a fixed list, so
+databases you created yourself come across as well. That includes the `postgres` database, which is
+copied into the new server's own `postgres` database. Only `template0` and `template1` are skipped;
+if `template1` holds user tables, the migration says so in its log.
+
+Roles are not copied. OpenHands connects as the `postgres` superuser and owns every object it
+creates, so if the old server has any other role the migration stops before touching anything and
+names them — create them on the new server, or migrate them by hand, then re-run.
+
+1. Install the operator and create the `postgres-superuser` Secret as above.
+
+2. Run the migration. Leave `postgresql.enabled` alone — the old server must stay up for the copy,
+   and keeping it deployed is what makes step 4 optional rather than urgent:
+
+   ```bash
+   helm upgrade openhands ... \
+     --set cnpg.enabled=true \
+     --set cnpg.migration.enabled=true \
+     --timeout 30m
+   ```
+
+   The migration refuses to run, leaving everything on the old server, if it cannot verify the copy
+   table by table. It is safe to re-run: a previous attempt's data is discarded and recopied.
+
+3. Verify the application works. Your data now lives in the CloudNativePG cluster, and the Bitnami
+   server is still deployed but idle.
+
+4. When you are satisfied, retire the old server and hand the cluster to Helm:
+
+   ```bash
+   helm upgrade openhands ... \
+     --set cnpg.enabled=true \
+     --set postgresql.enabled=false \
+     --set cnpg.migration.enabled=false
+   ```
+
+   Dropping `cnpg.migration.enabled` puts the Cluster back under Helm's management, which restarts
+   the database pod once. Leaving it enabled is also fine: it is a no-op after the first run.
+
+   The old server's PersistentVolumeClaim (`data-<release>-postgresql-0`) is left behind on purpose.
+   Until you delete it, re-enabling `postgresql` restores the pre-migration data. Delete it once you
+   no longer want that fallback.
+
+The CloudNativePG Cluster is annotated `helm.sh/resource-policy: keep`, so Helm never deletes it —
+deleting a Cluster would take its PersistentVolumeClaims, and the data, with it. `helm uninstall`
+therefore leaves the database standing; remove it with `kubectl delete cluster <release>-pg` when you
+really mean to.
+
 ### Bring Your Own S3-Compatible Storage
 
 To use an external S3 (or S3-compatible) store instead of the bundled MinIO,

--- a/charts/openhands/templates/NOTES.txt
+++ b/charts/openhands/templates/NOTES.txt
@@ -36,3 +36,25 @@ Next steps:
 
 Docs: https://docs.all-hands.dev
 {{- end }}
+{{- /*
+Outside the block above so the warning also reaches a release that deploys the
+Bitnami subchart without the application itself.
+*/}}
+{{- if .Values.postgresql.enabled }}
+{{- if eq (include "openhands.postgres.backend" .) "bitnami" }}
+
+WARNING: this release runs PostgreSQL from the bundled Bitnami chart, which is
+deprecated and will be removed in a future release.
+
+Move to CloudNativePG. The chart migrates your data in a single upgrade; see
+"In-Cluster PostgreSQL with CloudNativePG" in the chart README for the steps.
+{{- else }}
+
+NOTE: the Bitnami PostgreSQL server is still deployed alongside CloudNativePG,
+holding the pre-migration data. Once you have verified the application, retire
+it:
+
+    helm upgrade {{ .Release.Name }} ... \
+      --set postgresql.enabled=false --set cnpg.migration.enabled=false
+{{- end }}
+{{- end }}

--- a/charts/openhands/templates/_cnpg.tpl
+++ b/charts/openhands/templates/_cnpg.tpl
@@ -1,0 +1,116 @@
+{{/*
+The CloudNativePG Cluster manifest.
+
+Rendered into two places, which must agree byte for byte, because who creates
+this object depends on whether a migration is in progress:
+
+  templates/postgres-cnpg.yaml   the ordinary tracked resource
+  the migration hook's ConfigMap applied with kubectl by the pre-upgrade Job,
+                                 which needs the cluster to exist before Helm
+                                 applies the release's own resources
+
+The ownership label and both annotations are written out explicitly so that the
+object the hook creates is one Helm can adopt later. Helm refuses to take over an
+object missing any of the three.
+
+Bootstrap is always a plain initdb. The Cluster spec is therefore identical on a
+fresh install and on a migrated one, and data movement stays entirely in the
+migration hook rather than being a property of this object.
+
+Note for anyone tempted to make this a Helm hook resource so that both paths
+collapse into one: don't. Helm's default hook-delete-policy is
+before-hook-creation, so the second upgrade deletes the Cluster and recreates it
+— and CloudNativePG garbage-collects the PVCs of a deleted Cluster. That path
+destroys the database on an upgrade that looks like a no-op.
+*/}}
+{{- define "openhands.cnpg.cluster" -}}
+{{- $cnpg := .Values.cnpg -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "openhands.cnpg.clusterName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- /*
+    The shared labels carry app.kubernetes.io/managed-by from .Release.Service,
+    which is what lets Helm adopt this object once the manifest renders it. Helm
+    refuses an object missing that label or either annotation below, so keep all
+    three whatever else changes here.
+    */}}
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    # Never let Helm delete this object. It holds the database, and
+    # CloudNativePG garbage-collects the PVCs of a deleted Cluster, so a delete
+    # is unrecoverable. Without this, an upgrade that stops rendering the
+    # Cluster — switching the migration back on, or uninstalling the release —
+    # would take the data with it.
+    helm.sh/resource-policy: keep
+spec:
+  instances: {{ $cnpg.instances }}
+  imageName: {{ printf "%s:%s" $cnpg.image.repository (toString $cnpg.image.tag) | quote }}
+  imagePullPolicy: {{ $cnpg.image.pullPolicy | default "IfNotPresent" }}
+  {{- with $cnpg.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  # Every OpenHands service connects as the postgres superuser and creates its
+  # own database on startup, so superuser access must be on and its password
+  # must come from a Secret we control rather than one CloudNativePG generates.
+  enableSuperuserAccess: {{ $cnpg.enableSuperuserAccess }}
+  {{- if $cnpg.enableSuperuserAccess }}
+  superuserSecret:
+    name: {{ $cnpg.superuserSecret.name }}
+  {{- end }}
+  # A PodDisruptionBudget on a single-instance cluster has no availability to
+  # protect and blocks node drains, which stalls Kubernetes upgrades.
+  enablePDB: {{ $cnpg.enablePDB }}
+  primaryUpdateStrategy: {{ $cnpg.primaryUpdateStrategy }}
+  primaryUpdateMethod: {{ $cnpg.primaryUpdateMethod }}
+  bootstrap:
+    initdb:
+      encoding: {{ $cnpg.initdb.encoding | quote }}
+      {{- with $cnpg.initdb.localeCollate }}
+      localeCollate: {{ . | quote }}
+      {{- end }}
+      {{- with $cnpg.initdb.localeCType }}
+      localeCType: {{ . | quote }}
+      {{- end }}
+  storage:
+    size: {{ $cnpg.storage.size | quote }}
+    {{- with $cnpg.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- with $cnpg.walStorage }}
+  {{- if .enabled }}
+  walStorage:
+    size: {{ .size | quote }}
+    {{- with .storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- with $cnpg.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $cnpg.parameters }}
+  postgresql:
+    parameters:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with $cnpg.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $cnpg.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $cnpg.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -456,29 +456,15 @@
   value: "true"
 {{- end }}
 
-{{- $dbSslMode := "prefer" }}
-{{- if not .Values.postgresql.enabled }}
-{{- $dbSslMode = .Values.externalDatabase.sslMode | default "prefer" }}
-{{- end }}
-{{- if .Values.postgresql.enabled }}
+{{- $dbSslMode := include "openhands.postgres.sslMode" . }}
 - name: DB_HOST
-  value: "{{ .Release.Name }}-postgresql"
+  value: {{ include "openhands.postgres.host" . | quote }}
 - name: DB_PORT
-  value: "{{ .Values.postgresql.primary.service.ports.postgresql | default 5432 }}"
+  value: {{ include "openhands.postgres.port" . | quote }}
 - name: DB_USER
-  value: "{{ .Values.postgresql.auth.username }}"
+  value: {{ include "openhands.postgres.username" . | quote }}
 - name: DB_NAME
-  value: "{{ .Values.postgresql.auth.database }}"
-{{- else }}
-- name: DB_HOST
-  value: "{{ .Values.externalDatabase.host }}"
-- name: DB_PORT
-  value: "{{ .Values.externalDatabase.port | default 5432 }}"
-- name: DB_USER
-  value: "{{ .Values.externalDatabase.username }}"
-- name: DB_NAME
-  value: "{{ .Values.externalDatabase.database }}"
-{{- end }}
+  value: {{ include "openhands.postgres.database" . | quote }}
 - name: DB_SSL_MODE
   value: {{ $dbSslMode | quote }}
 - name: PGSSLMODE
@@ -539,7 +525,7 @@
 - name: DB_PASS
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ include "openhands.postgres.passwordSecret" . }}
       key: password
 {{- if .Values.jira.enabled }}
 - name: ENABLE_JIRA

--- a/charts/openhands/templates/_postgres.tpl
+++ b/charts/openhands/templates/_postgres.tpl
@@ -1,0 +1,108 @@
+{{/*
+PostgreSQL backend selection.
+
+The chart supports three backends, in this precedence order:
+
+  cnpg      a CloudNativePG Cluster managed by this chart (cnpg.enabled)
+  bitnami   the bundled Bitnami postgresql subchart (postgresql.enabled)
+  external  an operator-supplied server (externalDatabase.*)
+
+CNPG wins over Bitnami when both are enabled, which is the state a migration
+runs in: the old server stays deployed so its data survives for rollback while
+every consumer is already pointed at the new one.
+
+Consumers reach whichever in-cluster backend is active through a single alias
+Service, so subchart values that hardcode the hostname need no per-backend
+changes. See templates/service.yaml.
+*/}}
+
+{{- define "openhands.postgres.backend" -}}
+{{- if .Values.cnpg.enabled -}}
+cnpg
+{{- else if .Values.postgresql.enabled -}}
+bitnami
+{{- else -}}
+external
+{{- end -}}
+{{- end -}}
+
+{{/* Name of the CNPG Cluster, and therefore of its <name>-rw/-ro/-r Services. */}}
+{{- define "openhands.cnpg.clusterName" -}}
+{{- .Values.cnpg.clusterName | default (printf "%s-pg" .Release.Name) -}}
+{{- end -}}
+
+{{/* Alias Service every consumer connects to for an in-cluster backend. */}}
+{{- define "openhands.postgres.aliasService" -}}
+oh-main-postgresql
+{{- end -}}
+
+{{- define "openhands.postgres.host" -}}
+{{- $backend := include "openhands.postgres.backend" . -}}
+{{- if eq $backend "cnpg" -}}
+{{- include "openhands.postgres.aliasService" . -}}
+{{- else if eq $backend "bitnami" -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openhands.postgres.port" -}}
+{{- $backend := include "openhands.postgres.backend" . -}}
+{{- if eq $backend "cnpg" -}}
+5432
+{{- else if eq $backend "bitnami" -}}
+{{- .Values.postgresql.primary.service.ports.postgresql | default 5432 -}}
+{{- else -}}
+{{- .Values.externalDatabase.port | default 5432 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Application database user and name. Under CNPG both fall back to the Bitnami
+values so that turning cnpg.enabled on carries the existing names over with no
+further configuration; set cnpg.username / cnpg.database to override.
+*/}}
+{{- define "openhands.postgres.username" -}}
+{{- $backend := include "openhands.postgres.backend" . -}}
+{{- if eq $backend "cnpg" -}}
+{{- .Values.cnpg.username | default .Values.postgresql.auth.username -}}
+{{- else if eq $backend "bitnami" -}}
+{{- .Values.postgresql.auth.username -}}
+{{- else -}}
+{{- .Values.externalDatabase.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openhands.postgres.database" -}}
+{{- $backend := include "openhands.postgres.backend" . -}}
+{{- if eq $backend "cnpg" -}}
+{{- .Values.cnpg.database | default .Values.postgresql.auth.database -}}
+{{- else if eq $backend "bitnami" -}}
+{{- .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret holding the application's PostgreSQL password. CNPG names it explicitly
+rather than reading it out of a subchart that may be disabled; the Bitnami and
+external paths keep sourcing it as they always have.
+*/}}
+{{- define "openhands.postgres.passwordSecret" -}}
+{{- if .Values.cnpg.enabled -}}
+{{- .Values.cnpg.credentials.existingSecret -}}
+{{- else -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{/* sslMode for connections. In-cluster backends are unencrypted by default. */}}
+{{- define "openhands.postgres.sslMode" -}}
+{{- if eq (include "openhands.postgres.backend" .) "external" -}}
+{{- .Values.externalDatabase.sslMode | default "prefer" -}}
+{{- else -}}
+prefer
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/templates/postgres-cnpg-migration.yaml
+++ b/charts/openhands/templates/postgres-cnpg-migration.yaml
@@ -1,0 +1,652 @@
+{{- /*
+One-time migration of the in-cluster database from the Bitnami postgresql
+subchart to a CloudNativePG cluster.
+
+Shape: a pre-upgrade orchestrator Job (kubectl) that drives a transient copy Pod
+(postgres client). The copy runs in its own Pod rather than in the Job because
+the orchestrator has to keep control across the whole sequence: it freezes
+writes before the copy and must unfreeze them if anything fails, which it cannot
+do from a container that has already exited.
+
+Sequence, all of it idempotent and guarded by a marker ConfigMap:
+
+  1. (-3) RBAC + ConfigMap carrying the Cluster manifest, the copy Pod manifest
+     and the copy script.
+  2. (-2) Orchestrator Job: apply the Cluster (which this Job owns while a
+     migration is pending — see postgres-cnpg.yaml); stop there if already
+     migrated or if there is no Bitnami server; otherwise wait for the Cluster,
+     record replica counts, scale writers to zero and suspend CronJobs, run the
+     copy Pod, verify, and write the marker.
+
+Writers are deliberately left scaled to zero on success. Helm's own apply
+restores them, and it is that apply which repoints them at the new server —
+bringing them back here would reconnect them to the old one and strand every
+write they made in between.
+
+Pre-upgrade only: a fresh install has nothing to copy, and pre-upgrade hooks do
+not run on `helm install`. Weights sit after the CRD check (-5) so a missing
+operator is reported by that hook instead of failing here.
+*/ -}}
+{{- if and .Values.cnpg.enabled .Values.cnpg.migration.enabled }}
+{{- $rel := .Release.Name }}
+{{- $ns := .Release.Namespace }}
+{{- $m := .Values.cnpg.migration }}
+{{- $cluster := include "openhands.cnpg.clusterName" . }}
+{{- $sts := printf "%s-postgresql" $rel }}
+{{- $srcHost := $m.sourceHost | default $sts }}
+{{- $name := printf "%s-postgres-cnpg-migration" $rel }}
+{{- $copyPod := printf "%s-copy" $name }}
+{{- $marker := "postgres-cnpg-migrated" }}
+{{- $state := "postgres-cnpg-migration-state" }}
+{{- /*
+Workloads that write to the shared database, named as this chart renders them.
+Everything else in the namespace (redis, minio, the Replicated SDK, agent-canvas,
+Laminar and its own database) is left running.
+*/ -}}
+{{- $writers := list }}
+{{- if .Values.enabled }}
+{{- $writers = concat $writers (list "deployment/openhands" "deployment/openhands-integrations" "deployment/openhands-mcp") }}
+{{- end }}
+{{- if .Values.keycloak.enabled }}
+{{- $writers = append $writers "statefulset/keycloak" }}
+{{- end }}
+{{- if (index .Values "litellm-helm").enabled }}
+{{- $writers = append $writers (printf "deployment/%s-litellm" $rel) }}
+{{- end }}
+{{- if (index .Values "runtime-api").enabled }}
+{{- $writers = append $writers (printf "deployment/%s-runtime-api" $rel) }}
+{{- end }}
+{{- if .Values.automation.enabled }}
+{{- $writers = append $writers "deployment/automation" }}
+{{- end }}
+{{- if (index .Values "plugin-directory").enabled }}
+{{- $writers = append $writers "deployment/plugin-directory" }}
+{{- end }}
+{{- if (index .Values "integrations-hub").enabled }}
+{{- $writers = append $writers "deployment/integrations-hub" }}
+{{- end }}
+{{- $writers = concat $writers $m.extraWriters }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- with $m.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "create", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "statefulsets/scale"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  # The Cluster, identical to what templates/postgres-cnpg.yaml renders once the
+  # migration is switched off, so that Helm can adopt this object then.
+  cluster.yaml: |
+    {{- include "openhands.cnpg.cluster" . | nindent 4 }}
+  copy-pod.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: {{ $copyPod }}
+      namespace: {{ $ns }}
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-migration-copy
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: {{ $m.timeouts.copy }}
+      {{- with $m.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: copy
+          image: "{{ $m.images.postgres.repository | default .Values.cnpg.image.repository }}:{{ $m.images.postgres.tag | default .Values.cnpg.image.tag }}"
+          imagePullPolicy: {{ $m.images.postgres.pullPolicy | default "IfNotPresent" }}
+          command: ["bash", "/scripts/copy.sh"]
+          env:
+            - name: SRC_HOST
+              value: {{ $srcHost | quote }}
+            - name: SRC_PORT
+              value: "5432"
+            - name: SRC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $m.sourceSecret.name }}
+                  key: {{ $m.sourceSecret.usernameKey }}
+            - name: SRC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $m.sourceSecret.name }}
+                  key: {{ $m.sourceSecret.passwordKey }}
+            - name: DST_HOST
+              value: {{ printf "%s-rw" $cluster | quote }}
+            - name: DST_PORT
+              value: "5432"
+            # The superuser Secret CloudNativePG manages the target with. Read
+            # separately from the source credentials so the two are allowed to
+            # differ.
+            - name: DST_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cnpg.superuserSecret.name }}
+                  key: username
+            - name: DST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cnpg.superuserSecret.name }}
+                  key: password
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            {{- toYaml $m.resources | nindent 12 }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ $name }}
+            defaultMode: 0555
+            items:
+              - key: copy.sh
+                path: copy.sh
+  # Runs in the copy Pod. Copies database by database and verifies each one.
+  copy.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    log() { echo "[copy] $*"; }
+    SQ="psql -h $SRC_HOST -p $SRC_PORT -U $SRC_USER -v ON_ERROR_STOP=1 -tAq"
+    DQ="psql -h $DST_HOST -p $DST_PORT -U $DST_USER -v ON_ERROR_STOP=1 -tAq"
+    src() { PGPASSWORD="$SRC_PASSWORD" $SQ "$@"; }
+    dst() { PGPASSWORD="$DST_PASSWORD" $DQ "$@"; }
+
+    log "waiting for both servers to accept connections"
+    for _ in $(seq 1 60); do
+      if PGPASSWORD="$SRC_PASSWORD" pg_isready -h "$SRC_HOST" -p "$SRC_PORT" -U "$SRC_USER" >/dev/null 2>&1 \
+        && PGPASSWORD="$DST_PASSWORD" pg_isready -h "$DST_HOST" -p "$DST_PORT" -U "$DST_USER" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 2
+    done
+    PGPASSWORD="$SRC_PASSWORD" pg_isready -h "$SRC_HOST" -p "$SRC_PORT" -U "$SRC_USER" >/dev/null
+    PGPASSWORD="$DST_PASSWORD" pg_isready -h "$DST_HOST" -p "$DST_PORT" -U "$DST_USER" >/dev/null
+    log "source $(src -d postgres -c 'SHOW server_version') -> target $(dst -d postgres -c 'SHOW server_version')"
+
+    # Only the postgres superuser is expected to exist: OpenHands services all
+    # connect as it and own every object. Anything else would be silently left
+    # behind, so stop instead of copying a subset.
+    EXTRA_ROLES=$(src -d postgres -c "SELECT coalesce(string_agg(rolname,','),'') FROM pg_roles WHERE rolname <> '$SRC_USER' AND rolname NOT LIKE 'pg\_%'")
+    if [ -n "$EXTRA_ROLES" ]; then
+      log "ERROR: the source has roles this migration does not carry: $EXTRA_ROLES"
+      log "       migrate them by hand, then re-run."
+      exit 1
+    fi
+    log "role check passed: only '$SRC_USER' exists"
+
+    # Every database the source will let us connect to, discovered rather than
+    # listed, so databases an operator created by hand come across too. The
+    # postgres database is included: it is a normal database that may hold user
+    # objects. Only the template databases are skipped.
+    DBS=$(src -d postgres -c "SELECT datname||'|'||pg_encoding_to_char(encoding)||'|'||datcollate||'|'||datctype FROM pg_database WHERE datallowconn AND datname NOT IN ('template0','template1') ORDER BY 1")
+    if [ -z "$(printf '%s\n' "$DBS" | grep -v '^postgres|' || true)" ]; then
+      log "ERROR: the source has no databases besides 'postgres'; refusing to declare success"
+      exit 1
+    fi
+
+    # Template databases are not copied, so say so rather than dropping them
+    # silently. A customised template1 only affects databases created later.
+    T1_TABLES=$(src -d template1 -c "SELECT count(*) FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema')")
+    if [ "$T1_TABLES" != "0" ]; then
+      log "WARNING: the source's template1 holds $T1_TABLES user table(s), which are NOT copied."
+    fi
+
+    for entry in $DBS; do
+      IFS='|' read -r db enc coll ctype <<< "$entry"
+      log "--- $db (encoding=$enc collate=$coll) ---"
+      PG_DUMP_ARGS=""
+      if [ "$db" = "postgres" ]; then
+        # The target's postgres database is created by initdb and is the
+        # maintenance database CloudNativePG's own instance manager connects to,
+        # so it can be neither dropped nor recreated. Copy into it as it stands,
+        # with --clean so that a re-run replaces exactly the objects an earlier
+        # attempt brought over.
+        DST_ENC=$(dst -d postgres -c "SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname='postgres'")
+        if [ "$DST_ENC" != "$enc" ]; then
+          log "ERROR: the source's postgres database is $enc but the target's is $DST_ENC, and"
+          log "       an in-place copy cannot convert between encodings. Set"
+          log "       cnpg.initdb.encoding to $enc and let the cluster bootstrap again."
+          exit 1
+        fi
+        DST_COLL=$(dst -d postgres -c "SELECT datcollate FROM pg_database WHERE datname='postgres'")
+        if [ "$DST_COLL" != "$coll" ]; then
+          log "WARNING: the postgres database's collation differs (source $coll, target"
+          log "         $DST_COLL). Set cnpg.initdb.localeCollate to match if text ordering matters."
+        fi
+        PG_DUMP_ARGS="--clean --if-exists"
+      else
+        # Before cutover the target holds nothing but a copy, so a partial or
+        # complete earlier attempt is always safe to discard.
+        if [ -n "$(dst -d postgres -c "SELECT 1 FROM pg_database WHERE datname='$db'")" ]; then
+          log "discarding an earlier attempt's copy"
+          dst -d postgres -c "DROP DATABASE \"$db\" WITH (FORCE)" >/dev/null
+        fi
+        # TEMPLATE template0 so the source's locale can be applied verbatim.
+        dst -d postgres -c "CREATE DATABASE \"$db\" WITH TEMPLATE template0 ENCODING '$enc' LC_COLLATE '$coll' LC_CTYPE '$ctype'" >/dev/null
+      fi
+      START=$(date +%s)
+      PGPASSWORD="$SRC_PASSWORD" pg_dump -h "$SRC_HOST" -p "$SRC_PORT" -U "$SRC_USER" -d "$db" $PG_DUMP_ARGS \
+        | PGPASSWORD="$DST_PASSWORD" psql -h "$DST_HOST" -p "$DST_PORT" -U "$DST_USER" -d "$db" \
+            -v ON_ERROR_STOP=1 -q -o /dev/null
+      log "copied in $(( $(date +%s) - START ))s"
+      # The public schema must survive: --clean can drop it, and a database
+      # without it breaks anything that relies on the default search_path.
+      if [ -z "$(dst -d "$db" -c "SELECT 1 FROM pg_namespace WHERE nspname='public'")" ]; then
+        log "ERROR: the public schema is missing from '$db' after the copy."
+        exit 1
+      fi
+    done
+
+    # Verify table counts and every table's row count, per database.
+    FAIL=0
+    for entry in $DBS; do
+      IFS='|' read -r db _ _ _ <<< "$entry"
+      GEN="SELECT coalesce(string_agg(format('SELECT %L AS t, count(*) AS n FROM %I.%I', schemaname||'.'||tablename, schemaname, tablename), ' UNION ALL '),'SELECT NULL,NULL') FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema')"
+      Q=$(src -d "$db" -c "$GEN")
+      SRC_TABLES=$(src -d "$db" -c "SELECT count(*) FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema')")
+      DST_TABLES=$(dst -d "$db" -c "SELECT count(*) FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema')")
+      SRC_FP=$(src -d "$db" -c "$Q ORDER BY 1" | md5sum | cut -d' ' -f1)
+      DST_FP=$(dst -d "$db" -c "$Q ORDER BY 1" | md5sum | cut -d' ' -f1)
+      SRC_ROWS=$(src -d "$db" -c "$Q" | awk -F'|' '{s+=$2} END {print s+0}')
+      if [ "$SRC_FP" = "$DST_FP" ] && [ "$SRC_TABLES" = "$DST_TABLES" ]; then
+        log "verified $db: tables=$SRC_TABLES rows=$SRC_ROWS"
+      else
+        DST_ROWS=$(dst -d "$db" -c "$Q" | awk -F'|' '{s+=$2} END {print s+0}')
+        log "MISMATCH $db: tables src=$SRC_TABLES dst=$DST_TABLES rows src=$SRC_ROWS dst=$DST_ROWS"
+        FAIL=1
+      fi
+    done
+    if [ "$FAIL" != "0" ]; then
+      log "ERROR: verification failed; the source database is untouched"
+      exit 1
+    fi
+    log "COPY VERIFIED"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ $m.backoffLimit }}
+  activeDeadlineSeconds: {{ $m.timeouts.total }}
+  template:
+    metadata:
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-migration
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      {{- with $m.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: "{{ $m.images.kubectl.repository }}:{{ $m.images.kubectl.tag }}"
+          imagePullPolicy: {{ $m.images.kubectl.pullPolicy | default "IfNotPresent" }}
+          env:
+            # kubectl writes its discovery cache under $HOME; give it a writable one.
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml $m.resources | nindent 12 }}
+          volumeMounts:
+            - name: manifests
+              mountPath: /migration
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              NS='{{ $ns }}'
+              STS='{{ $sts }}'
+              CLUSTER='{{ $cluster }}'
+              COPY_POD='{{ $copyPod }}'
+              MARKER='{{ $marker }}'
+              STATE='{{ $state }}'
+              WRITERS='{{ join " " $writers }}'
+              CRONJOB_PREFIX='{{ $rel }}-'
+              CLUSTER_TIMEOUT={{ $m.timeouts.clusterReady }}
+              SETTLE={{ $m.timeouts.settle }}
+              DRAIN_TIMEOUT={{ $m.timeouts.drain }}
+              COPY_TIMEOUT={{ $m.timeouts.copy }}
+              K="kubectl -n $NS"
+
+              log() { echo "[migrate] $*"; }
+
+              # ---- Cluster ----
+              # This Job owns the Cluster while a migration is pending, so apply
+              # it on every run, ahead of the guards below: that is what keeps
+              # changes to the cnpg values reaching the cluster on later
+              # upgrades. `apply` patches an existing Cluster; it never replaces
+              # it, so the data is untouched.
+              # metadata.generation across the apply tells us whether the
+              # operator has any reconciling left to do. Unchanged means the
+              # apply was a no-op and whatever the Cluster reports is current;
+              # changed (or newly created) means a reconcile is pending and its
+              # status still describes the old state. CloudNativePG publishes no
+              # observedGeneration to wait on, so section 1 uses this.
+              GEN_BEFORE=$($K get cluster "$CLUSTER" -o jsonpath='{.metadata.generation}' 2>/dev/null || echo "")
+              log "applying cluster '$CLUSTER'"
+              $K apply -f /migration/cluster.yaml
+              GEN_AFTER=$($K get cluster "$CLUSTER" -o jsonpath='{.metadata.generation}' 2>/dev/null || echo "")
+
+              # ---- Guards ----
+              if $K get configmap "$MARKER" >/dev/null 2>&1; then
+                log "marker '$MARKER' present; already migrated. Nothing else to do."
+                exit 0
+              fi
+              if ! $K get statefulset "$STS" >/dev/null 2>&1; then
+                log "no Bitnami StatefulSet '$STS'; nothing to migrate."
+                exit 0
+              fi
+              log "found '$STS'. Migrating to CloudNativePG cluster '$CLUSTER'."
+
+              # Restore whatever we scaled down, so a failure leaves the
+              # application running against the untouched source database.
+              SUCCESS=0
+              restore() {
+                if [ "$SUCCESS" = "1" ]; then
+                  log "writers left scaled to zero on purpose; the upgrade's apply brings them back on the new server."
+                  return
+                fi
+                log "restoring writers after a failed migration"
+                RECORDED=$($K get configmap "$STATE" -o jsonpath='{.data.replicas}' 2>/dev/null || echo "")
+                for line in $RECORDED; do
+                  W=$(echo "$line" | cut -d= -f1)
+                  N=$(echo "$line" | cut -d= -f2)
+                  log "  scaling $W back to $N"
+                  $K scale "$W" --replicas="$N" >/dev/null 2>&1 || true
+                done
+                for cj in $($K get cronjobs -o name 2>/dev/null | sed 's|.*/||'); do
+                  case "$cj" in
+                    "$CRONJOB_PREFIX"*) $K patch cronjob "$cj" -p '{"spec":{"suspend":false}}' >/dev/null 2>&1 || true ;;
+                  esac
+                done
+                log "restore done; the application is back on '$STS'."
+              }
+              trap restore EXIT
+
+              # ---- 1. Target cluster ----
+              # Wait for the operator to have settled on the spec applied above,
+              # rather than for something to be merely serving. A readiness
+              # signal that is not specific to the server the copy will actually
+              # write to is how the Bitnami PVC migration streamed a restore
+              # into a temporary init server that was then stopped.
+              #
+              # Measured against a real cluster, an operand-image change reports
+              # this one second after the apply:
+              #
+              #   phase                readyInstances   spec.imageName == status.image
+              #   healthy (stale)      1                yes
+              #
+              # Every field says healthy while the operator is about to delete
+              # the primary pod and build a new one, so no single snapshot can be
+              # trusted. status.image in particular is written eagerly and never
+              # lags, so it does not indicate a pending roll. Two things guard
+              # against that snapshot:
+              #
+              #   1. If the apply changed the spec, give the operator SETTLE
+              #      seconds before believing anything. It moved phase off
+              #      healthy in about a second, so this is a wide margin.
+              #   2. Require the healthy reading to hold across consecutive
+              #      polls, so a slow operator cannot be missed in the gap.
+              #
+              # Held together, then, all of:
+              #   phase is the terminal healthy phase
+              #   readyInstances has caught up with spec.instances
+              #   currentPrimary == targetPrimary, so no switchover is running
+              #   status.image == spec.imageName, which catches a roll that
+              #     started and stalled rather than one that has yet to start
+              # Both sides of every comparison come from the live object, so this
+              # asks whether the operator agrees with its own spec rather than
+              # trusting a value rendered into this script.
+              if [ "$GEN_BEFORE" != "$GEN_AFTER" ]; then
+                log "the apply changed the cluster spec (generation '$GEN_BEFORE' -> '$GEN_AFTER');"
+                log "  waiting ${SETTLE}s for the operator to act on it before reading its health"
+                sleep "$SETTLE"
+              fi
+              HEALTHY='Cluster in healthy state'
+              STABLE_POLLS=3
+              SETTLED=0
+              C_PHASE='' C_READY='' C_WANT='' C_CUR='' C_TGT='' C_SPECIMG='' C_STATIMG=''
+              log "waiting for '$CLUSTER' to settle (timeout ${CLUSTER_TIMEOUT}s)"
+              DEADLINE=$(( $(date +%s) + CLUSTER_TIMEOUT ))
+              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                SNAP=$($K get cluster "$CLUSTER" -o jsonpath='{.status.phase}|{.status.readyInstances}|{.spec.instances}|{.status.currentPrimary}|{.status.targetPrimary}|{.spec.imageName}|{.status.image}' 2>/dev/null || echo "")
+                C_PHASE=$(printf '%s' "$SNAP" | cut -d'|' -f1)
+                C_READY=$(printf '%s' "$SNAP" | cut -d'|' -f2)
+                C_WANT=$(printf '%s' "$SNAP" | cut -d'|' -f3)
+                C_CUR=$(printf '%s' "$SNAP" | cut -d'|' -f4)
+                C_TGT=$(printf '%s' "$SNAP" | cut -d'|' -f5)
+                C_SPECIMG=$(printf '%s' "$SNAP" | cut -d'|' -f6)
+                C_STATIMG=$(printf '%s' "$SNAP" | cut -d'|' -f7)
+                if [ "$C_PHASE" = "$HEALTHY" ] && [ -n "$C_READY" ] && [ "$C_READY" = "$C_WANT" ] \
+                   && [ -n "$C_CUR" ] && [ "$C_CUR" = "$C_TGT" ] \
+                   && [ -n "$C_STATIMG" ] && [ "$C_SPECIMG" = "$C_STATIMG" ]; then
+                  SETTLED=$(( SETTLED + 1 ))
+                  [ "$SETTLED" -ge "$STABLE_POLLS" ] && break
+                else
+                  SETTLED=0
+                fi
+                sleep 5
+              done
+              if [ "$SETTLED" -lt "$STABLE_POLLS" ]; then
+                log "ERROR: cluster '$CLUSTER' did not settle within ${CLUSTER_TIMEOUT}s."
+                log "  phase='$C_PHASE' (want '$HEALTHY')"
+                log "  readyInstances='$C_READY' spec.instances='$C_WANT'"
+                log "  currentPrimary='$C_CUR' targetPrimary='$C_TGT'"
+                log "  spec.imageName='$C_SPECIMG' status.image='$C_STATIMG'"
+                exit 1
+              fi
+              PRIMARY="$C_CUR"
+              log "cluster settled: primary '$PRIMARY' running '$C_STATIMG'"
+
+              # ---- 2. Freeze writes ----
+              # Record the replica counts once: a retry of this Job must not
+              # capture the zeros a previous attempt left behind.
+              if $K get configmap "$STATE" >/dev/null 2>&1; then
+                log "reusing recorded replica counts from an earlier attempt"
+              else
+                : > /tmp/replicas
+                for w in $WRITERS; do
+                  CUR=$($K get "$w" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+                  [ -z "$CUR" ] && { log "  $w not present; skipping"; continue; }
+                  echo "$w=$CUR" >> /tmp/replicas
+                done
+                $K create configmap "$STATE" --from-file=replicas=/tmp/replicas >/dev/null
+                log "recorded replica counts:"
+                sed 's/^/    /' /tmp/replicas
+              fi
+
+              log "scaling writers to zero"
+              for line in $($K get configmap "$STATE" -o jsonpath='{.data.replicas}'); do
+                W=$(echo "$line" | cut -d= -f1)
+                $K scale "$W" --replicas=0 >/dev/null 2>&1 || log "  could not scale $W"
+              done
+
+              log "suspending CronJobs named '${CRONJOB_PREFIX}*'"
+              for cj in $($K get cronjobs -o name 2>/dev/null | sed 's|.*/||'); do
+                case "$cj" in
+                  "$CRONJOB_PREFIX"*) $K patch cronjob "$cj" -p '{"spec":{"suspend":true}}' >/dev/null 2>&1 || true ;;
+                esac
+              done
+
+              log "waiting for writer pods to exit (timeout ${DRAIN_TIMEOUT}s)"
+              DEADLINE=$(( $(date +%s) + DRAIN_TIMEOUT ))
+              REMAINING=-1
+              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                REMAINING=0
+                for line in $($K get configmap "$STATE" -o jsonpath='{.data.replicas}'); do
+                  W=$(echo "$line" | cut -d= -f1)
+                  N=$($K get "$W" -o jsonpath='{.status.replicas}' 2>/dev/null || echo "")
+                  [ -n "$N" ] && [ "$N" != "0" ] && REMAINING=$(( REMAINING + N ))
+                done
+                [ "$REMAINING" = "0" ] && break
+                sleep 5
+              done
+              # Confirm the drain instead of announcing it: the loop above also
+              # ends on timeout, and a source still taking writes yields a target
+              # that cannot be verified against it. Failing here scales the
+              # writers back up and leaves everything on the old server.
+              if [ "$REMAINING" != "0" ]; then
+                log "ERROR: writers did not stop within ${DRAIN_TIMEOUT}s ($REMAINING pod(s) still running)."
+                log "       Copying from a source that is still being written to would not be consistent."
+                exit 1
+              fi
+              log "writers are down"
+
+              # ---- 3. Copy ----
+              # Stamp the server the copy is about to write to. If it turns out
+              # to have been replaced or restarted underneath the copy, that is
+              # worth naming in this log: diagnosing exactly that on the PVC
+              # migration took a customer support bundle.
+              PRIMARY_STAMP=$($K get pod "$PRIMARY" -o jsonpath='{.metadata.uid}/{.status.containerStatuses[?(@.name=="postgres")].restartCount}' 2>/dev/null || echo "")
+              $K delete pod "$COPY_POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+              log "starting copy pod '$COPY_POD'"
+              $K apply -f /migration/copy-pod.yaml
+              DEADLINE=$(( $(date +%s) + COPY_TIMEOUT ))
+              PHASE=""
+              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                PHASE=$($K get pod "$COPY_POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+                { [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; } && break
+                sleep 5
+              done
+              log "----- copy log -----"
+              $K logs "$COPY_POD" 2>/dev/null || true
+              log "--------------------"
+              if [ "$PHASE" != "Succeeded" ]; then
+                log "ERROR: copy did not succeed (phase='$PHASE'). The source database is untouched."
+                exit 1
+              fi
+
+              # The copy re-read every table's row count from both servers after
+              # writing, so a restart here does not by itself mean the data is
+              # wrong, and blocking the upgrade over it would be worse than
+              # saying so. Report it and carry on.
+              PRIMARY_STAMP_NOW=$($K get pod "$PRIMARY" -o jsonpath='{.metadata.uid}/{.status.containerStatuses[?(@.name=="postgres")].restartCount}' 2>/dev/null || echo "")
+              if [ "$PRIMARY_STAMP_NOW" != "$PRIMARY_STAMP" ]; then
+                log "WARNING: the primary '$PRIMARY' restarted or was replaced while the copy ran"
+                log "         (was '$PRIMARY_STAMP', now '$PRIMARY_STAMP_NOW'). The copy verified"
+                log "         every table afterwards and matched, so the data is consistent, but"
+                log "         find out what restarted it before relying on this cluster."
+              fi
+
+              # ---- 4. Record success ----
+              $K create configmap "$MARKER" \
+                --from-literal=cluster="$CLUSTER" \
+                --from-literal=source="$STS" \
+                --from-literal=note="database copied from the Bitnami server to CloudNativePG" >/dev/null
+              $K delete pod "$COPY_POD" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+              SUCCESS=1
+              log "migration complete. The upgrade will now point every service at '$CLUSTER'."
+              log "The Bitnami PersistentVolumeClaim is retained: re-enabling postgresql restores the pre-migration data."
+      volumes:
+        - name: manifests
+          configMap:
+            name: {{ $name }}
+            items:
+              - key: cluster.yaml
+                path: cluster.yaml
+              - key: copy-pod.yaml
+                path: copy-pod.yaml
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/openhands/templates/postgres-cnpg-migration.yaml
+++ b/charts/openhands/templates/postgres-cnpg-migration.yaml
@@ -10,22 +10,31 @@ do from a container that has already exited.
 
 Sequence, all of it idempotent and guarded by a marker ConfigMap:
 
-  1. (-3) RBAC + ConfigMap carrying the Cluster manifest, the copy Pod manifest
-     and the copy script.
-  2. (-2) Orchestrator Job: apply the Cluster (which this Job owns while a
-     migration is pending — see postgres-cnpg.yaml); stop there if already
-     migrated or if there is no Bitnami server; otherwise wait for the Cluster,
-     record replica counts, scale writers to zero and suspend CronJobs, run the
-     copy Pod, verify, and write the marker.
+  1. pre-upgrade (-3) RBAC + ConfigMap carrying the Cluster manifest, the copy
+     Pod manifest and the copy script.
+  2. pre-upgrade (-2) Orchestrator Job: apply the Cluster (which this Job owns
+     while a migration is pending — see postgres-cnpg.yaml); stop there if
+     already migrated or if there is no Bitnami server; otherwise wait for the
+     Cluster, record replica counts and CronJob suspend states, scale writers
+     to zero and suspend CronJobs, run the copy Pod, verify, and write the
+     marker.
+  3. post-upgrade (-2) Resume Job: finish the restore once the upgrade's apply
+     has repointed everything at the new server. The apply restores only the
+     replica counts its own manifests render. It never resumes the CronJobs
+     (no manifest here renders spec.suspend, so the three-way merge has
+     nothing to overwrite the patched true with), nor extraWriters outside
+     this release, nor an autoscaled writer whose manifest omits replicas —
+     an HPA does not scale a workload up from zero. This Job covers those,
+     then deletes the recorded state.
 
-Writers are deliberately left scaled to zero on success. Helm's own apply
-restores them, and it is that apply which repoints them at the new server —
-bringing them back here would reconnect them to the old one and strand every
-write they made in between.
+Writers are deliberately left scaled to zero when the orchestrator succeeds:
+restoring them there, before the upgrade's apply, would reconnect them to the
+old server and strand every write they made in between.
 
-Pre-upgrade only: a fresh install has nothing to copy, and pre-upgrade hooks do
-not run on `helm install`. Weights sit after the CRD check (-5) so a missing
-operator is reported by that hook instead of failing here.
+Upgrades only: a fresh install has nothing to copy, and neither pre-upgrade nor
+post-upgrade hooks run on `helm install`. Pre-upgrade weights sit after the CRD
+check (-5) so a missing operator is reported by that hook instead of failing
+here.
 */ -}}
 {{- if and .Values.cnpg.enabled .Values.cnpg.migration.enabled }}
 {{- $rel := .Release.Name }}
@@ -75,7 +84,9 @@ metadata:
     {{- include "openhands.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres-migration
   annotations:
-    "helm.sh/hook": pre-upgrade
+    # Both hook events: the orchestrator Job (pre-upgrade) and the resume Job
+    # (post-upgrade) run under this identity. Same on the Role and RoleBinding.
+    "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation
 {{- with $m.imagePullSecrets }}
@@ -92,7 +103,7 @@ metadata:
     {{- include "openhands.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres-migration
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
@@ -116,7 +127,9 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "create", "patch", "update"]
+    # delete is for the resume Job, which removes the recorded state once the
+    # restore is finished.
+    verbs: ["get", "list", "create", "patch", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -127,7 +140,7 @@ metadata:
     {{- include "openhands.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres-migration
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
@@ -444,7 +457,8 @@ spec:
               SUCCESS=0
               restore() {
                 if [ "$SUCCESS" = "1" ]; then
-                  log "writers left scaled to zero on purpose; the upgrade's apply brings them back on the new server."
+                  log "writers left scaled to zero and CronJobs left suspended on purpose;"
+                  log "  the upgrade's apply and the post-upgrade resume job bring them back on the new server."
                   return
                 fi
                 log "restoring writers after a failed migration"
@@ -455,9 +469,17 @@ spec:
                   log "  scaling $W back to $N"
                   $K scale "$W" --replicas="$N" >/dev/null 2>&1 || true
                 done
+                # Resume every CronJob this migration may have suspended, except
+                # one recorded as already suspended before it started: that state
+                # is the operator's, so put it back the way it was found.
+                RECORDED_CJS=" $($K get configmap "$STATE" -o jsonpath='{.data.cronjobs}' 2>/dev/null | tr '\n' ' ') "
                 for cj in $($K get cronjobs -o name 2>/dev/null | sed 's|.*/||'); do
                   case "$cj" in
-                    "$CRONJOB_PREFIX"*) $K patch cronjob "$cj" -p '{"spec":{"suspend":false}}' >/dev/null 2>&1 || true ;;
+                    "$CRONJOB_PREFIX"*)
+                      case "$RECORDED_CJS" in
+                        *" $cj=true "*) log "  leaving $cj suspended, as it was before the migration" ;;
+                        *) $K patch cronjob "$cj" -p '{"spec":{"suspend":false}}' >/dev/null 2>&1 || true ;;
+                      esac ;;
                   esac
                 done
                 log "restore done; the application is back on '$STS'."
@@ -540,10 +562,13 @@ spec:
               log "cluster settled: primary '$PRIMARY' running '$C_STATIMG'"
 
               # ---- 2. Freeze writes ----
-              # Record the replica counts once: a retry of this Job must not
-              # capture the zeros a previous attempt left behind.
+              # Record the replica counts and CronJob suspend states once: a
+              # retry of this Job must not capture the zeros and trues a
+              # previous attempt left behind. The suspend states let both
+              # restore paths tell a CronJob this migration suspended from one
+              # the operator had suspended beforehand.
               if $K get configmap "$STATE" >/dev/null 2>&1; then
-                log "reusing recorded replica counts from an earlier attempt"
+                log "reusing recorded state from an earlier attempt"
               else
                 : > /tmp/replicas
                 for w in $WRITERS; do
@@ -551,9 +576,19 @@ spec:
                   [ -z "$CUR" ] && { log "  $w not present; skipping"; continue; }
                   echo "$w=$CUR" >> /tmp/replicas
                 done
-                $K create configmap "$STATE" --from-file=replicas=/tmp/replicas >/dev/null
-                log "recorded replica counts:"
-                sed 's/^/    /' /tmp/replicas
+                : > /tmp/cronjobs
+                for cj in $($K get cronjobs -o name 2>/dev/null | sed 's|.*/||'); do
+                  case "$cj" in
+                    "$CRONJOB_PREFIX"*)
+                      SUS=$($K get cronjob "$cj" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+                      echo "$cj=${SUS:-false}" >> /tmp/cronjobs ;;
+                  esac
+                done
+                $K create configmap "$STATE" \
+                  --from-file=replicas=/tmp/replicas \
+                  --from-file=cronjobs=/tmp/cronjobs >/dev/null
+                log "recorded pre-migration state:"
+                sed 's/^/    /' /tmp/replicas /tmp/cronjobs
               fi
 
               log "scaling writers to zero"
@@ -636,7 +671,8 @@ spec:
                 --from-literal=note="database copied from the Bitnami server to CloudNativePG" >/dev/null
               $K delete pod "$COPY_POD" --ignore-not-found --wait=false >/dev/null 2>&1 || true
               SUCCESS=1
-              log "migration complete. The upgrade will now point every service at '$CLUSTER'."
+              log "migration complete. The upgrade will now point every service at '$CLUSTER',"
+              log "and the post-upgrade resume job then brings back the CronJobs and any writer the apply leaves at zero."
               log "The Bitnami PersistentVolumeClaim is retained: re-enabling postgresql restores the pre-migration data."
       volumes:
         - name: manifests
@@ -647,6 +683,125 @@ spec:
                 path: cluster.yaml
               - key: copy-pod.yaml
                 path: copy-pod.yaml
+        - name: tmp
+          emptyDir: {}
+---
+# Finishes the restore after the upgrade's apply has repointed everything at
+# the new server. Runs on every upgrade while the migration is enabled and
+# exits immediately unless the orchestrator recorded state this upgrade.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}-resume
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ $m.backoffLimit }}
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-migration
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      {{- with $m.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: resume
+          image: "{{ $m.images.kubectl.repository }}:{{ $m.images.kubectl.tag }}"
+          imagePullPolicy: {{ $m.images.kubectl.pullPolicy | default "IfNotPresent" }}
+          env:
+            # kubectl writes its discovery cache under $HOME; give it a writable one.
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml $m.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              NS='{{ $ns }}'
+              STATE='{{ $state }}'
+              CRONJOB_PREFIX='{{ $rel }}-'
+              K="kubectl -n $NS"
+
+              log() { echo "[resume] $*"; }
+
+              if ! $K get configmap "$STATE" >/dev/null 2>&1; then
+                log "no migration state recorded; nothing to resume."
+                exit 0
+              fi
+              log "a migration froze writers during this upgrade; finishing the restore"
+              FAILED=0
+
+              # The apply has already restored every replica count its manifests
+              # render, so a recorded writer still sitting at zero is one the
+              # apply does not manage: an extraWriter outside this release, or
+              # an autoscaled writer whose manifest omits replicas — an HPA does
+              # not scale a workload up from zero. Scale those back itself. A
+              # writer the apply deliberately set to zero this upgrade is
+              # indistinguishable from these and comes back too; the next apply
+              # reasserts the zero.
+              RECORDED=$($K get configmap "$STATE" -o jsonpath='{.data.replicas}' 2>/dev/null || echo "")
+              for line in $RECORDED; do
+                W=$(echo "$line" | cut -d= -f1)
+                N=$(echo "$line" | cut -d= -f2)
+                CUR=$($K get "$W" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+                if [ "$CUR" = "0" ] && [ "$N" != "0" ]; then
+                  log "  scaling $W back to $N; the apply left it at zero"
+                  $K scale "$W" --replicas="$N" >/dev/null 2>&1 \
+                    || { log "  ERROR: could not scale $W"; FAILED=1; }
+                fi
+              done
+
+              # Resume the CronJobs the migration suspended: no manifest in this
+              # chart renders spec.suspend, so the apply leaves the patched true
+              # in place. One recorded as suspended before the migration stays
+              # that way; one not recorded at all (created since, or state
+              # written by an older chart version) is resumed rather than left
+              # stuck.
+              RECORDED_CJS=" $($K get configmap "$STATE" -o jsonpath='{.data.cronjobs}' 2>/dev/null | tr '\n' ' ') "
+              for cj in $($K get cronjobs -o name 2>/dev/null | sed 's|.*/||'); do
+                case "$cj" in
+                  "$CRONJOB_PREFIX"*)
+                    case "$RECORDED_CJS" in
+                      *" $cj=true "*) log "  leaving $cj suspended, as it was before the migration" ;;
+                      *)
+                        log "  resuming $cj"
+                        $K patch cronjob "$cj" -p '{"spec":{"suspend":false}}' >/dev/null 2>&1 \
+                          || { log "  ERROR: could not resume $cj"; FAILED=1; }
+                        ;;
+                    esac ;;
+                esac
+              done
+
+              if [ "$FAILED" != "0" ]; then
+                log "ERROR: some workloads could not be restored. The recorded state is kept"
+                log "       so retrying the upgrade retries the restore."
+                exit 1
+              fi
+              $K delete configmap "$STATE" >/dev/null
+              log "restore complete; every workload the migration stopped is back."
+      volumes:
         - name: tmp
           emptyDir: {}
 {{- end }}

--- a/charts/openhands/templates/postgres-cnpg.yaml
+++ b/charts/openhands/templates/postgres-cnpg.yaml
@@ -1,0 +1,19 @@
+{{- /*
+Who creates the Cluster depends on whether an upgrade is migrating data into it.
+
+Helm snapshots the live state of the release's resources before hooks run, so an
+object that first appears during a pre-upgrade hook is one Helm then refuses to
+apply ("original object Cluster ... not found"), failing the upgrade after the
+hook has already frozen writes. So on a migrating upgrade this template renders
+nothing and the hook's Job owns the Cluster; Helm adopts it on the next upgrade
+that leaves the migration off, which works because by then the object predates
+the upgrade.
+
+A fresh install renders it here regardless: the migration hook is pre-upgrade
+only, so on an install there is nothing else to create it.
+*/ -}}
+{{- if .Values.cnpg.enabled }}
+{{- if or .Release.IsInstall (not .Values.cnpg.migration.enabled) }}
+{{- include "openhands.cnpg.cluster" . }}
+{{- end }}
+{{- end }}

--- a/charts/openhands/templates/service.yaml
+++ b/charts/openhands/templates/service.yaml
@@ -36,26 +36,39 @@ spec:
     app.kubernetes.io/name: runtime-api
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-{{- if and .Values.enabled .Values.postgresql.enabled }}
+{{- $pgBackend := include "openhands.postgres.backend" . }}
+{{- if or (and .Values.enabled (eq $pgBackend "bitnami")) (eq $pgBackend "cnpg") }}
 ---
+# Stable alias for whichever in-cluster PostgreSQL backend is active, so
+# consumers configured with this hostname need no change when the backend
+# changes. targetPort is numeric because the two backends name the container
+# port differently (Bitnami tcp-postgresql, CloudNativePG postgresql).
 apiVersion: v1
 kind: Service
 metadata:
-  name: oh-main-postgresql
+  name: {{ include "openhands.postgres.aliasService" . }}
   labels:
     {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
 spec:
   type: ClusterIP
   sessionAffinity: None
   ports:
     - name: tcp-postgresql
       port: 5432
-      targetPort: tcp-postgresql
+      targetPort: 5432
       nodePort: null
   selector:
+    {{- if eq $pgBackend "cnpg" }}
+    # Same selector CloudNativePG's own <cluster>-rw Service uses, so the alias
+    # follows a failover to a new primary.
+    cnpg.io/cluster: {{ include "openhands.cnpg.clusterName" . }}
+    cnpg.io/instanceRole: primary
+    {{- else }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: postgresql
     app.kubernetes.io/component: primary
+    {{- end }}
 {{- end }}
 {{- if and .Values.enabled (index .Values "litellm-helm") (index .Values "litellm-helm" "enabled") }}
 ---

--- a/charts/openhands/templates/troubleshoot/preflights.yaml
+++ b/charts/openhands/templates/troubleshoot/preflights.yaml
@@ -13,6 +13,14 @@ spec:
     {{- end }}
   analyzers:
     {{- include "troubleshoot.analyzers.shared" . | nindent 4 }}
+    {{- /*
+    No analyzer for the CloudNativePG CRD. These preflights only ever run under
+    KOTS, which runs them before it deploys any release, so the CRD is legitimately
+    absent on a fresh install and the check would fail for something the operator
+    cannot act on. The ordering is enforced where it belongs instead: the
+    crd-check hook waits for clusters.postgresql.cnpg.io at weight -5, by which
+    point the infra-cnpg release has installed the operator.
+    */ -}}
     {{- if $sysbox.selected }}
     {{- include "troubleshoot.analyzers.sysbox" . | nindent 4 }}
     {{- end }}

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -70,6 +70,24 @@ spec:
         limits:
           maxAge: 336h
     {{- end }}
+    {{- if .Values.cnpg.enabled }}
+    # PostgreSQL logs (CloudNativePG). Instance pods carry cnpg.io/cluster, and
+    # the operator's own logs live in its namespace, not this one.
+    - logs:
+        name: app/{{ include "openhands.cnpg.clusterName" . }}/logs
+        namespace: {{ .Release.Namespace }}
+        selector:
+          - cnpg.io/cluster={{ include "openhands.cnpg.clusterName" . }}
+        limits:
+          maxAge: 336h
+    - logs:
+        name: app/cloudnative-pg-operator/logs
+        namespace: {{ .Values.cnpg.operatorNamespace | default "cnpg-system" }}
+        selector:
+          - app.kubernetes.io/name=cloudnative-pg
+        limits:
+          maxAge: 336h
+    {{- end }}
     {{- if .Values.redis.enabled }}
     # Redis logs (Bitnami chart)
     - logs:
@@ -434,10 +452,10 @@ spec:
         namespace: ingress-nginx
         limits:
           maxAge: 336h
-    {{- if and .Values.postgresql.enabled .Values.replicated.enabled .Values.replicated.postgresPassword }}
+    {{- if and (ne (include "openhands.postgres.backend" .) "external") .Values.replicated.enabled .Values.replicated.postgresPassword }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
+        uri: postgresql://{{ .Values.replicated.postgresUsername | urlquery }}:{{ .Values.replicated.postgresPassword | urlquery }}@{{ include "openhands.postgres.host" . }}.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.replicated.postgresDatabase }}?sslmode=disable
         tls:
           disabled: true
     {{- end }}
@@ -573,7 +591,7 @@ spec:
           - fail:
               when: "!= Healthy"
               message: "Pod {{`{{ .Namespace }}/{{ .Name }}`}} is not Healthy: {{`{{ .Status.Reason }}`}}"
-    {{- if and .Values.postgresql.enabled .Values.replicated.enabled .Values.replicated.postgresPassword }}
+    {{- if and (ne (include "openhands.postgres.backend" .) "external") .Values.replicated.enabled .Values.replicated.postgresPassword }}
     - postgresql:
         checkName: "PostgreSQL Database Health"
         collectorName: postgresql

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -9,8 +9,11 @@ are never rendered, so a server-less release must not trip them.
 {{- if and .Values.enabled .Values.ingress.enabled (not .Values.ingress.host) -}}
 {{- fail "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false." -}}
 {{- end -}}
-{{- if and .Values.enabled (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
-{{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
+{{- if and .Values.enabled (eq (include "openhands.postgres.backend" .) "external") (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
+{{- fail "No PostgreSQL backend is configured. Set externalDatabase.host and externalDatabase.username, or enable an in-cluster backend with postgresql.enabled=true (Bitnami) or cnpg.enabled=true (CloudNativePG)." -}}
+{{- end -}}
+{{- if and .Values.cnpg.enabled .Values.cnpg.enableSuperuserAccess (not .Values.cnpg.superuserSecret.name) -}}
+{{- fail "cnpg.enableSuperuserAccess is true but cnpg.superuserSecret.name is empty. Point it at a kubernetes.io/basic-auth Secret holding the postgres password, or CloudNativePG will generate one the application cannot read." -}}
 {{- end -}}
 {{/*
 Data-loss guard for the bundled MinIO. Its chart runs the bucket job on

--- a/charts/openhands/tests/labels_test.yaml
+++ b/charts/openhands/tests/labels_test.yaml
@@ -9,6 +9,8 @@ templates:
   - deployment.yaml
   - litellm-config-script.yaml
   - service.yaml
+  - postgres-cnpg.yaml
+  - postgres-cnpg-migration.yaml
   - troubleshoot/preflights.yaml
   - troubleshoot/secrets.yaml
   - troubleshoot/support-bundle.yaml
@@ -156,3 +158,94 @@ tests:
       - matchRegex:
           path: metadata.labels["troubleshoot.sh/kind"]
           pattern: ^(preflight|support-bundle)$
+
+  - it: the CloudNativePG Cluster carries the recommended labels and stays adoptable
+    template: postgres-cnpg.yaml
+    set:
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: database
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+      # Helm adopts the object the migration hook creates only when all three of
+      # these are on it, so the shared labels must keep supplying managed-by.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.annotations["meta.helm.sh/release-name"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.annotations["meta.helm.sh/release-namespace"]
+          value: NAMESPACE
+
+  - it: the postgres alias Service carries the recommended labels
+    template: service.yaml
+    set:
+      cnpg.enabled: true
+      postgresql.enabled: false
+    documentSelector:
+      path: metadata.name
+      value: oh-main-postgresql
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: database
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+
+  - it: the migration hook resources carry the recommended labels
+    template: postgres-cnpg-migration.yaml
+    set:
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres-migration
+          documentIndex: 0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+          documentIndex: 0
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^openhands-
+          documentIndex: 0
+
+  - it: the migration Job and its pod template carry the recommended labels
+    template: postgres-cnpg-migration.yaml
+    set:
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+      postgresql.enabled: false
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres-migration
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: postgres-migration
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/openhands/tests/labels_test.yaml
+++ b/charts/openhands/tests/labels_test.yaml
@@ -230,7 +230,7 @@ tests:
           pattern: ^openhands-
           documentIndex: 0
 
-  - it: the migration Job and its pod template carry the recommended labels
+  - it: both migration Jobs and their pod templates carry the recommended labels
     template: postgres-cnpg-migration.yaml
     set:
       cnpg.enabled: true
@@ -239,6 +239,7 @@ tests:
     documentSelector:
       path: kind
       value: Job
+      matchMany: true
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]

--- a/charts/openhands/tests/postgres_backend_test.yaml
+++ b/charts/openhands/tests/postgres_backend_test.yaml
@@ -1,0 +1,203 @@
+suite: postgres backend selection
+templates:
+  # The DB_* env vars come from an include in _env.yaml, so the assertions have
+  # to target the templates that render it.
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+  - service.yaml
+  - postgres-cnpg.yaml
+tests:
+  - it: points the app at the bitnami server by default
+    template: deployment.yaml
+    set:
+      image.tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: RELEASE-NAME-postgresql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_SSL_MODE
+            value: prefer
+
+  - it: renders no CNPG Cluster by default
+    template: postgres-cnpg.yaml
+    set:
+      image.tag: test
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: points the app at the alias service when cnpg is enabled
+    template: deployment.yaml
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: oh-main-postgresql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PORT
+            value: "5432"
+
+  - it: inherits the bitnami user and database name when cnpg does not override them
+    template: deployment.yaml
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.auth.username: pgadmin
+      postgresql.auth.database: ohdb
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: pgadmin
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_NAME
+            value: ohdb
+
+  - it: prefers explicit cnpg user and database over the bitnami values
+    template: deployment.yaml
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.auth.username: pgadmin
+      postgresql.auth.database: ohdb
+      cnpg.username: cnpgadmin
+      cnpg.database: cnpgdb
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: cnpgadmin
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_NAME
+            value: cnpgdb
+
+  - it: reads the app password from the cnpg credentials secret
+    template: deployment.yaml
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.credentials.existingSecret: custom-pg-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: custom-pg-secret
+                key: password
+
+  - it: points the app at the external server when neither in-cluster backend is on
+    template: deployment.yaml
+    set:
+      image.tag: test
+      postgresql.enabled: false
+      externalDatabase.enabled: true
+      externalDatabase.host: rds.example.com
+      externalDatabase.username: pgadmin
+      externalDatabase.database: ohdb
+      externalDatabase.sslMode: require
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: rds.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_SSL_MODE
+            value: require
+
+  - it: cnpg takes precedence over bitnami so a migration cuts consumers over
+    template: deployment.yaml
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: oh-main-postgresql
+
+  - it: aliases the bitnami primary by default
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: oh-main-postgresql
+    set:
+      image.tag: test
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: postgresql
+            app.kubernetes.io/component: primary
+      - contains:
+          path: spec.ports
+          content:
+            name: tcp-postgresql
+            port: 5432
+            targetPort: 5432
+            nodePort: null
+
+  - it: aliases the cnpg primary when cnpg is enabled
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: oh-main-postgresql
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            cnpg.io/cluster: RELEASE-NAME-pg
+            cnpg.io/instanceRole: primary
+      # Numeric: the two backends name this container port differently.
+      - contains:
+          path: spec.ports
+          content:
+            name: tcp-postgresql
+            port: 5432
+            targetPort: 5432
+            nodePort: null
+
+  - it: renders the alias for cnpg even when the app server is not deployed
+    template: service.yaml
+    set:
+      image.tag: test
+      enabled: false
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: oh-main-postgresql

--- a/charts/openhands/tests/postgres_cnpg_cluster_test.yaml
+++ b/charts/openhands/tests/postgres_cnpg_cluster_test.yaml
@@ -1,0 +1,188 @@
+suite: cnpg cluster
+templates:
+  - postgres-cnpg.yaml
+tests:
+  - it: renders a single-instance cluster with our superuser secret
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Cluster
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-pg
+      - equal:
+          path: spec.instances
+          value: 1
+      - equal:
+          path: spec.enableSuperuserAccess
+          value: true
+      - equal:
+          path: spec.superuserSecret.name
+          value: postgres-superuser
+      - equal:
+          path: spec.bootstrap.initdb.localeCollate
+          value: en_US.UTF-8
+      - equal:
+          path: spec.bootstrap.initdb.localeCType
+          value: en_US.UTF-8
+      # Bootstrap is always a plain initdb: data movement belongs to the
+      # migration hook, so a fresh and a migrated cluster have the same spec.
+      - notExists:
+          path: spec.bootstrap.initdb.import
+      - notExists:
+          path: spec.externalClusters
+
+  - it: never creates a PodDisruptionBudget, which would block node drains
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - equal:
+          path: spec.enablePDB
+          value: false
+
+  - it: pins an operand image carrying the en_US.UTF-8 locale
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      # A "minimal" variant ships only C/C.UTF-8/POSIX, which makes the restore
+      # of an en_US.UTF-8 database fail.
+      - matchRegex:
+          path: spec.imageName
+          pattern: "^ghcr\\.io/cloudnative-pg/postgresql:[0-9.]+-standard-.+$"
+
+  - it: carries the helm ownership metadata a hook-created cluster needs
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      # All three are required for Helm to adopt a Cluster the migration hook
+      # created imperatively; missing any one fails the upgrade.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.annotations["meta.helm.sh/release-name"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.annotations["meta.helm.sh/release-namespace"]
+          value: NAMESPACE
+
+  - it: is never deleted by helm
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      # CloudNativePG garbage-collects the PVCs of a deleted Cluster, so any
+      # path that stops rendering this object must not delete it.
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: is not rendered by an upgrade that is migrating data into it
+    release:
+      upgrade: true
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    asserts:
+      # The migration Job owns it during that upgrade: Helm refuses to apply an
+      # object that first appeared during a hook.
+      - hasDocuments:
+          count: 0
+
+  - it: is rendered on a fresh install even with the migration enabled
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    asserts:
+      # The migration hook is pre-upgrade only, so nothing else would create it.
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Cluster
+
+  - it: is rendered again once an upgrade leaves the migration off
+    release:
+      upgrade: true
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Cluster
+
+  - it: honours storage, image and resource overrides
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+      cnpg.clusterName: custom-pg
+      cnpg.instances: 3
+      cnpg.image.repository: registry.example.com/proxy/postgresql
+      cnpg.image.tag: 17.10-standard-bookworm
+      cnpg.storage.size: 100Gi
+      cnpg.storage.storageClass: fast
+      cnpg.imagePullSecrets:
+        - name: pull-secret
+      cnpg.parameters:
+        max_connections: "200"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-pg
+      - equal:
+          path: spec.instances
+          value: 3
+      - equal:
+          path: spec.imageName
+          value: registry.example.com/proxy/postgresql:17.10-standard-bookworm
+      - equal:
+          path: spec.storage.size
+          value: 100Gi
+      - equal:
+          path: spec.storage.storageClass
+          value: fast
+      - contains:
+          path: spec.imagePullSecrets
+          content:
+            name: pull-secret
+      - equal:
+          path: spec.postgresql.parameters.max_connections
+          value: "200"
+
+  - it: omits storageClass so the cluster default applies
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - notExists:
+          path: spec.storage.storageClass
+
+  - it: adds a WAL volume only when asked
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+      cnpg.walStorage.enabled: true
+      cnpg.walStorage.size: 20Gi
+    asserts:
+      - equal:
+          path: spec.walStorage.size
+          value: 20Gi

--- a/charts/openhands/tests/postgres_cnpg_migration_test.yaml
+++ b/charts/openhands/tests/postgres_cnpg_migration_test.yaml
@@ -24,8 +24,10 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      # Two Jobs render from this template, so kind alone is ambiguous. The
+      # orchestrator's container is named migrate, the post-upgrade one resume.
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
@@ -41,8 +43,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # rancher/kubectl ships no shell, so `sh -c` cannot start in it.
       - equal:
@@ -153,8 +155,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # This Job owns the Cluster while a migration is pending, so changes to
       # the cnpg values have to reach it here.
@@ -174,8 +176,8 @@ tests:
       plugin-directory.enabled: false
       integrations-hub.enabled: false
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
@@ -193,8 +195,8 @@ tests:
       plugin-directory.enabled: true
       integrations-hub.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
@@ -223,8 +225,8 @@ tests:
       cnpg.migration.extraWriters:
         - deployment/custom-writer
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
@@ -258,8 +260,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # Measured on a real cluster: one second after an operand-image change the
       # Cluster still reports phase healthy, readyInstances 1 and a matching
@@ -286,8 +288,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # CloudNativePG publishes no observedGeneration, so metadata.generation
       # across the apply is what says whether a reconcile is still pending.
@@ -308,8 +310,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # The drain loop also ends on timeout, so the result has to be confirmed.
       # Announcing "writers are down" regardless meant a copy could be taken
@@ -324,8 +326,8 @@ tests:
       cnpg.enabled: true
       cnpg.migration.enabled: true
     documentSelector:
-      path: kind
-      value: Job
+      path: spec.template.spec.containers[0].name
+      value: migrate
     asserts:
       # Diagnosing exactly this on the PVC migration took a support bundle. A
       # warning rather than a failure: the copy re-reads every table's row count
@@ -336,3 +338,122 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'WARNING: the primary .* restarted or was replaced'
+
+  - it: records each CronJob's suspend state before touching it
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: migrate
+    asserts:
+      # The restore paths only resume what the migration itself suspended; a
+      # CronJob the operator had suspended beforehand goes back the way it was
+      # found. Unset suspend records as false.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '--from-file=cronjobs=/tmp/cronjobs'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\$\{SUS:-false\}'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\*" \$cj=true "\*\) log "  leaving \$cj suspended'
+
+  - it: runs the resume Job after the upgrade has repointed the writers
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: resume
+    asserts:
+      # Resuming from the orchestrator would reconnect everything to the old
+      # server and strand the writes made before the apply.
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-postgres-cnpg-migration-resume
+
+  - it: resume covers exactly what the apply cannot restore
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: resume
+    asserts:
+      # No manifest in this chart renders spec.suspend, so the apply's
+      # three-way merge never clears the patched true: the resume Job must.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"suspend":false'
+      # A recorded writer still at zero is one the apply does not manage
+      # (extraWriters, autoscaled writers); anything the apply already
+      # restored is left alone.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\[ "\$CUR" = "0" \] && \[ "\$N" != "0" \]'
+      # A CronJob suspended before the migration stays suspended.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\*" \$cj=true "\*\) log "  leaving \$cj suspended'
+      # The recorded state is removed once the restore is done, and only then.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\$K delete configmap "\$STATE"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'recorded state is kept'
+
+  - it: exits quietly on upgrades where no migration ran
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: resume
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'no migration state recorded; nothing to resume'
+
+  - it: shares one identity across both hook Jobs
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    asserts:
+      # The RBAC trio must exist at both hook points or the resume Job starts
+      # without permissions.
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade,post-upgrade
+
+  - it: lets the resume Job delete the recorded state
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            verbs: ["get", "list", "create", "patch", "update", "delete"]

--- a/charts/openhands/tests/postgres_cnpg_migration_test.yaml
+++ b/charts/openhands/tests/postgres_cnpg_migration_test.yaml
@@ -1,0 +1,338 @@
+suite: cnpg migration hook
+templates:
+  - postgres-cnpg-migration.yaml
+tests:
+  - it: renders nothing by default
+    set:
+      image.tag: test
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when cnpg is on but the migration is not requested
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the orchestrator as a pre-upgrade hook ordered after the CRD check
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      # crd-check runs its Job at -5, so a missing operator is reported there.
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-2"
+
+  - it: uses an orchestrator image that has a shell
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # rancher/kubectl ships no shell, so `sh -c` cannot start in it.
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/alpine/k8s:1.30.0
+
+  - it: copies from the bitnami service, never from the alias
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      # The alias points at the new cluster by the time this runs, so reading it
+      # would copy the target onto itself.
+      - matchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: 'value: "RELEASE-NAME-postgresql"'
+      - notMatchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: 'SRC_HOST\n\s+value: "oh-main-postgresql"'
+
+  - it: copies every database it discovers, skipping only the templates
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      # Discovery, not a hardcoded list, so databases an operator created by
+      # hand come across too — and the postgres database is a normal database
+      # that may hold user objects.
+      - matchRegex:
+          path: data["copy.sh"]
+          pattern: "datname NOT IN \\('template0','template1'\\) ORDER BY 1"
+      - notMatchRegex:
+          path: data["copy.sh"]
+          pattern: "'template0','template1','postgres'"
+
+  - it: copies the postgres database in place rather than recreating it
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      # The target's postgres database is CloudNativePG's maintenance database
+      # and cannot be dropped; --clean keeps a retry idempotent instead.
+      - matchRegex:
+          path: data["copy.sh"]
+          pattern: 'if \[ "\$db" = "postgres" \]; then'
+      - matchRegex:
+          path: data["copy.sh"]
+          pattern: 'PG_DUMP_ARGS="--clean --if-exists"'
+      # Nothing may drop the postgres database.
+      - notMatchRegex:
+          path: data["copy.sh"]
+          pattern: 'DROP DATABASE "postgres"'
+
+  - it: defaults the copy client to the operand image
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      # pg_dump refuses to dump a server newer than itself, so the client must
+      # not be older than either end of the copy.
+      - matchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: 'image: "ghcr\.io/cloudnative-pg/postgresql:17\.10-standard-trixie"'
+
+  - it: embeds the same cluster manifest the release applies
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      # Helm adopts the hook-created Cluster only if all three ownership keys
+      # are present.
+      - matchRegex:
+          path: data["cluster.yaml"]
+          pattern: 'app\.kubernetes\.io/managed-by: Helm'
+      - matchRegex:
+          path: data["cluster.yaml"]
+          pattern: 'meta\.helm\.sh/release-name: RELEASE-NAME'
+      - matchRegex:
+          path: data["cluster.yaml"]
+          pattern: 'meta\.helm\.sh/release-namespace: NAMESPACE'
+      - matchRegex:
+          path: data["cluster.yaml"]
+          pattern: 'helm\.sh/resource-policy: keep'
+
+  - it: applies the cluster on every run, before the already-migrated guard
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # This Job owns the Cluster while a migration is pending, so changes to
+      # the cnpg values have to reach it here.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'apply -f /migration/cluster\.yaml[\s\S]*marker.*present'
+
+  - it: quiesces only the writers that are deployed
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+      keycloak.enabled: false
+      litellm-helm.enabled: false
+      runtime-api.enabled: false
+      automation.enabled: false
+      plugin-directory.enabled: false
+      integrations-hub.enabled: false
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "WRITERS='deployment/openhands deployment/openhands-integrations deployment/openhands-mcp'"
+
+  - it: adds every enabled database consumer to the quiesce list
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+      keycloak.enabled: true
+      litellm-helm.enabled: true
+      runtime-api.enabled: true
+      automation.enabled: true
+      plugin-directory.enabled: true
+      integrations-hub.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "statefulset/keycloak"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/RELEASE-NAME-litellm"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/RELEASE-NAME-runtime-api"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/automation"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/plugin-directory"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/integrations-hub"
+
+  - it: appends operator-supplied writers
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+      cnpg.migration.extraWriters:
+        - deployment/custom-writer
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/custom-writer"
+
+  - it: grants only the permissions the orchestrator uses
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["postgresql.cnpg.io"]
+            resources: ["clusters"]
+            verbs: ["get", "list", "create", "patch", "update"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get"]
+
+  - it: waits for the cluster to settle rather than for anything to be serving
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # Measured on a real cluster: one second after an operand-image change the
+      # Cluster still reports phase healthy, readyInstances 1 and a matching
+      # status.image, while the operator is about to delete the primary pod. A
+      # bare readiness check starts the copy against a server that then goes
+      # away, which is how the Bitnami PVC migration lost a restore.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'STABLE_POLLS=3'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'C_READY" = "\$C_WANT'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'C_CUR" = "\$C_TGT'
+      # The old check. readyInstances alone, and hardcoded to one instance.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'READY" != "1"'
+
+  - it: gives the operator time to react when the apply changed the spec
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # CloudNativePG publishes no observedGeneration, so metadata.generation
+      # across the apply is what says whether a reconcile is still pending.
+      # Skipped when the apply changed nothing, so a retry is not slowed.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'GEN_BEFORE=\$\(\$K get cluster'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'GEN_BEFORE" != "\$GEN_AFTER'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'sleep "\$SETTLE"'
+
+  - it: fails rather than copying from a source that is still taking writes
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # The drain loop also ends on timeout, so the result has to be confirmed.
+      # Announcing "writers are down" regardless meant a copy could be taken
+      # from a moving source, which verification would then reject.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'REMAINING" != "0" \]; then[\s\S]*writers did not stop'
+
+  - it: reports a primary that was replaced while the copy ran
+    set:
+      image.tag: test
+      cnpg.enabled: true
+      cnpg.migration.enabled: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # Diagnosing exactly this on the PVC migration took a support bundle. A
+      # warning rather than a failure: the copy re-reads every table's row count
+      # from both servers afterwards, so it is the authority on the data.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'PRIMARY_STAMP=\$\(\$K get pod'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'WARNING: the primary .* restarted or was replaced'

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -9,12 +9,26 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ingress.enabled is true but ingress.host is empty. Set ingress.host to the hostname operators reach OpenHands on (e.g. app.example.com), or set ingress.enabled=false."
-  - it: fails when postgresql is disabled without an external database
+  - it: fails when no postgres backend is configured
     set:
       postgresql.enabled: false
     asserts:
       - failedTemplate:
-          errorMessage: "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database."
+          errorMessage: "No PostgreSQL backend is configured. Set externalDatabase.host and externalDatabase.username, or enable an in-cluster backend with postgresql.enabled=true (Bitnami) or cnpg.enabled=true (CloudNativePG)."
+  - it: accepts cnpg as the backend with no bitnami and no external database
+    set:
+      postgresql.enabled: false
+      cnpg.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: fails when cnpg superuser access is on without a superuser secret
+    set:
+      cnpg.enabled: true
+      cnpg.superuserSecret.name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "cnpg.enableSuperuserAccess is true but cnpg.superuserSecret.name is empty. Point it at a kubernetes.io/basic-auth Secret holding the postgres password, or CloudNativePG will generate one the application cannot read."
   - it: renders no resources when ingress has a host
     set:
       ingress.enabled: true

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -95,6 +95,52 @@
         "accessKeyIdKey": { "type": "string" },
         "secretAccessKeyKey": { "type": "string" }
       }
+    },
+    "cnpg": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "clusterName": { "type": "string" },
+        "operatorNamespace": { "type": "string" },
+        "instances": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "enableSuperuserAccess": { "type": "boolean" },
+        "superuserSecret": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          }
+        },
+        "credentials": {
+          "type": "object",
+          "properties": {
+            "existingSecret": { "type": "string", "minLength": 1 }
+          }
+        },
+        "username": { "type": "string" },
+        "database": { "type": "string" },
+        "enablePDB": { "type": "boolean" },
+        "storage": {
+          "type": "object",
+          "properties": {
+            "size": { "type": "string", "minLength": 1 },
+            "storageClass": { "type": "string" }
+          }
+        },
+        "migration": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -855,10 +855,11 @@ cnpg:
   # server.
   #
   # Writes are frozen while it runs: the workloads that write to the database
-  # scale to zero, the databases are copied and verified, and the upgrade's own
-  # apply brings them back pointed at the new server. If any step fails, the
-  # workloads are scaled back up against the untouched source and the upgrade
-  # fails.
+  # scale to zero and their CronJobs are suspended, the databases are copied
+  # and verified, the upgrade's own apply brings the workloads back pointed at
+  # the new server, and a post-upgrade hook resumes the CronJobs and anything
+  # else the apply leaves at zero. If any step fails, everything is restored
+  # against the untouched source and the upgrade fails.
   #
   # Allow more time than the default Helm timeout: hooks, apply and --wait all
   # share one budget (helm upgrade --timeout 30m).

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -759,6 +759,162 @@ postgresql:
     # podAnnotations:
     #   karpenter.sh/do-not-evict: "true"
 
+# In-cluster PostgreSQL managed by the CloudNativePG operator, as an
+# alternative to the Bitnami postgresql subchart above.
+#
+# The operator is cluster-scoped and is NOT installed by this chart. Install it
+# first (charts/infra, or the upstream cloudnative-pg chart) — with the CRDs
+# absent, rendering a Cluster fails with an unknown-kind error.
+#
+# Off by default: Bitnami remains the bundled default so existing installs are
+# unaffected. Enabling this takes precedence over postgresql.enabled, so during
+# a migration both can be on — the old server stays deployed for rollback while
+# consumers are already reading and writing the new one.
+cnpg:
+  enabled: false
+  # Cluster name; defaults to <release>-pg. Determines the names of the
+  # Services the operator creates (<name>-rw, -ro, -r).
+  clusterName: ""
+  # Namespace the operator runs in. Used only to collect its logs into support
+  # bundles.
+  operatorNamespace: cnpg-system
+  instances: 1
+  image:
+    repository: ghcr.io/cloudnative-pg/postgresql
+    # The variant matters. Operand images must carry the locale of the
+    # databases being restored into them — en_US.UTF-8 for every database an
+    # OpenHands install creates — and the "minimal" images ship only C,
+    # C.UTF-8 and POSIX, which makes CREATE DATABASE fail. "standard" also
+    # keeps the base OS current, unlike the bare version tags.
+    tag: 17.10-standard-trixie
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # Superuser (postgres) access, required because every OpenHands service
+  # connects as the superuser and creates its own database on startup.
+  enableSuperuserAccess: true
+  superuserSecret:
+    # Must be type kubernetes.io/basic-auth with username and password keys,
+    # and must hold the same password as credentials.existingSecret below.
+    # Secret types are immutable in Kubernetes, so this cannot be the existing
+    # Opaque postgres-password Secret; it is a second Secret with the same
+    # value. openhands-secrets renders it; create it by hand otherwise:
+    #
+    #   kubectl create secret generic postgres-superuser -n openhands \
+    #     --type=kubernetes.io/basic-auth \
+    #     --from-literal=username=postgres \
+    #     --from-literal=password="$POSTGRES_PASSWORD"
+    name: postgres-superuser
+  # Secret the application reads its database password from. Unchanged from the
+  # Bitnami path; both backends use the same credentials.
+  credentials:
+    existingSecret: postgres-password
+  # Application database user and name. Empty means inherit whatever the
+  # Bitnami values use, so enabling CNPG carries the existing names over.
+  username: ""
+  database: ""
+  # No PodDisruptionBudget: with a single instance there is no availability to
+  # protect, and the PDB blocks node drains, stalling Kubernetes upgrades.
+  enablePDB: false
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: restart
+  initdb:
+    encoding: UTF8
+    # Match the locale of the databases an existing Bitnami install created, so
+    # a migrated cluster's template1 and postgres databases agree with the
+    # restored ones.
+    localeCollate: en_US.UTF-8
+    localeCType: en_US.UTF-8
+  storage:
+    size: 50Gi
+    storageClass: ""
+  # Separate volume for WAL. Off by default; PGDATA holds WAL, matching the
+  # Bitnami layout.
+  walStorage:
+    enabled: false
+    size: 10Gi
+    storageClass: ""
+  # Mirrors the Bitnami primary's resources.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # postgresql.conf overrides. Empty: CloudNativePG's defaults already match
+  # what the Bitnami server runs (shared_buffers 128MB, max_connections 100).
+  parameters: {}
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # One-time copy of the data from the Bitnami postgresql subchart into the
+  # CloudNativePG cluster, run as a pre-upgrade hook. Enable it for the single
+  # upgrade that performs the migration; it is a no-op afterwards (a marker
+  # ConfigMap records that it ran) and on installs that never had a Bitnami
+  # server.
+  #
+  # Writes are frozen while it runs: the workloads that write to the database
+  # scale to zero, the databases are copied and verified, and the upgrade's own
+  # apply brings them back pointed at the new server. If any step fails, the
+  # workloads are scaled back up against the untouched source and the upgrade
+  # fails.
+  #
+  # Allow more time than the default Helm timeout: hooks, apply and --wait all
+  # share one budget (helm upgrade --timeout 30m).
+  migration:
+    enabled: false
+    images:
+      # Orchestrator image, which needs a shell as well as kubectl. Not
+      # rancher/kubectl: it ships no shell, so `sh -c` cannot start.
+      kubectl:
+        repository: docker.io/alpine/k8s
+        tag: "1.30.0"
+        pullPolicy: IfNotPresent
+      # PostgreSQL client for the copy. Defaults to the operand image above,
+      # which matters: the client must be no older than either server, and
+      # pg_dump refuses to dump a server newer than itself.
+      postgres:
+        repository: ""
+        tag: ""
+        pullPolicy: IfNotPresent
+    # Source server. Defaults to the Bitnami Service, <release>-postgresql.
+    # Deliberately not the oh-main-postgresql alias: that alias points at the
+    # new cluster by the time this runs, so reading it could copy the target
+    # onto itself.
+    sourceHost: ""
+    sourceSecret:
+      name: postgres-password
+      usernameKey: username
+      passwordKey: password
+    # Workloads to scale down beyond the ones this chart deploys, as
+    # "deployment/name" or "statefulset/name".
+    extraWriters: []
+    timeouts:
+      # Seconds to wait for the new cluster to report a ready instance.
+      clusterReady: 600
+      # Seconds to give the operator to react before the migration trusts what
+      # the Cluster reports, used only when applying the Cluster changed its
+      # spec. CloudNativePG leaves phase on the previous value until it picks the
+      # change up (measured at about a second), so health read immediately after
+      # an apply can describe the instance that is about to be replaced.
+      settle: 15
+      # Seconds to wait for writer pods to exit after scaling to zero.
+      drain: 300
+      # Seconds allowed for the copy itself.
+      copy: 1800
+      # Ceiling for the whole Job. Keep below the helm --timeout so the failure
+      # is this Job's, with its logs, rather than Helm's.
+      total: 2700
+    backoffLimit: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    imagePullSecrets: []
+
 externalDatabase:
   enabled: false
   port: "5432"

--- a/replicated/application.yaml
+++ b/replicated/application.yaml
@@ -16,6 +16,15 @@ spec:
     # The Sysbox installer DaemonSet runs in kube-system (privileged, host
     # namespaces), so KOTS must provision the image pull secret there too.
     - kube-system
+    # CloudNativePG operator (infra-cnpg release).
+    - cnpg-system
+
+  # PostgreSQL operand image. CloudNativePG takes it from a Cluster resource
+  # rather than a PodSpec, so KOTS cannot discover it by scanning manifests;
+  # listing it here mirrors it into air-gapped bundles. The reference the cluster
+  # actually uses is templated in replicated/openhands.yaml.
+  additionalImages:
+    - ghcr.io/cloudnative-pg/postgresql:17.10-standard-trixie
 
   statusInformers:
     # openhands
@@ -68,9 +77,10 @@ spec:
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/ingress/laminar-api-ingress{{repl end}}'
     - '{{repl if ConfigOptionEquals "analytics_enabled" "1" }}openhands/ingress/laminar-frontend-ingress{{repl end}}'
 
-    # postgres
-    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/statefulset/openhands-postgresql{{repl end}}'
-    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/service/openhands-postgresql{{repl end}}'
+    # postgres. CloudNativePG manages bare Pods, so there is no Deployment or
+    # StatefulSet to watch; the alias Service reports endpoints once the primary
+    # is serving.
+    - '{{repl if ConfigOptionEquals "postgres_type" "embedded_postgres"}}openhands/service/oh-main-postgresql{{repl end}}'
 
     # redis
     - openhands/statefulset/openhands-redis-master

--- a/replicated/infra-cnpg.yaml
+++ b/replicated/infra-cnpg.yaml
@@ -1,0 +1,41 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: infra-cnpg
+spec:
+  chart:
+    name: infra
+  releaseName: infra-cnpg
+  namespace: cnpg-system
+  # Weight 7 installs the operator and its CRDs after cert-manager (5) and
+  # trust-manager (6), and before openhands (10), whose Cluster resource is an
+  # unknown kind until these CRDs are registered.
+  weight: 7
+  helmUpgradeFlags: ["--wait", "--timeout", "600s"]
+  values:
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    cloudnative-pg:
+      enabled: true
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/cloudnative-pg/cloudnative-pg'
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
+
+  optionalValues:
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        cloudnative-pg:
+          image:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/cloudnative-pg'
+
+  builder:
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    cloudnative-pg:
+      enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -8,7 +8,9 @@ spec:
   releaseName: openhands
   namespace: openhands
   weight: 10
-  helmUpgradeFlags: ["--wait", "--timeout", "600s", "--force-conflicts"]
+  # 1800s, not 600s: hooks, apply and --wait share one budget, and the
+  # embedded-postgres migration hook runs inside it (freeze, copy, verify).
+  helmUpgradeFlags: ["--wait", "--timeout", "1800s", "--force-conflicts"]
   values:
     global:
       imageRegistry: 'images.r9.all-hands.dev'
@@ -513,21 +515,48 @@ spec:
         plugin-directory:
           databaseMigrations:
             createDatabases: true
+        # Embedded PostgreSQL runs under the CloudNativePG operator, installed by
+        # the infra-cnpg release at weight 7. The Bitnami subchart is off: an
+        # install that has one keeps it, and its data, until the pre-upgrade
+        # migration below has copied everything across and verified it.
         postgresql:
-          enabled: true
+          enabled: false
+          # Read for the user and database names even with the subchart off, so
+          # cnpg inherits whatever the install already used.
           auth:
             username: '{{repl ConfigOption "postgres_username"}}'
-            password: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
-            postgresPassword: '{{repl ConfigOption "postgres_password" | Base64Encode }}'
             database: '{{repl ConfigOption "postgres_database"}}'
-          # Persistence MUST be nested under primary — the Bitnami chart ignores a
-          # top-level postgresql.persistence, which is why embedded postgres ran on
-          # an emptyDir (data lost on any pod reschedule).
-          primary:
-            persistence:
-              enabled: true
-              storageClass: openebs-hostpath
-              size: 50Gi
+        cnpg:
+          enabled: true
+          image:
+            repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/cloudnative-pg/postgresql'
+          imagePullSecrets:
+            - name: '{{repl ImagePullSecretName }}'
+          storage:
+            storageClass: openebs-hostpath
+            size: 50Gi
+          migration:
+            # A no-op once the marker ConfigMap exists, and on installs that
+            # never had a Bitnami server, so it is safe to leave on.
+            enabled: true
+            images:
+              kubectl:
+                repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/alpine/k8s'
+            imagePullSecrets:
+              - name: '{{repl ImagePullSecretName }}'
+        # Wait for the CloudNativePG CRD as well, since the Cluster this release
+        # renders needs it. Listed in full because Helm replaces arrays rather
+        # than merging them.
+        crdCheck:
+          crds:
+            - certificates.cert-manager.io
+            - issuers.cert-manager.io
+            - clusterissuers.cert-manager.io
+            - bundles.trust.cert-manager.io
+            - ingressroutes.traefik.io
+            - middlewares.traefik.io
+            - tlsstores.traefik.io
+            - clusters.postgresql.cnpg.io
     - when: '{{repl ConfigOptionEquals "postgres_type" "external_postgres" }}'
       recursiveMerge: true
       values:
@@ -680,6 +709,15 @@ spec:
         postgresql:
           image:
             repository: '{{repl LocalRegistryNamespace }}/postgresql'
+        cnpg:
+          # CloudNativePG reads this from a Cluster resource, which KOTS does not
+          # rewrite, so the local-registry path is set here explicitly.
+          image:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/postgresql'
+          migration:
+            images:
+              kubectl:
+                repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/k8s'
         redis:
           image:
             repository: '{{repl LocalRegistryNamespace }}/redis'
@@ -1167,3 +1205,11 @@ spec:
       enabled: true
     agent-canvas:
       enabled: true
+    # Renders the migration hook at build time so its orchestrator image is
+    # discovered for air-gapped bundles. The operand image the Cluster uses is
+    # not discoverable this way and is listed in the Application's
+    # additionalImages instead.
+    cnpg:
+      enabled: true
+      migration:
+        enabled: true

--- a/replicated/secrets.yaml
+++ b/replicated/secrets.yaml
@@ -124,6 +124,14 @@ spec:
       tls_env: '{{repl Namespace }}'
 
   optionalValues:
+    # Embedded PostgreSQL runs under CloudNativePG, which needs the postgres
+    # password in a basic-auth Secret alongside the Opaque postgres-password one.
+    # This release is weight 1, so it exists before the cluster bootstraps.
+    - when: '{{repl ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
+      recursiveMerge: true
+      values:
+        cnpg:
+          enabled: true
     - when: '{{repl ConfigOptionEquals "automations_enabled" "1" }}'
       recursiveMerge: true
       values:


### PR DESCRIPTION
## Description

Moves embedded postgres off the bitnami chart and onto CloudNativePG.

The two install paths behave differently on purpose. The replicated installer does the whole thing in one deploy: it installs the operator, brings up a CNPG cluster, copies the data across, and leaves the bitnami server deployed but idle. Plain helm installs are untouched unless they opt in. Bitnami stays the default and `cnpg.enabled` is false, so an existing install upgrades exactly as it did before.

The operator is cluster-scoped, so it lives in a release of its own: `charts/infra` for plain helm, and `replicated/infra-cnpg.yaml` at weight 7 for the installer. Plain helm users install it before turning on `cnpg.enabled`, which the chart README covers.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes
