### PR TITLE
fix(budget-maintenance): disable cronjob until fixed image ships

### DIFF
--- a/charts/openhands/tests/budget_maintenance_cronjob_test.yaml
+++ b/charts/openhands/tests/budget_maintenance_cronjob_test.yaml
@@ -2,6 +2,13 @@ suite: openhands budget maintenance cronjob
 templates:
   - budget-maintenance-cronjob.yaml
 tests:
+  - it: is disabled by default
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders a CronJob running the budget maintenance command
     set:
       enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -813,7 +813,9 @@ maintenanceTasks:
       cpu: "500m"
 
 budgetMaintenance:
-  enabled: true
+  # Disabled until a published enterprise-server image includes
+  # https://github.com/OpenHands/enterprise/pull/80.
+  enabled: false
   schedule: "*/15 * * * *" # Run every 15 minutes
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Description

Restores the safe default from #978 by disabling the budget-maintenance CronJob until a published `enterprise-server` image includes the corrected import from OpenHands/enterprise#80.

The pinned `1.49.0` image predates that fix, so enabling the CronJob by default causes every scheduled job to fail with `ModuleNotFoundError`. This also adds a Helm regression test asserting that the CronJob is not rendered by default, while preserving the existing opt-in rendering coverage.

Fixes #997.

## Validation

- `helm unittest charts/openhands` — 63 tests passed
- Default render is covered by the new Helm unit test
- Existing explicit `budgetMaintenance.enabled=true` rendering test still passes
- `git diff --check`

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations; explicit overrides remain unaffected
- [x] I have updated the chart README if needed; not applicable, because this restores the prior safe default and adds no required values

## Additional Notes

Re-enable `budgetMaintenance.enabled` only in the same change that pins the first released enterprise image containing OpenHands/enterprise#80.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._