### PR TITLE
fix(litellm): PLTF-3363 bump pinned litellm image to 1.93.0

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -614,7 +614,7 @@ litellm-helm:
   # crashes on startup. Bare semver, no "v" prefix or "-stable" suffix (the
   # format BerriAI uses for 1.84.x+ stable images).
   image:
-    tag: "1.84.1"
+    tag: "1.93.0"
   masterkeySecretName: lite-llm-api-key
   masterkeySecretKey: lite-llm-api-key
   environmentSecrets: [litellm-env-secrets]


### PR DESCRIPTION
## Why

LiteLLM 1.84.1 floods the proxy logs with cache deserialization errors. The fix
landed upstream in [BerriAI/litellm#27874](https://github.com/BerriAI/litellm/issues/27874)
and ships in 1.93.0.

## Validation

`ghcr.io/berriai/litellm-database:1.93.0` resolves in the registry (manifest
`200`).

Rendered the chart with the subchart enabled and confirmed the deployment picks
up the new tag:

```
$ helm template oh charts/openhands --set litellm-helm.enabled=true \
    --set litellm-helm.db.deployStandalone=false | grep litellm-database
          image: "ghcr.io/berriai/litellm-database:1.93.0"
```

1.93.0 has already been soaking on a pre-production deployment with zero cache
deserialization errors.

_This PR was drafted by an AI agent on behalf of the user._
