### PR TITLE
fix(replicated): PLTF-3264 pass the SDK its pull secret in map form

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -415,15 +415,6 @@ spec:
         repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/redis'
       auth:
         password: '{{repl ConfigOption "redis_password" | Base64Encode }}'
-    replicated:
-      # The SDK subchart falls back to global.imagePullSecrets when this is unset
-      # (1.19.7: `.Values.imagePullSecrets | default .Values.global.imagePullSecrets`)
-      # and renders it with toYaml, which requires the map form. The global is a
-      # list of BARE STRINGS because the minio subchart renders it as
-      # `- name: {{ . }}` and would break on maps. Setting it explicitly here gives
-      # each consumer the shape it needs.
-      imagePullSecrets:
-        - name: '{{repl ImagePullSecretName }}'
     filestore:
       ephemeral: true
     minio:
@@ -477,6 +468,13 @@ spec:
 
     replicated:
       enabled: true
+      # SDK 1.19.7 reads `.Values.imagePullSecrets | default .Values.global.imagePullSecrets`
+      # and renders it with toYaml, which requires the map form. The global is a
+      # list of BARE STRINGS because the minio subchart renders it as
+      # `- name: {{ . }}` and breaks on maps, so it is set explicitly here rather
+      # than changing the global.
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
       redisPassword: 'repl{{ ConfigOption "redis_password" }}'
       postgresUsername: 'repl{{ ConfigOption "postgres_username" }}'
       postgresPassword: 'repl{{ ConfigOption "postgres_password" }}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -415,6 +415,15 @@ spec:
         repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/redis'
       auth:
         password: '{{repl ConfigOption "redis_password" | Base64Encode }}'
+    replicated:
+      # The SDK subchart falls back to global.imagePullSecrets when this is unset
+      # (1.19.7: `.Values.imagePullSecrets | default .Values.global.imagePullSecrets`)
+      # and renders it with toYaml, which requires the map form. The global is a
+      # list of BARE STRINGS because the minio subchart renders it as
+      # `- name: {{ . }}` and would break on maps. Setting it explicitly here gives
+      # each consumer the shape it needs.
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
     filestore:
       ephemeral: true
     minio:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -468,11 +468,6 @@ spec:
 
     replicated:
       enabled: true
-      # SDK 1.19.7 reads `.Values.imagePullSecrets | default .Values.global.imagePullSecrets`
-      # and renders it with toYaml, which requires the map form. The global is a
-      # list of BARE STRINGS because the minio subchart renders it as
-      # `- name: {{ . }}` and breaks on maps, so it is set explicitly here rather
-      # than changing the global.
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
       redisPassword: 'repl{{ ConfigOption "redis_password" }}'


### PR DESCRIPTION
## Why

Deploying any release that carries Replicated SDK 1.19.7 to a KOTS or Embedded Cluster install fails:

```
UPGRADE FAILED: server-side apply failed for object openhands/replicated apps/v1, Kind=Deployment:
  .spec.template.spec.imagePullSecrets: element 0: associative list with keys may not have non-map elements
```

SDK 1.19.7 falls back to `global.imagePullSecrets` when its own value is unset, and renders it with `toYaml`, which requires the map form. That global is a list of bare strings, so the SDK receives a malformed field. Setting the SDK's own value explicitly takes precedence over the fallback. The global is deliberately left as it is, because another subchart renders it as `- name: {{ . }}` and would break if it became maps.

The SDK pod previously had no registry credentials attached and pulled its image without them; it now has the license credentials attached. Worth noting because the rest of the change only corrects the shape of a value.

## Validation

- **The upgrade that previously failed now completes.** Stable 0.28.0 to a release carrying this change: KOTS reaches a deployed sequence, Helm ends on a deployed revision, the SDK Deployment comes up on 1.19.7 with `imagePullSecrets: [{name: openhands-registry}]`, and a conversation completes end to end. The identical path without this change fails at the SDK Deployment.
- **Attaching credentials did not break the pull.** With the license credentials now attached to the SDK pod, its image still downloaded, in about three seconds.
- **Nothing else broke.** Five components read the same shared registry-login setting, and this change deliberately leaves that shared setting untouched. All five pods came up with correct credentials and no download errors.

_This PR was drafted by an AI agent on behalf of the user._
