### PR TITLE
chore: bump Agent Canvas chart image to 1.9.0

### DIFF
--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -13,7 +13,7 @@ image:
   # images via Release Please). Environments that want a specific build can
   # override this, but the default should track a published release so the
   # chart ships a known-good version out of the box.
-  tag: "1.8.0"
+  tag: "1.9.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description
Bumps the embedded Agent Canvas chart default image tag from `1.8.0` to `1.9.0`.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Local validation performed:
- `git diff --check`
- Confirmed no remaining `1.8.0` references under `charts` or `replicated`

I did not run Helm-based validation locally because `helm` is not installed in this environment. This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e81917ce-d9f0-4b68-a728-337bcbe138da)