### PR TITLE
chore: Collect node OOM diagnostics in support bundles

### DIFF
--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -4,7 +4,10 @@ kind: SupportBundle
 metadata:
   name: {{ .Release.Name }}-support-bundle
 spec:
+  runHostCollectorsInPod: true
   collectors: {{- include "troubleshoot.collectors.shared" .  | nindent 4 }}
+    # Point-in-time kubelet stats include node and pod memory usage.
+    - nodeMetrics: {}
     {{- /* Presence of admin-configured/optional secrets: a key renders only when its KOTS
     value is set, so includeValue:false keyExists ⇔ value-set -- presence only, never the value.
     Always-generated internal secrets are omitted; they'd read "set" unconditionally. */}}
@@ -446,6 +449,18 @@ spec:
         collectorName: redis
         uri: redis://default:{{ .Values.replicated.redisPassword | urlquery }}@{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379
     {{- end }}
+  hostCollectors:
+    # Preserve host-level OOM evidence after the affected pod is deleted.
+    - journald:
+        collectorName: kernel-messages
+        system: true
+        dmesg: true
+        since: "14 days ago"
+        output: short-iso-precise
+        lines: 50000
+        reverse: true
+        utc: true
+        timeout: 1m
   analyzers: {{- include "troubleshoot.analyzers.shared" .  | nindent 4 }}
     - deploymentStatus:
         name: openhands

--- a/charts/openhands/tests/support_bundle_node_diagnostics_test.yaml
+++ b/charts/openhands/tests/support_bundle_node_diagnostics_test.yaml
@@ -1,0 +1,39 @@
+suite: support bundle node diagnostics
+templates:
+  - troubleshoot/preflights.yaml
+  - troubleshoot/secrets.yaml
+  - troubleshoot/support-bundle.yaml
+tests:
+  - it: captures node memory metrics and bounded kernel history
+    template: troubleshoot/secrets.yaml
+    set:
+      enabled: true
+      replicated.enabled: true
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^  runHostCollectorsInPod: true$'
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^    - nodeMetrics: \{\}$'
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^  hostCollectors:$'
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^        collectorName: kernel-messages$'
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^        since: "14 days ago"$'
+      - documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: '(?m)^        lines: 50000$'


### PR DESCRIPTION
## Summary

- enable host collectors in pod mode so host-level diagnostics are available in support bundles
- collect point-in-time node and pod memory metrics with `nodeMetrics`
- collect a bounded kernel journal window for OOM and memory-pressure evidence
- add Helm unit coverage for the rendered collector configuration

## Why

Pod logs and status alone are often insufficient after an affected workload has restarted or been deleted. Kernel OOM messages and node-level memory metrics provide durable host context that is broadly useful for diagnosing memory pressure without making support bundles unbounded.

The kernel collector is limited to the most recent 14 days and 50,000 lines, uses UTC precise timestamps, and has a one-minute timeout.

## Validation

- `helm lint charts/openhands`
- `helm unittest charts/openhands`: 14 suites, 64 tests passed
- `make lint`
- rendered and extracted the support-bundle spec, then linted the added collectors with Troubleshoot `v0.123.18`
- collected a support bundle on an isolated Replicated test instance and confirmed:
  - `node-metrics/<node>.json` was present and contained metrics for 29 pods
  - `host-collectors/<node>/journald/kernel-messages.txt` was present with 1,239 bounded lines
  - temporary collector workloads were removed after collection

## Scope

This preserves host-level OOM evidence after a workload disappears. Persisting deleted application logs and adding broader secret-redaction rules remain separate concerns.
