### PR TITLE
fix(build): PLTF-1250 stop shipping Chart.yaml.bak in released charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,12 @@ $(BUILDDIR)/$1-$(VER).tgz : $(CHARTDIR)/$1 $(shell find $(CHARTDIR)/$1 -name '*.
 	@# Rewrite any dependency that points to a remote registry but exists as a
 	@# sibling chart to use a local file:// reference instead. This lets
 	@# `helm package -u` resolve unpublished chart versions during local builds.
-	@cp $(CHARTDIR)/$1/Chart.yaml $(CHARTDIR)/$1/Chart.yaml.bak
-	@trap 'mv $(CHARTDIR)/$1/Chart.yaml.bak $(CHARTDIR)/$1/Chart.yaml' EXIT; \
+	@# The copy lives outside the chart directory. Held inside it, `helm package`
+	@# picks it up and every released chart ships a Chart.yaml.bak alongside the
+	@# real one, because the restore only runs after packaging.
+	@mkdir -p $(BUILDDIR)/.chartbak/$1
+	@cp $(CHARTDIR)/$1/Chart.yaml $(BUILDDIR)/.chartbak/$1/Chart.yaml
+	@trap 'mv $(BUILDDIR)/.chartbak/$1/Chart.yaml $(CHARTDIR)/$1/Chart.yaml' EXIT; \
 	for dep in $$$$(yq -r '.dependencies[].name // ""' $(CHARTDIR)/$1/Chart.yaml); do \
 		if [ -d $(CHARTDIR)/$$$$dep ]; then \
 			yq -i "(.dependencies[] | select(.name == \"$$$$dep\")).repository = \"file://../$$$$dep\"" $(CHARTDIR)/$1/Chart.yaml; \


### PR DESCRIPTION
## Why

Every released chart ships a `Chart.yaml.bak` next to the real `Chart.yaml`. Confirmed in the current Unstable
release and in 0.37.0 before it, so this has been going out for a while.

The chart target copies `Chart.yaml` aside before rewriting dependency repositories to `file://../<dep>` for local
resolution, and restores it from a shell `trap` on exit. The copy is made **inside the chart directory** and the
restore runs **after** `helm package`, so packaging sees it and includes it. Moving the copy under `build/` keeps
it out of the packaged tree while the rewrite and restore behave exactly as before.

Worth knowing separately: the released `Chart.yaml` itself carries `repository: file://../crd-check` from that
rewrite. It does not break an install, because the subchart is vendored under `charts/`, but `helm dependency
update` against a released chart would fail on it. Left alone here.

## Validation

- **Built all three charts and none contains the file** — `infra`, `openhands` and `openhands-secrets` tarballs go
  from carrying `Chart.yaml.bak` to zero occurrences.
- **The rewrite and restore still work** — `Chart.yaml` is unmodified in the working tree after a build, and no
  `.bak` is left anywhere under `charts/`.

_This PR was drafted by an AI agent on behalf of the user._
