### PR TITLE
fix(build): PLTF-1250 restore Chart.lock after packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,14 @@ $(BUILDDIR)/$1-$(VER).tgz : $(CHARTDIR)/$1 $(shell find $(CHARTDIR)/$1 -name '*.
 	@# The copy lives outside the chart directory. Held inside it, `helm package`
 	@# picks it up and every released chart ships a Chart.yaml.bak alongside the
 	@# real one, because the restore only runs after packaging.
+	@# Chart.lock is restored for the same reason: `helm package -u` regenerates it
+	@# to match the rewritten repositories, and a lock describing a Chart.yaml that
+	@# no longer exists fails `helm dependency build` with an out-of-sync error.
 	@mkdir -p $(BUILDDIR)/.chartbak/$1
 	@cp $(CHARTDIR)/$1/Chart.yaml $(BUILDDIR)/.chartbak/$1/Chart.yaml
-	@trap 'mv $(BUILDDIR)/.chartbak/$1/Chart.yaml $(CHARTDIR)/$1/Chart.yaml' EXIT; \
+	@if [ -f $(CHARTDIR)/$1/Chart.lock ]; then cp $(CHARTDIR)/$1/Chart.lock $(BUILDDIR)/.chartbak/$1/Chart.lock; fi
+	@trap 'mv $(BUILDDIR)/.chartbak/$1/Chart.yaml $(CHARTDIR)/$1/Chart.yaml; \
+		if [ -f $(BUILDDIR)/.chartbak/$1/Chart.lock ]; then mv $(BUILDDIR)/.chartbak/$1/Chart.lock $(CHARTDIR)/$1/Chart.lock; fi' EXIT; \
 	for dep in $$$$(yq -r '.dependencies[].name // ""' $(CHARTDIR)/$1/Chart.yaml); do \
 		if [ -d $(CHARTDIR)/$$$$dep ]; then \
 			yq -i "(.dependencies[] | select(.name == \"$$$$dep\")).repository = \"file://../$$$$dep\"" $(CHARTDIR)/$1/Chart.yaml; \


### PR DESCRIPTION
## Why

Every `make charts` or `make release` leaves `charts/*/Chart.lock` modified, so the drift has to be reverted by hand
before committing or it breaks CI.

The chart target rewrites dependency repositories to `file://../<dep>` so local builds can resolve unpublished
sibling charts, and restores `Chart.yaml` from a `trap` afterwards. `helm package -u` also regenerates `Chart.lock`
to match those rewritten repositories, and nothing restores the lock — leaving one that describes a `Chart.yaml`
which no longer exists:

```
- name: crd-check
-  repository: oci://ghcr.io/openhands/helm-charts
+  repository: file://../crd-check
```

Helm compares the lock's digest against `Chart.yaml`, so committing that state fails the two CI jobs that run
`helm dependency build` — `pr-checks` and `test-scripts`:

```
Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml).
Please update the dependencies
```

Backing the lock up and restoring it alongside `Chart.yaml` removes the manual step.

## Validation

- **A full `make charts` now leaves the working tree clean** — all three charts package, and `Chart.lock` and
  `Chart.yaml` are both unmodified afterwards, where previously two locks were rewritten every time.
- **`helm dependency build charts/openhands` succeeds straight after a build**, with no `git checkout` in between;
  before this it failed with the out-of-sync error above.

_This PR was drafted by an AI agent on behalf of the user._
