### PR TITLE
fix(replicated): PLTF-3264 include app and license info in support bundles

### DIFF
--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 20.3.0
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.9.0
+  version: 1.19.7
 - name: rustfs
   repository: https://charts.rustfs.com/
   version: 0.10.0
@@ -41,5 +41,5 @@ dependencies:
 - name: agent-canvas
   repository: ""
   version: '*'
-digest: sha256:693867877f59079af43583137beeb95dc6298f7b1c5a72d8e429a7ab954770e1
-generated: "2026-07-28T22:40:10.320867-05:00"
+digest: sha256:a79b4f3d871e867b6fd24059e351dd6273968950b75bf75faf80924d432113d3
+generated: "2026-07-30T14:12:47.475503-05:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     condition: redis.enabled
   - name: replicated
     repository: oci://registry.replicated.com/library
-    version: 1.9.0
+    version: 1.19.7
     condition: replicated.enabled
   - name: rustfs
     version: 0.10.0


### PR DESCRIPTION
## Why

Support bundles reach the Vendor Portal without application or licence data, showing "No app-info file found" and "No license file found". The SDK's `app-info` and `license-info` collectors invoke `curl`, and the pinned `replicated-sdk-image:1.9.0` is busybox-based with no `curl` on `$PATH`, so both fail with `exec: "curl": executable file not found`. The `1.19.7` image ships `/usr/bin/curl`, which is what makes those collectors return data. On Embedded Cluster the exec permission already exists, so this change alone restores that data there.

The jump is ten minor versions, so the compatibility surface was checked rather than assumed: the SDK's service-account name helper is byte-identical, so anything binding to that account keeps working; the values keys the SDK has gained do not collide with the keys this chart sets under `replicated:`; the two new optional templates stay gated off by default; and the KOTS image references carry no tag, so the proxy and airgap paths follow appVersion automatically.

## Validation

- **The collectors go from failing to returning data.** On a licensed KinD install with the SDK's exec permission in place, `app-info` and `license-info` wrote `-errors.json` containing `exec: "curl": executable file not found` on 1.9.0, and real `-stdout.txt` payloads once the 1.19.7 image was in use: app slug, channel, current release, customer identity and entitlements.
- **Compatibility verified across the version jump.** The service-account helper is unchanged, the SDK's new values keys (`createPullSecret`, `highAvailability`, `proxy`, `readOnlyMode`, `replicaCount`) do not collide with this chart's `replicated.*` keys, the added PodDisruptionBudget and pull-secret templates render only when explicitly enabled, and the rendered image resolves to `replicated-sdk-image:1.19.7`.

_This PR was drafted by an AI agent on behalf of the user._
