### PR TITLE
fix(replicated): preserve Keycloak identity provider timeout

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -168,6 +168,8 @@ spec:
           value: "xforwarded"
         - name: KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI
           value: "true"
+        - name: KC_SPI_CONNECTIONS_HTTP_CLIENT__DEFAULT__SOCKET_TIMEOUT_MILLIS
+          value: "15000"
         - name: KC_TRUSTSTORE_PATHS
           value: /etc/openhands/ca-bundle/ca-bundle.crt
         - name: KC_DB_URL_PROPERTIES

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -21,6 +21,7 @@ KEYCLOAK_CONFIG_SCRIPT = (
     REPO_ROOT / "charts" / "openhands" / "templates" / "keycloak-config-script.yaml"
 )
 OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
 
 
 def pkce_enabled_providers_missing_method(realm: dict) -> list[str]:
@@ -224,4 +225,14 @@ def test_keycloak_identity_provider_socket_timeout() -> None:
         r"name: KC_SPI_CONNECTIONS_HTTP_CLIENT__DEFAULT__SOCKET_TIMEOUT_MILLIS"
         r"\s+value: [\"']15000[\"']",
         result.stdout,
+    )
+
+
+def test_replicated_keycloak_identity_provider_socket_timeout() -> None:
+    replicated_values = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
+
+    assert re.search(
+        r"name: KC_SPI_CONNECTIONS_HTTP_CLIENT__DEFAULT__SOCKET_TIMEOUT_MILLIS"
+        r"\s+value: [\"']15000[\"']",
+        replicated_values,
     )


### PR DESCRIPTION
## Summary

- preserve the 15-second Keycloak identity-provider socket timeout from #975 in Replicated/KOTS deployments
- add a regression test for the Replicated-specific Keycloak environment array

## Root cause

`replicated/openhands.yaml` supplies a complete `keycloak.extraEnvVars` array. Helm replaces arrays instead of merging them, so this Replicated override dropped the timeout added to the chart defaults by #975. KOTS installations therefore continued using Keycloak's shorter default timeout.

## Impact

Replicated deployments now use the same 15-second identity-provider timeout as ordinary Helm deployments. This gives self-hosted identity providers more time to recover from transient DNS or network delays without adding an Admin Console setting.

## Validation

- `uv run --with pytest --with requests --with PyGithub --with fastapi --with uvicorn --with httpx --with ruamel.yaml python -m pytest scripts -q` — 444 passed
- `helm lint charts/openhands --set enabled=true --set keycloak.enabled=true` — passed
- verified the new regression test fails without the Replicated environment entry and passes with it
