### PR TITLE
fix(charts): pass fuse_s3_mount through warm-runtimes configmap

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
@@ -45,6 +45,10 @@ data:
           {{- with $config.count }}
           "count": {{ $config.count }},
           {{- end }}
+          {{- /* Omitted when false/unset: the loader defaults fuse_s3_mount to false. */}}
+          {{- with $config.fuse_s3_mount }}
+          "fuse_s3_mount": {{ . }},
+          {{- end }}
           "command": {{ $config.command | toJson }},
           "environment": {{ mergeOverwrite (deepCopy ($config.environment | default dict)) (deepCopy $globalAgentEnv) | toJson }}
           {{- with $config.run_as_user }},

--- a/charts/openhands/charts/runtime-api/tests/warm_runtimes_configmap_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtimes_configmap_test.yaml
@@ -1,0 +1,23 @@
+suite: warm runtimes configmap
+templates:
+  - templates/warm-runtimes-configmap.yaml
+tests:
+  - it: passes fuse_s3_mount through to the rendered config JSON
+    set:
+      warmRuntimes.enabled: true
+      warmRuntimes.configsByName.fusey.fuse_s3_mount: true
+      warmRuntimes.configsByName.fusey.working_dir: /workspace
+      warmRuntimes.configsByName.fusey.command:
+        - /usr/local/bin/openhands-agent-server
+    asserts:
+      - matchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: '"fuse_s3_mount": true'
+
+  - it: omits fuse_s3_mount for configs that do not set it
+    set:
+      warmRuntimes.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: fuse_s3_mount

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -247,6 +247,10 @@ warmRuntimes:
   # Canonical map form. Each key is the config's name (promoted to "name" in the
   # rendered JSON). Maps merge cleanly across values layers, so consumers can
   # override one field of one entry without re-declaring every entry.
+  # Set `fuse_s3_mount: true` on an entry for fusey warm pods: dormant startup,
+  # /workspace FUSE-mounted from object storage instead of a PVC. Needs the
+  # FUSEY_* env on runtime-api and /dev/fuse on the sandbox nodes (see the
+  # device-plugin subchart).
   configsByName:
     default:
       # image omitted -> defaults to global.agentServerImage (repo:tag).


### PR DESCRIPTION
## Summary

runtime-api warm configs support `fuse_s3_mount` (the flag that makes a config's warm pods dormant fusey pods), but the chart's warm-runtimes ConfigMap template enumerates config fields explicitly and drops it. A chart-managed fusey config silently renders without the flag, so its warm pool comes up as ordinary PVC-backed pods.

This passes the field through, omitted when false or unset so existing rendered configs are byte-identical. Unit tests cover both cases.