### PR TITLE
fix: disable email changes for Replicated installs

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -51,6 +51,9 @@ spec:
       ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_BILLING: false
       OH_WEB_CLIENT_FEATURE_FLAGS_HIDE_BILLING_PAGE: true
+      # Keep account email immutable until OHE can reliably deliver Keycloak verification.
+      EMAIL_CHANGE_ENABLED: false
+      OH_WEB_CLIENT_EMAIL_CHANGE_ENABLED: false
       # Frontend feature flags must be set via the structured OH_WEB_CLIENT_FEATURE_FLAGS_*
       # form. Once any of these is present, from_env(AppServerConfig, 'OH') builds
       # feature_flags from them and the plain ENABLE_JIRA_DC env (set in _env.yaml) is

--- a/scripts/test_replicated_email_change_policy.py
+++ b/scripts/test_replicated_email_change_policy.py
@@ -1,0 +1,14 @@
+"""Tests for the Replicated account email change policy."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+
+
+def test_replicated_disables_email_changes_in_api_and_ui() -> None:
+    values = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
+
+    assert "      EMAIL_CHANGE_ENABLED: false\n" in values
+    assert "      OH_WEB_CLIENT_EMAIL_CHANGE_ENABLED: false\n" in values


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

Implemented and validated the Replicated policy wiring and chart package.

---

## Why

Replicated OHE does not yet guarantee that Keycloak can deliver and complete account email verification. Until that flow is fully supported, allowing users to change their login email can leave them unverified and locked out.

OpenHands/enterprise#110 adds a guarded email-change capability that remains enabled by default. This PR disables it specifically for Replicated installs.

## Summary

- Set `EMAIL_CHANGE_ENABLED=false` to enforce the policy in the email update API.
- Set `OH_WEB_CLIENT_EMAIL_CHANGE_ENABLED=false` so the OHE UI shows the current address as read-only.
- Add a regression test that requires both controls to remain aligned.

## Issue Number

FDE-102

## How to Test

- `uvx --from pytest pytest -q scripts/test_replicated_email_change_policy.py` — 1 passed.
- `make charts` successfully packaged the release charts and dependencies.
- `helm lint build/openhands-*.tgz` — 2 charts linted, 0 failures.

## Video/Screenshots

Not included. End-to-end deployment validation will be performed with the combined cherry-pick release after the companion enterprise image is available.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Depends on OpenHands/enterprise#110 and must ship with an enterprise image containing that change.
- This prevents new lockouts but does not repair accounts that are already unverified.
- No new KOTS Admin Console setting is exposed; this is an OHE deployment default.
