### PR TITLE
fix: bump agent-canvas chart default to 1.8.0

### DIFF
--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -13,7 +13,7 @@ image:
   # images via Release Please). Environments that want a specific build can
   # override this, but the default should track a published release so the
   # chart ships a known-good version out of the box.
-  tag: "1.6.1"
+  tag: "1.8.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Update the `agent-canvas` subchart default image tag from `1.6.1` to `1.8.0` in `charts/openhands/charts/agent-canvas/values.yaml`.

## Verification
- `helm template agent-canvas charts/openhands/charts/agent-canvas` renders `ghcr.io/openhands/agent-canvas:1.8.0`.

## Chart versioning
- Did not manually bump `charts/openhands/Chart.yaml`.
- The repository release workflow says release-please owns chart `version:` updates, and `.github/workflows/pr.yml` notes that the conventional PR title drives versioning after squash merge.
- The PR title is now `fix: ...`, so release-please should create the follow-up OpenHands chart release/version bump after merge.

_This PR was updated by an AI agent (OpenHands) on behalf of the user._
