### PR TITLE
fix(charts)!: OHE-3033 durable automation package storage

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Run chart unit tests
         run: |
           helm unittest charts/openhands
+          helm unittest charts/openhands/charts/automation
           helm unittest charts/openhands/charts/device-plugin
           helm unittest charts/openhands/charts/integrations-hub
           helm unittest charts/openhands/charts/runtime-api

--- a/charts/openhands/Chart.lock
+++ b/charts/openhands/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: device-plugin
   repository: ""
   version: '*'
-digest: sha256:81001d0244e69166b42d16abb81df294e664a91ec8e268736ebd2dc7afb34d3c
-generated: "2026-08-03T16:50:36.593345669Z"
+digest: sha256:0ad41488e887e41253f880752ce1c70e3479600eaeea2ceecbf561be35d69415
+generated: "2026-08-04T10:48:38.125056-04:00"

--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     condition: litellm-helm.enabled
   - name: minio
     version: 5.0.10
-    condition: filestore.ephemeral
+    condition: minio.enabled
     repository: https://charts.min.io/
   - name: postgresql
     version: 15.x.x

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -455,16 +455,17 @@ To use an external PostgreSQL database instead of deploying one with the chart:
 ### Bring Your Own S3-Compatible Storage
 
 To use an external S3 (or S3-compatible) store instead of the bundled MinIO,
-disable the ephemeral filestore and configure the connection:
+disable the bundled MinIO and configure the connection:
 
 ```yaml
+minio:
+  enabled: false            # stops deploying the in-cluster MinIO
 filestore:
-  ephemeral: false          # stops deploying the in-cluster MinIO
   type: s3
   bucket: your-bucket-name
   region: your-s3-region
   # endpoint: https://your-s3-endpoint   # only for S3-compatible stores (MinIO/R2/…); omit for AWS S3
-  # secure: false                        # only for a plain-HTTP endpoint
+  #                                      # TLS is inferred from the URL scheme
   existingSecret: s3-credentials         # omit to use IRSA / Pod Identity instead
 ```
 

--- a/charts/openhands/charts/automation/templates/_env.yaml
+++ b/charts/openhands/charts/automation/templates/_env.yaml
@@ -35,38 +35,50 @@
 - name: AUTOMATION_GCP_REGION
   value: {{ .Values.gcp.region | quote }}
 {{- end }}
-# File storage configuration
-- name: FILE_STORE_PATH
-  value: {{ .Values.filestore.bucket }}
-{{- if .Values.filestore.ephemeral }}
-# Ephemeral mode: use S3-compatible storage (minio)
+# Uploaded-package storage (see values.filestore)
 - name: FILE_STORE
-  value: s3
-{{- if .Values.minio.enabled }}
-# Using deployed minio subchart
-- name: AWS_ACCESS_KEY_ID
-  value: {{ (index .Values.minio.svcaccts 0).accessKey }}
-- name: AWS_SECRET_ACCESS_KEY
-  value: {{ (index .Values.minio.svcaccts 0).secretKey }}
-- name: AWS_S3_ENDPOINT
-  value: {{ printf "http://%s-minio:9000" .Release.Name }}
-{{- else }}
-# Using external minio (e.g., parent chart's minio instance)
-- name: AWS_ACCESS_KEY_ID
-  value: {{ .Values.minio.external.accessKey }}
-- name: AWS_SECRET_ACCESS_KEY
-  value: {{ .Values.minio.external.secretKey }}
-- name: AWS_S3_ENDPOINT
-  value: {{ .Values.minio.external.endpoint }}
-{{- end }}
+  value: {{ .Values.filestore.type | quote }}
+{{- if eq .Values.filestore.type "s3" }}
 - name: AWS_S3_BUCKET
-  value: {{ .Values.filestore.bucket }}
+  value: {{ .Values.filestore.bucket | quote }}
+{{- with .Values.filestore.endpoint }}
+- name: AWS_S3_ENDPOINT
+  value: {{ . | quote }}
+# The service refuses an AWS_S3_SECURE value that contradicts the endpoint
+# scheme, so it is derived rather than configurable.
 - name: AWS_S3_SECURE
-  value: "false"
+  value: {{ hasPrefix "https://" . | quote }}
+{{- end }}
+{{- with .Values.filestore.region }}
+- name: AWS_REGION
+  value: {{ . | quote }}
+{{- end }}
+{{- if .Values.filestore.createBucket }}
+- name: AWS_S3_AUTO_CREATE_BUCKET
+  value: "true"
+{{- end }}
+{{- if .Values.filestore.existingSecret }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.existingSecret }}
+      key: {{ .Values.filestore.accessKeyIdKey | default "AWS_ACCESS_KEY_ID" }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.existingSecret }}
+      key: {{ .Values.filestore.secretAccessKeyKey | default "AWS_SECRET_ACCESS_KEY" }}
+{{- else if .Values.filestore.accessKey }}
+- name: AWS_ACCESS_KEY_ID
+  value: {{ .Values.filestore.accessKey | quote }}
+- name: AWS_SECRET_ACCESS_KEY
+  value: {{ .Values.filestore.secretKey | quote }}
+{{- end }}
+{{- else if eq .Values.filestore.type "gcs" }}
+- name: GCS_BUCKET_NAME
+  value: {{ .Values.filestore.bucket | quote }}
 {{- else }}
-# Production mode: use cloud storage (gcs, s3, etc.)
-- name: FILE_STORE
-  value: {{ .Values.filestore.type }}
+{{- fail (printf "filestore.type must be \"s3\" or \"gcs\", got %q" .Values.filestore.type) }}
 {{- end }}
 # Admin API key for issuing per-user automation API keys
 {{- if .Values.adminApiKeyFromSecret }}

--- a/charts/openhands/charts/automation/templates/_env.yaml
+++ b/charts/openhands/charts/automation/templates/_env.yaml
@@ -35,10 +35,13 @@
 - name: AUTOMATION_GCP_REGION
   value: {{ .Values.gcp.region | quote }}
 {{- end }}
-# Uploaded-package storage (see values.filestore)
+# Uploaded-package storage (see values.filestore). "google_cloud" normalizes
+# to "gcs", the service's native FILE_STORE value.
+{{- $store := .Values.filestore.type }}
+{{- if eq $store "google_cloud" }}{{- $store = "gcs" }}{{- end }}
 - name: FILE_STORE
-  value: {{ .Values.filestore.type | quote }}
-{{- if eq .Values.filestore.type "s3" }}
+  value: {{ $store | quote }}
+{{- if eq $store "s3" }}
 - name: AWS_S3_BUCKET
   value: {{ .Values.filestore.bucket | quote }}
 {{- with .Values.filestore.endpoint }}
@@ -74,11 +77,11 @@
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .Values.filestore.secretKey | quote }}
 {{- end }}
-{{- else if eq .Values.filestore.type "gcs" }}
+{{- else if eq $store "gcs" }}
 - name: GCS_BUCKET_NAME
   value: {{ .Values.filestore.bucket | quote }}
 {{- else }}
-{{- fail (printf "filestore.type must be \"s3\" or \"gcs\", got %q" .Values.filestore.type) }}
+{{- fail (printf "filestore.type must be \"s3\", \"gcs\", or \"google_cloud\", got %q" .Values.filestore.type) }}
 {{- end }}
 # Admin API key for issuing per-user automation API keys
 {{- if .Values.adminApiKeyFromSecret }}

--- a/charts/openhands/charts/automation/tests/storage_env_test.yaml
+++ b/charts/openhands/charts/automation/tests/storage_env_test.yaml
@@ -119,9 +119,24 @@ tests:
             name: AWS_S3_BUCKET
           any: true
 
+  - it: accepts google_cloud as an alias of the service's native gcs
+    set:
+      filestore.type: google_cloud
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: gcs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GCS_BUCKET_NAME
+            value: automation-data
+
   - it: rejects storage backends the service does not support
     set:
       filestore.type: local
     asserts:
       - failedTemplate:
-          errorPattern: filestore.type must be "s3" or "gcs"
+          errorPattern: filestore.type must be "s3", "gcs", or "google_cloud"

--- a/charts/openhands/charts/automation/tests/storage_env_test.yaml
+++ b/charts/openhands/charts/automation/tests/storage_env_test.yaml
@@ -1,0 +1,127 @@
+suite: filestore env wiring
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: wires an S3-compatible store (bundled MinIO) with inline creds and bucket auto-create
+    set:
+      filestore.type: s3
+      filestore.endpoint: http://openhands-minio:9000
+      filestore.createBucket: true
+      filestore.accessKey: default
+      filestore.secretKey: notasecret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: s3
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_BUCKET
+            value: automation-data
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://openhands-minio:9000
+      # http endpoint means plaintext — AWS_S3_SECURE is derived, not configured
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_AUTO_CREATE_BUCKET
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: default
+
+  - it: derives AWS_S3_SECURE=true from an https endpoint
+    set:
+      filestore.type: s3
+      filestore.endpoint: https://s3.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+            value: "true"
+
+  - it: prefers existingSecret credentials over inline keys
+    set:
+      filestore.type: s3
+      filestore.existingSecret: s3-creds
+      filestore.accessKey: should-not-render
+      filestore.secretKey: should-not-render
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-creds
+                key: AWS_SECRET_ACCESS_KEY
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: should-not-render
+
+  - it: renders no credential env for ambient identity (IRSA) and no endpoint vars for real AWS
+    set:
+      filestore.type: s3
+      filestore.bucket: acme-automation
+      filestore.region: us-east-1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-east-1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_SECURE
+          any: true
+
+  - it: wires GCS from the shared bucket value by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: gcs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GCS_BUCKET_NAME
+            value: automation-data
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_BUCKET
+          any: true
+
+  - it: rejects storage backends the service does not support
+    set:
+      filestore.type: local
+    asserts:
+      - failedTemplate:
+          errorPattern: filestore.type must be "s3" or "gcs"

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -114,7 +114,8 @@ gcp:
 # pod, so this is always a durable object store: any S3-compatible store
 # (AWS S3, MinIO, ...) or GCS.
 filestore:
-  # "s3" or "gcs"
+  # "s3" or "gcs". "google_cloud" is accepted as an alias of "gcs"; the
+  # template renders whichever spelling the service natively reads.
   type: gcs
 
   # Bucket to store packages in (both backends).

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -110,41 +110,36 @@ gcp:
   project: ""
   region: ""
 
-# File storage configuration (aligned with openhands chart pattern)
-# Supports multiple backends: gcs, s3, or in-cluster minio for ephemeral environments
+# Object storage for uploaded automation packages. Packages must outlive the
+# pod, so this is always a durable object store: any S3-compatible store
+# (AWS S3, MinIO, ...) or GCS.
 filestore:
-  # When true, uses S3-compatible storage (minio) for ephemeral/feature environments
-  # When false, uses cloud storage specified by 'type' (for production)
-  ephemeral: false
-  # Bucket name for storing automation data
-  bucket: automation-data
-  # Storage type when ephemeral=false (e.g., gcs, s3)
+  # "s3" or "gcs"
   type: gcs
 
-# Minio configuration for ephemeral storage (filestore.ephemeral=true)
-#
-# Two deployment modes:
-# 1. Standalone: Set minio.enabled=true to deploy minio as a subchart
-# 2. Subchart of openhands: Set minio.enabled=false and configure minio.external
-#    to use the parent chart's minio instance
-minio:
-  # When true, point the app at the release's minio service
-  # (http://<release>-minio:9000) using the first svcaccts credentials below.
-  # Set to false when deployed as subchart of openhands (uses parent's minio)
-  enabled: false
+  # Bucket to store packages in (both backends).
+  bucket: automation-data
 
-  # External minio configuration (used when enabled=false but filestore.ephemeral=true)
-  # Configure this to point to an existing minio instance (e.g., parent chart's minio)
-  external:
-    endpoint: "http://minio:9000"
-    accessKey: "default"
-    secretKey: "notasecret"
+  # s3 only. Leave empty for AWS (boto3 targets the regional endpoint); set
+  # for other S3-compatible stores, e.g. an in-cluster MinIO:
+  # http://<release>-minio:9000. TLS is inferred from the URL scheme — an
+  # http:// endpoint renders AWS_S3_SECURE=false.
+  endpoint: ""
+  region: ""
 
-  # Credentials used when enabled=true (only the first entry is read)
-  svcaccts:
-    - accessKey: "automationkey"
-      secretKey: "automationsecret"
-      user: root
+  # s3 only. Create the bucket at startup if nothing else provisions it.
+  createBucket: false
+
+  # s3 credentials — first match wins:
+  #   1. existingSecret: Secret holding the access key pair (key names below)
+  #   2. accessKey/secretKey: inline, for throwaway/dev environments only
+  #   3. neither: ambient AWS identity (IRSA, instance profile)
+  # gcs always uses ambient identity (Workload Identity / ADC).
+  existingSecret: ""
+  accessKeyIdKey: AWS_ACCESS_KEY_ID
+  secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  accessKey: ""
+  secretKey: ""
 
 # Service key from K8s secret (for staging/production)
 # Used by OpenHands SaaS to authenticate requests to the automation service

--- a/charts/openhands/charts/runtime-api/templates/_env.yaml
+++ b/charts/openhands/charts/runtime-api/templates/_env.yaml
@@ -26,11 +26,14 @@
 {{- if .Values.runtimeFileArchive.enabled }}
 # Archive the workspace before the cleanup CronJob pauses/stops a runtime. See
 # values.runtimeFileArchive. s3 targets the in-cluster minio (or external S3);
-# google_cloud uses the cleanup ServiceAccount's Workload Identity.
+# google_cloud uses the cleanup ServiceAccount's Workload Identity. "gcs"
+# normalizes to the archive code's native "google_cloud".
+{{- $archiveStore := .Values.runtimeFileArchive.storeType | default "google_cloud" }}
+{{- if eq $archiveStore "gcs" }}{{- $archiveStore = "google_cloud" }}{{- end }}
 - name: RUNTIME_FILE_ARCHIVE_ENABLED
   value: "true"
 - name: RUNTIME_FILE_ARCHIVE_STORE_TYPE
-  value: {{ .Values.runtimeFileArchive.storeType | default "google_cloud" | quote }}
+  value: {{ $archiveStore | quote }}
 - name: RUNTIME_FILE_ARCHIVE_BUCKET
   value: {{ .Values.runtimeFileArchive.bucket | quote }}
 - name: RUNTIME_FILE_ARCHIVE_PREFIX
@@ -39,7 +42,7 @@
   value: {{ .Values.runtimeFileArchive.path | default "/workspace/project" | quote }}
 - name: RUNTIME_FILE_ARCHIVE_FORMAT
   value: {{ .Values.runtimeFileArchive.format | default "both" | quote }}
-{{- if eq (.Values.runtimeFileArchive.storeType | default "google_cloud") "s3" }}
+{{- if eq $archiveStore "s3" }}
 {{- with .Values.runtimeFileArchive.s3.endpoint }}
 - name: AWS_S3_ENDPOINT
   value: {{ . | quote }}

--- a/charts/openhands/charts/runtime-api/templates/_env.yaml
+++ b/charts/openhands/charts/runtime-api/templates/_env.yaml
@@ -40,28 +40,15 @@
 - name: RUNTIME_FILE_ARCHIVE_FORMAT
   value: {{ .Values.runtimeFileArchive.format | default "both" | quote }}
 {{- if eq (.Values.runtimeFileArchive.storeType | default "google_cloud") "s3" }}
-{{- if .Values.runtimeFileArchive.s3.endpoint }}
+{{- with .Values.runtimeFileArchive.s3.endpoint }}
 - name: AWS_S3_ENDPOINT
-  value: {{ .Values.runtimeFileArchive.s3.endpoint | quote }}
-{{- else if not (or .Values.runtimeFileArchive.s3.region .Values.runtimeFileArchive.s3.existingSecret) }}
-# No explicit endpoint and no external-S3 markers (region/existingSecret):
-# default to the bundled in-cluster minio. When those markers ARE set, leave
-# the endpoint unset so boto3 uses the AWS regional endpoint instead of being
-# force-pinned to minio (which would misroute external-S3 archives).
-- name: AWS_S3_ENDPOINT
-  value: {{ printf "http://%s-minio:9000" .Release.Name | quote }}
+  value: {{ . | quote }}
 {{- end }}
-{{- if .Values.runtimeFileArchive.s3.secure }}
-# Only emitted when explicitly enabled. Otherwise TLS is inferred from the
-# endpoint scheme (bundled minio is http://), and an endpoint-less external S3
-# (region/existingSecret) defaults to TLS in the client — so plain HTTP is never
-# forced onto a real S3 endpoint.
-- name: AWS_S3_SECURE
-  value: "true"
-{{- end }}
-{{- if .Values.runtimeFileArchive.s3.region }}
+{{- /* AWS_S3_SECURE is never emitted: the cleanup client infers TLS from the
+       endpoint scheme, and an endpoint-less real-AWS store defaults to TLS. */}}
+{{- with .Values.runtimeFileArchive.s3.region }}
 - name: AWS_REGION
-  value: {{ .Values.runtimeFileArchive.s3.region | quote }}
+  value: {{ . | quote }}
 {{- end }}
 {{- if .Values.runtimeFileArchive.s3.existingSecret }}
 - name: AWS_ACCESS_KEY_ID
@@ -74,15 +61,13 @@
     secretKeyRef:
       name: {{ .Values.runtimeFileArchive.s3.existingSecret }}
       key: {{ .Values.runtimeFileArchive.s3.secretAccessKeyKey | default "AWS_SECRET_ACCESS_KEY" }}
-{{- else }}
-# Explicit creds — default to the bundled minio dev creds (s3.accessKeyId /
-# secretAccessKey in values, matching minio.svcaccts). Set them (or use
-# existingSecret) for a real store.
+{{- else if .Values.runtimeFileArchive.s3.accessKeyId }}
 - name: AWS_ACCESS_KEY_ID
   value: {{ .Values.runtimeFileArchive.s3.accessKeyId | quote }}
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .Values.runtimeFileArchive.s3.secretAccessKey | quote }}
 {{- end }}
+{{- /* No credential env at all: ambient AWS identity. */}}
 {{- end }}
 {{- end }}
 {{- if .Values.runtimeInSameCluster }}

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -213,7 +213,7 @@ cleanup:
 # (endpoint defaults to http://<release>-minio:9000) or any S3-compatible store.
 runtimeFileArchive:
   enabled: false
-  storeType: google_cloud # google_cloud | s3
+  storeType: google_cloud # s3 | gcs (alias: google_cloud)
   # Existing object-storage bucket that receives the archives. The chart does
   # not create it; provision it and grant the cleanup identity write access.
   bucket: ""

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -225,17 +225,20 @@ runtimeFileArchive:
   format: both # both, git-delta (compact), or tar.gz.
   # S3-compatible connection — only used when storeType=s3.
   s3:
-    # Empty endpoint -> bundled in-cluster minio (http://<release>-minio:9000),
-    # UNLESS region or existingSecret is set (external S3), in which case the
-    # endpoint is left unset so boto3 targets the AWS regional endpoint.
+    # Leave empty for AWS (boto3 targets the regional endpoint); set for any
+    # other S3-compatible store, e.g. the parent chart's bundled MinIO:
+    # http://<release>-minio:9000. TLS is inferred from the URL scheme.
     endpoint: ""
-    region: "" # Set for external (non-minio) S3; also drops the minio endpoint default.
-    secure: false # true for HTTPS endpoints (external S3).
-    # Defaults to the bundled minio dev creds (match minio.svcaccts). Override
-    # for an external store, or use existingSecret below.
-    accessKeyId: "default"
-    secretAccessKey: "notasecret"
-    existingSecret: "" # Optional secret with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.
+    region: "" # AWS region of the bucket; required for real AWS S3.
+    # Credentials — first match wins: existingSecret, inline
+    # accessKeyId/secretAccessKey, else the pod's ambient AWS identity
+    # (IRSA / Pod Identity / instance profile). For the bundled MinIO, set the
+    # inline pair to the parent chart's minio.svcaccts credentials.
+    existingSecret: "" # Secret with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY keys.
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    accessKeyId: ""
+    secretAccessKey: ""
 
 warmRuntimes:
   enabled: false

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -95,13 +95,14 @@
 {{- end }}
 {{- /* No credential env at all: ambient AWS identity (IRSA / Pod Identity /
        instance profile). */}}
-{{- else if eq .Values.filestore.type "google_cloud" }}
+{{- else if or (eq .Values.filestore.type "gcs") (eq .Values.filestore.type "google_cloud") }}
 # GCS via ambient identity (Workload Identity / ADC); the bucket comes from
-# FILE_STORE_PATH above.
+# FILE_STORE_PATH above. "gcs" is the charts' canonical spelling; the app's
+# native FILE_STORE value is "google_cloud", so both normalize to it here.
 - name: FILE_STORE
   value: google_cloud
 {{- else }}
-{{- fail (printf "filestore.type must be \"s3\" or \"google_cloud\", got %q" .Values.filestore.type) }}
+{{- fail (printf "filestore.type must be \"s3\", \"gcs\", or \"google_cloud\", got %q" .Values.filestore.type) }}
 {{- end }}
 {{- if .Values.filestore.provider }}
 - name: SHARED_EVENT_STORAGE_PROVIDER
@@ -109,6 +110,8 @@
 {{- end }}
 {{- if .Values.runtimeFileArchive.enabled }}
 {{- $archiveStore := .Values.runtimeFileArchive.storeType | default (ternary "s3" "google_cloud" (eq .Values.filestore.type "s3")) }}
+{{- /* "gcs" normalizes to the archive code's native "google_cloud". */}}
+{{- if eq $archiveStore "gcs" }}{{- $archiveStore = "google_cloud" }}{{- end }}
 # Archive a sandbox's workspace before an explicit delete. Empty storeType
 # follows filestore.type. The s3 store reuses the AWS_S3_*/AWS_*_KEY connection
 # env populated from values.filestore above (bundled MinIO, external S3, or the

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -47,43 +47,28 @@
   value: 'true'
 - name: SANDBOX_CLOSE_DELAY
   value: "1800"
-{{- if .Values.filestore.ephemeral }}
-- name: FILE_STORE
-  value: s3
-- name: AWS_ACCESS_KEY_ID
-  value: {{ (index .Values.minio.svcaccts 0).accessKey }}
-- name: AWS_SECRET_ACCESS_KEY
-  value: {{ (index .Values.minio.svcaccts 0).secretKey }}
-- name: AWS_S3_ENDPOINT
-  value: {{ printf "http://%s-minio:9000" $.Release.Name }}
-- name: AWS_S3_BUCKET
-  value: {{ .Values.filestore.bucket }}
-- name: AWS_S3_SECURE
-  value: 'false'
-{{- else if or (eq (.Values.filestore.type | default "") "s3") .Values.filestore.existingSecret .Values.filestore.region .Values.filestore.endpoint }}
-# External S3 (or S3-compatible) object store — the durable alternative to the
-# bundled MinIO. Engaged by filestore.type=s3 or any external marker
-# (existingSecret / region / endpoint). The app's S3FileStore uses boto3, so
-# credentials come from filestore.existingSecret when set, otherwise from the
-# pod's ambient AWS identity (IRSA / Pod Identity / instance profile). Unlike the
-# ephemeral branch, AWS_S3_ENDPOINT is left unset for real AWS so boto3 targets
-# the regional endpoint instead of being pinned to MinIO.
+{{- if eq .Values.filestore.type "s3" }}
+{{- /* Empty endpoint targets the bundled MinIO when it is deployed, otherwise
+       real AWS (boto3 uses the regional endpoint). */}}
+{{- $endpoint := .Values.filestore.endpoint }}
+{{- if and (not $endpoint) .Values.minio.enabled }}
+{{- $endpoint = printf "http://%s-minio:9000" $.Release.Name }}
+{{- end }}
 - name: FILE_STORE
   value: s3
 - name: AWS_S3_BUCKET
   value: {{ .Values.filestore.bucket | quote }}
-{{- if .Values.filestore.region }}
+{{- with .Values.filestore.region }}
 - name: AWS_REGION
-  value: {{ .Values.filestore.region | quote }}
+  value: {{ . | quote }}
 {{- end }}
-{{- if .Values.filestore.endpoint }}
+{{- if $endpoint }}
 - name: AWS_S3_ENDPOINT
-  value: {{ .Values.filestore.endpoint | quote }}
+  value: {{ $endpoint | quote }}
 {{- end }}
-{{- $secure := .Values.filestore.secure }}
-{{- if kindIs "invalid" $secure }}{{- $secure = true }}{{- end }}
+# TLS is inferred from the endpoint scheme; no endpoint (real AWS) means TLS.
 - name: AWS_S3_SECURE
-  value: {{ $secure | quote }}
+  value: {{ or (not $endpoint) (hasPrefix "https://" $endpoint) | quote }}
 {{- if .Values.filestore.existingSecret }}
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
@@ -95,23 +80,40 @@
     secretKeyRef:
       name: {{ .Values.filestore.existingSecret }}
       key: {{ .Values.filestore.secretAccessKeyKey | default "AWS_SECRET_ACCESS_KEY" }}
+{{- else if .Values.filestore.accessKey }}
+- name: AWS_ACCESS_KEY_ID
+  value: {{ .Values.filestore.accessKey | quote }}
+- name: AWS_SECRET_ACCESS_KEY
+  value: {{ .Values.filestore.secretKey | quote }}
+{{- else if .Values.minio.enabled }}
+# Bundled MinIO service-account creds — the default when the chart deploys its
+# own MinIO and no explicit credentials are configured.
+- name: AWS_ACCESS_KEY_ID
+  value: {{ (index .Values.minio.svcaccts 0).accessKey }}
+- name: AWS_SECRET_ACCESS_KEY
+  value: {{ (index .Values.minio.svcaccts 0).secretKey }}
 {{- end }}
-{{- else }}
+{{- /* No credential env at all: ambient AWS identity (IRSA / Pod Identity /
+       instance profile). */}}
+{{- else if eq .Values.filestore.type "google_cloud" }}
+# GCS via ambient identity (Workload Identity / ADC); the bucket comes from
+# FILE_STORE_PATH above.
 - name: FILE_STORE
-  value: {{ .Values.filestore.type }}
+  value: google_cloud
+{{- else }}
+{{- fail (printf "filestore.type must be \"s3\" or \"google_cloud\", got %q" .Values.filestore.type) }}
 {{- end }}
 {{- if .Values.filestore.provider }}
 - name: SHARED_EVENT_STORAGE_PROVIDER
   value: {{ .Values.filestore.provider }}
 {{- end }}
 {{- if .Values.runtimeFileArchive.enabled }}
-{{- $archiveStore := .Values.runtimeFileArchive.storeType | default (ternary "s3" "google_cloud" .Values.filestore.ephemeral) }}
-# Archive a sandbox's workspace before an explicit delete. The s3 store reuses
-# the AWS_S3_*/AWS_*_KEY connection env: with filestore.ephemeral it is the
-# in-cluster minio set above; on a non-ephemeral external-S3 store the operator
-# supplies it through the pod's normal AWS credential mechanism (IRSA, a mounted
-# secret, etc.). google_cloud uses the pod ServiceAccount's Workload Identity.
-# See values.runtimeFileArchive.
+{{- $archiveStore := .Values.runtimeFileArchive.storeType | default (ternary "s3" "google_cloud" (eq .Values.filestore.type "s3")) }}
+# Archive a sandbox's workspace before an explicit delete. Empty storeType
+# follows filestore.type. The s3 store reuses the AWS_S3_*/AWS_*_KEY connection
+# env populated from values.filestore above (bundled MinIO, external S3, or the
+# pod's ambient AWS identity). google_cloud uses the pod ServiceAccount's
+# Workload Identity. See values.runtimeFileArchive.
 - name: RUNTIME_FILE_ARCHIVE_ENABLED
   value: "true"
 - name: RUNTIME_FILE_ARCHIVE_STORE_TYPE

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -96,7 +96,7 @@ spec:
         limits:
           maxAge: 336h
     {{- end }}
-    {{- if .Values.filestore.ephemeral }}
+    {{- if .Values.minio.enabled }}
     # MinIO logs (MinIO chart)
     - logs:
         name: app/{{ .Release.Name }}-minio/logs
@@ -495,7 +495,7 @@ spec:
               when: ">= 1"
               message: "OpenHands LiteLLM deployment is ready"
     {{- end }}
-    {{- if .Values.filestore.ephemeral }}
+    {{- if .Values.minio.enabled }}
     - deploymentStatus:
         name: {{ .Release.Name }}-minio
         namespace: {{ .Release.Namespace }}

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -19,10 +19,10 @@ contents before recreating it — so with purge on, every ordinary upgrade of a
 persistent install destroys the conversation and session files. Deliberately NOT
 scoped to .Values.enabled: the bundled store is shared with runtime-api and
 automation, so the data is at risk even in a server-less release. Scoped instead
-to filestore.ephemeral, which is what deploys the bundled store at all, so
+to minio.enabled, which is what deploys the bundled store at all, so
 external-S3/GCS releases are unaffected by whatever sits in .Values.minio.
 */}}
-{{- if .Values.filestore.ephemeral -}}
+{{- if .Values.minio.enabled -}}
 {{- range .Values.minio.buckets -}}
 {{- if .purge -}}
 {{- fail (printf "minio.buckets entry %q sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data." .name) -}}

--- a/charts/openhands/tests/filestore_env_test.yaml
+++ b/charts/openhands/tests/filestore_env_test.yaml
@@ -89,13 +89,12 @@ tests:
                 name: s3-creds
                 key: secret-key
 
-  - it: uses ambient identity and a custom endpoint when no secret is set
+  - it: derives TLS from the endpoint scheme and uses ambient identity when no creds are set
     set:
       enabled: true
       filestore.type: s3
       filestore.bucket: bk
-      filestore.endpoint: https://minio.example.com
-      filestore.secure: false
+      filestore.endpoint: http://minio.internal:9000
     asserts:
       - template: deployment.yaml
         contains:
@@ -108,7 +107,8 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: AWS_S3_ENDPOINT
-            value: https://minio.example.com
+            value: http://minio.internal:9000
+      # http endpoint means plaintext — AWS_S3_SECURE is derived, not configured.
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -124,29 +124,15 @@ tests:
         notExists:
           path: spec.template.spec.containers[0].env[?(@.name=="AWS_SECRET_ACCESS_KEY")]
 
-  - it: auto-engages the external S3 path from a marker field without type=s3
-    set:
-      enabled: true
-      filestore.bucket: bk
-      filestore.region: eu-central-1
-    asserts:
-      - template: deployment.yaml
-        contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: FILE_STORE
-            value: s3
-      - template: deployment.yaml
-        contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: AWS_REGION
-            value: eu-central-1
+  # Rejection of unsupported filestore.type values is covered by the schema
+  # enum (see values_schema_test.yaml); the template guard in _env.yaml is
+  # unreachable behind it and kept only for schema-bypassed renders.
 
-  - it: leaves the ephemeral MinIO wiring unchanged
+  - it: targets the bundled MinIO when it is deployed and no endpoint or creds are set
     set:
       enabled: true
-      filestore.ephemeral: true
+      minio.enabled: true
+      filestore.type: s3
       filestore.bucket: openhands-sessions
     asserts:
       - template: deployment.yaml
@@ -167,8 +153,43 @@ tests:
           content:
             name: AWS_S3_SECURE
             value: "false"
+      # Falls back to the bundled MinIO's svcaccts credentials.
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: default
 
-  - it: passes a non-S3 store type straight through to FILE_STORE
+  - it: prefers explicit configuration over the bundled MinIO fallback
+    set:
+      enabled: true
+      minio.enabled: true
+      filestore.type: s3
+      filestore.endpoint: https://s3.example.com
+      filestore.accessKey: explicit-key
+      filestore.secretKey: explicit-secret
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: https://s3.example.com
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: explicit-key
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: default
+
+  - it: wires GCS through FILE_STORE with no S3 env
     set:
       enabled: true
       filestore.type: google_cloud
@@ -180,7 +201,7 @@ tests:
           content:
             name: FILE_STORE
             value: google_cloud
-      # The external-S3 branch stays dormant, so none of its AWS_S3_* env leaks.
+      # The S3 branch stays dormant, so none of its AWS_S3_* env leaks.
       - template: deployment.yaml
         notExists:
           path: spec.template.spec.containers[0].env[?(@.name=="AWS_S3_BUCKET")]
@@ -191,7 +212,8 @@ tests:
   - it: keeps the app on the bundled MinIO when rustfs is enabled
     set:
       enabled: true
-      filestore.ephemeral: true
+      minio.enabled: true
+      filestore.type: s3
       rustfs.enabled: true
     asserts:
       - template: deployment.yaml

--- a/charts/openhands/tests/filestore_env_test.yaml
+++ b/charts/openhands/tests/filestore_env_test.yaml
@@ -189,6 +189,18 @@ tests:
             name: AWS_ACCESS_KEY_ID
             value: default
 
+  - it: normalizes the canonical gcs spelling to the app's native google_cloud
+    set:
+      enabled: true
+      filestore.type: gcs
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILE_STORE
+            value: google_cloud
+
   - it: wires GCS through FILE_STORE with no S3 env
     set:
       enabled: true

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -50,7 +50,7 @@ tests:
   # install. These cases pin the guard that rejects it.
   - it: fails when the bundled MinIO bucket sets purge true
     set:
-      filestore.ephemeral: true
+      minio.enabled: true
       minio.buckets:
         - name: openhands-sessions
           policy: none
@@ -63,7 +63,7 @@ tests:
     # regardless of whether this release runs the server.
     set:
       enabled: false
-      filestore.ephemeral: true
+      minio.enabled: true
       minio.buckets:
         - name: openhands-sessions
           policy: none
@@ -73,7 +73,7 @@ tests:
           errorMessage: 'minio.buckets entry "openhands-sessions" sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data.'
   - it: fails on any purging bucket, not just the first
     set:
-      filestore.ephemeral: true
+      minio.enabled: true
       minio.buckets:
         - name: openhands-sessions
           policy: none
@@ -86,15 +86,15 @@ tests:
           errorMessage: 'minio.buckets entry "scratch" sets purge: true, which makes the bundled MinIO bucket job delete every object in the bucket on each post-upgrade run. Set purge: false to protect existing conversation and session data.'
   - it: allows the bundled MinIO with the shipped purge false default
     set:
-      filestore.ephemeral: true
+      minio.enabled: true
     asserts:
       - hasDocuments:
           count: 0
   - it: ignores minio values entirely for external-store releases
-    # ephemeral: false never renders the minio dependency, so leftover values
-    # must not block an external-S3 or GCS install.
+    # minio.enabled: false never renders the minio dependency, so leftover
+    # values must not block an external-S3 or GCS install.
     set:
-      filestore.ephemeral: false
+      minio.enabled: false
       minio.buckets:
         - name: openhands-sessions
           policy: none

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -20,18 +20,18 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "ingress/enabled.*want boolean"
-  - it: rejects a non-boolean filestore.secure
+  - it: rejects a storage backend the app does not support
     set:
-      filestore.secure: "yes"
+      filestore.type: local
     asserts:
       - failedTemplate:
-          errorPattern: "filestore/secure.*want boolean"
-  - it: rejects a non-boolean filestore.ephemeral
+          errorPattern: "filestore/type"
+  - it: rejects a non-boolean minio.enabled
     set:
-      filestore.ephemeral: "nope"
+      minio.enabled: "yes"
     asserts:
       - failedTemplate:
-          errorPattern: "filestore/ephemeral.*want boolean"
+          errorPattern: "minio/enabled.*want boolean"
   - it: rejects a non-string filestore.region
     set:
       filestore.region: true
@@ -47,7 +47,6 @@ tests:
       filestore.bucket: prod-sessions
       filestore.region: us-west-2
       filestore.endpoint: https://minio.example.com
-      filestore.secure: false
       filestore.existingSecret: s3-creds
       filestore.accessKeyIdKey: access-key
       filestore.secretAccessKeyKey: secret-key

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -85,7 +85,7 @@
       "type": "object",
       "properties": {
         "bucket": { "type": "string" },
-        "type": { "type": "string", "enum": ["s3", "google_cloud"] },
+        "type": { "type": "string", "enum": ["s3", "gcs", "google_cloud"] },
         "provider": { "type": "string" },
         "region": { "type": "string" },
         "endpoint": { "type": "string" },

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -84,16 +84,22 @@
     "filestore": {
       "type": "object",
       "properties": {
-        "ephemeral": { "type": "boolean" },
         "bucket": { "type": "string" },
-        "type": { "type": "string" },
+        "type": { "type": "string", "enum": ["s3", "google_cloud"] },
         "provider": { "type": "string" },
         "region": { "type": "string" },
         "endpoint": { "type": "string" },
-        "secure": { "type": "boolean" },
         "existingSecret": { "type": "string" },
         "accessKeyIdKey": { "type": "string" },
-        "secretAccessKeyKey": { "type": "string" }
+        "secretAccessKeyKey": { "type": "string" },
+        "accessKey": { "type": "string" },
+        "secretKey": { "type": "string" }
+      }
+    },
+    "minio": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
       }
     }
   }

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -101,38 +101,41 @@ agentServerEnv: {}
 integrations:
   resolverLabel: "openhands"
 
+# Object storage for conversation/session files. Always a durable object
+# store: any S3-compatible store (AWS S3, the bundled MinIO, R2, ...) or GCS.
+# To use the bundled MinIO, set minio.enabled: true and type: s3 — with no
+# endpoint or credentials configured, the app targets the bundled instance
+# automatically.
 filestore:
-  # ephemeral: true deploys the bundled in-cluster MinIO (a conditional
-  # dependency) and points the app at it — handy for POC/feature envs. NOTE the
-  # name is misleading: the bundled MinIO is only non-persistent with THIS
-  # chart's minio.persistence.enabled: false default, and Replicated installs
-  # override it to true (replicated/openhands.yaml), so those hold durable
-  # customer data in a PVC. Treat the bundled store as persistent unless you
-  # have checked minio.persistence for the install in front of you. For a
-  # managed store set ephemeral: false and use an external store (S3 or GCS).
-  ephemeral: false
-  # Bucket name (S3/GCS) or MinIO bucket for conversation/session file storage.
+  # "s3" or "google_cloud" (GCS).
+  type: google_cloud
+
+  # Bucket to store conversation/session files in (both backends).
   bucket: openhands-sessions
-  # Store backend when ephemeral: false. "s3" (AWS S3 or any S3-compatible store)
-  # or "google_cloud" / "gcs" (GCS via Workload Identity). Empty keeps the legacy
-  # behavior (FILE_STORE set to this raw value). The external-S3 path below also
-  # auto-engages if any of region/endpoint/existingSecret is set.
-  type: ""
-  # --- External S3 (used when type: s3, or any field below is set) ---
+
+  # s3 only. Leave empty for AWS (boto3 targets the regional endpoint) or for
+  # the bundled MinIO (minio.enabled). Set for any other S3-compatible store.
+  # TLS is inferred from the URL scheme — an http:// endpoint renders
+  # AWS_S3_SECURE=false.
+  endpoint: ""
   # AWS region of the bucket. Required for real AWS S3 (boto3 needs it to sign).
   region: ""
-  # Custom endpoint for S3-compatible stores (MinIO/R2/GCS-interop/…). Leave
-  # empty for real AWS S3 so boto3 uses the regional endpoint.
-  endpoint: ""
-  # Use TLS. Defaults to true when unset; set false only for a plain-HTTP
-  # S3-compatible endpoint.
-  secure: true
-  # Name of an existing Secret holding AWS credentials. Omit to use the pod's
-  # ambient AWS identity (IRSA / Pod Identity / instance profile) with no keys.
+
+  # s3 credentials — first match wins:
+  #   1. existingSecret: Secret holding the access key pair (key names below)
+  #   2. accessKey/secretKey: inline, for throwaway/dev environments only
+  #   3. minio.enabled: the bundled MinIO's minio.svcaccts credentials
+  #   4. none: ambient AWS identity (IRSA / Pod Identity / instance profile)
+  # google_cloud always uses ambient identity (Workload Identity / ADC).
   existingSecret: ""
-  # Keys within existingSecret (defaults match the AWS SDK env var names).
   accessKeyIdKey: AWS_ACCESS_KEY_ID
   secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+  accessKey: ""
+  secretKey: ""
+
+  # Optional SHARED_EVENT_STORAGE_PROVIDER override ("aws" | "gcp"); when empty
+  # the app derives the provider from FILE_STORE.
+  provider: ""
 
 # Workspace archiving (app-server, explicit-delete path): before a still-running
 # sandbox is deleted, copy its workspace to object storage so the agent's work
@@ -142,12 +145,12 @@ filestore:
 #
 # storeType: "google_cloud" uses the app-server ServiceAccount's Workload
 # Identity (GKE; needs roles/storage.objectAdmin on the bucket). "s3" uses the
-# AWS_S3_*/AWS_*_KEY env, already populated from the in-cluster minio when
-# filestore.ephemeral=true — so self-hosted installs can archive to minio or any
-# S3-compatible store. Empty = auto (s3 if ephemeral, else google_cloud).
+# AWS_S3_*/AWS_*_KEY env populated from values.filestore — so self-hosted
+# installs can archive to the bundled MinIO or any S3-compatible store.
+# Empty = follow filestore.type (s3 -> s3, google_cloud -> google_cloud).
 runtimeFileArchive:
   enabled: false
-  storeType: "" # google_cloud | s3; empty = auto by filestore.ephemeral
+  storeType: "" # google_cloud | s3; empty = follow filestore.type
   # Existing object-storage bucket that receives the archives. The chart does
   # not create it; provision it and grant the app-server identity write access.
   bucket: ""
@@ -681,6 +684,13 @@ litellm-helm:
       allowed_fails: 3
 
 minio:
+  # Deploy the bundled in-cluster MinIO (a conditional dependency) — handy for
+  # POC/feature envs and self-contained installs. Durability follows
+  # persistence.enabled below: false here by default, but Replicated installs
+  # override it to true (replicated/openhands.yaml) and hold durable customer
+  # data in a PVC. When enabled and filestore.type is s3 with no endpoint or
+  # credentials configured, the app targets this instance automatically.
+  enabled: false
   replicas: 1
   mode: standalone
   persistence:
@@ -713,9 +723,9 @@ minio:
       cpu: 100m
 
 # Opt-in alternative to the bundled MinIO. RustFS speaks S3, so point the app at
-# it with the existing external-S3 values — no separate wiring:
-#   filestore: {ephemeral: false, type: s3, secure: false,
-#               endpoint: "http://<release>-rustfs-svc:9000", existingSecret: <s3 keys>}
+# it with the ordinary filestore values — no separate wiring:
+#   filestore: {type: s3, endpoint: "http://<release>-rustfs-svc:9000",
+#               existingSecret: <s3 keys>}
 rustfs:
   enabled: false
   # The subchart refuses to render without credentials. These match

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -107,8 +107,9 @@ integrations:
 # endpoint or credentials configured, the app targets the bundled instance
 # automatically.
 filestore:
-  # "s3" or "google_cloud" (GCS).
-  type: google_cloud
+  # "s3" or "gcs". "google_cloud" is accepted as an alias of "gcs"; the
+  # template renders whichever spelling the app natively reads.
+  type: gcs
 
   # Bucket to store conversation/session files in (both backends).
   bucket: openhands-sessions
@@ -150,7 +151,7 @@ filestore:
 # Empty = follow filestore.type (s3 -> s3, google_cloud -> google_cloud).
 runtimeFileArchive:
   enabled: false
-  storeType: "" # google_cloud | s3; empty = follow filestore.type
+  storeType: "" # s3 | gcs (alias: google_cloud); empty = follow filestore.type
   # Existing object-storage bucket that receives the archives. The chart does
   # not create it; provision it and grant the app-server identity write access.
   bucket: ""

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1189,27 +1189,30 @@ automation:
     project: ""
     region: ""
   
-  # File storage configuration (aligned with openhands chart pattern)
-  # Supports multiple backends: gcs, s3, or in-cluster minio for ephemeral environments
+  # Object storage for uploaded automation packages. Packages must outlive the
+  # pod, so this is always a durable object store: any S3-compatible store
+  # (AWS S3, MinIO, ...) or GCS. See the automation subchart's values.yaml for
+  # the full key reference. To use the bundled MinIO, set type: s3 and
+  # endpoint: http://<release>-minio:9000 with createBucket: true.
   filestore:
-    # When true, uses S3-compatible storage (minio) for ephemeral/feature environments
-    # When false, uses cloud storage specified by 'type' (for production)
-    ephemeral: false
-    # Bucket name for storing automation data
-    bucket: automation-data
-    # Storage type when ephemeral=false (e.g., gcs, s3)
+    # "s3" or "gcs"
     type: gcs
-  
-  # Minio configuration for ephemeral storage
-  # When deployed as subchart of openhands, automation uses parent's minio instance
-  minio:
-    # Don't deploy minio as subchart - use parent's minio instance
-    enabled: false
-    # External minio configuration (points to parent chart's minio)
-    external:
-      endpoint: "http://minio:9000"
-      accessKey: "default"
-      secretKey: "notasecret"
+    # Bucket to store packages in (both backends).
+    bucket: automation-data
+    # s3 only. Leave empty for AWS; set for other S3-compatible stores. TLS is
+    # inferred from the URL scheme.
+    endpoint: ""
+    region: ""
+    # s3 only. Create the bucket at startup if nothing else provisions it.
+    createBucket: false
+    # s3 credentials: existingSecret wins, then inline accessKey/secretKey,
+    # then ambient AWS identity (IRSA, instance profile). gcs always uses
+    # ambient identity (Workload Identity / ADC).
+    existingSecret: ""
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    accessKey: ""
+    secretKey: ""
   
   # Service key from K8s secret
   serviceKeyFromSecret:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -670,10 +670,23 @@ spec:
             - name: '{{repl ImagePullSecretName }}'
           openhandsApiUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           automationBaseUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
+          # Uploaded automation packages must survive pod replacement, so store
+          # them on the bundled MinIO (persistent here — minio.persistence
+          # above) instead of the pod filesystem. ephemeral: true selects the
+          # subchart's S3 mode; minio.enabled stays false so it targets the
+          # parent chart's MinIO through minio.external.
           filestore:
-            type: local
+            ephemeral: true
+          minio:
+            external:
+              endpoint: http://openhands-minio:9000
+              # Matches the parent chart's minio.svcaccts credentials.
+              accessKey: default
+              secretKey: notasecret
           env:
-            LOCAL_STORAGE_PATH: /tmp/automation
+            # The bundled MinIO's bucket job only creates the parent chart's
+            # buckets, so the service provisions its own bucket on startup.
+            AWS_S3_AUTO_CREATE_BUCKET: "true"
           database:
             createDatabaseUser: true
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -672,21 +672,16 @@ spec:
           automationBaseUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           # Uploaded automation packages must survive pod replacement, so store
           # them on the bundled MinIO (persistent here — minio.persistence
-          # above) instead of the pod filesystem. ephemeral: true selects the
-          # subchart's S3 mode; minio.enabled stays false so it targets the
-          # parent chart's MinIO through minio.external.
+          # above) instead of the pod filesystem.
           filestore:
-            ephemeral: true
-          minio:
-            external:
-              endpoint: http://openhands-minio:9000
-              # Matches the parent chart's minio.svcaccts credentials.
-              accessKey: default
-              secretKey: notasecret
-          env:
+            type: s3
+            endpoint: http://openhands-minio:9000
             # The bundled MinIO's bucket job only creates the parent chart's
-            # buckets, so the service provisions its own bucket on startup.
-            AWS_S3_AUTO_CREATE_BUCKET: "true"
+            # buckets, so the service provisions its own on startup.
+            createBucket: true
+            # Matches the parent chart's minio.svcaccts credentials.
+            accessKey: default
+            secretKey: notasecret
           database:
             createDatabaseUser: true
             host: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_host"}}{{repl else}}openhands-postgresql{{repl end}}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -453,9 +453,13 @@ spec:
         repository: 'proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/bitnamilegacy/redis'
       auth:
         password: '{{repl ConfigOption "redis_password" | Base64Encode }}'
+    # Conversation/session files live on the bundled MinIO, which is durable
+    # here (persistence below). With no endpoint or credentials configured,
+    # the app targets the bundled instance automatically.
     filestore:
-      ephemeral: true
+      type: s3
     minio:
+      enabled: true
       persistence:
         enabled: true
       resources:


### PR DESCRIPTION
## Description

Fixes [OHE-3033](https://linear.app/all-hands-ai/issue/OHE-3033/bug-automations-replicated-automation-packages-are-lost-after): on replicated installs the automation service ran with a local file store, so uploaded automation package tarballs lived on the pod filesystem. Any pod replacement (upgrade, reschedule, restart) deleted them while the automation definitions stayed in postgres. Every later run then failed with `FileNotFoundError` on the package and surfaced as `FAILED: Internal error` before a conversation was created. The fix points the automation service at the bundled minio, which replicated installs already run persistently.

The bug traced back to how the storage values are laid out. Everything hung off `filestore.ephemeral`, a flag named for our ephemeral feature environments that actually deploys the bundled minio and points the app at it. The name reads wrong everywhere outside our cloud pipeline, so this PR also restructures storage config across the umbrella:

- `minio.enabled` deploys the bundled minio (the dependency condition)
- `filestore` is a flat block per service: `type`, `bucket`, `endpoint`, `region`, and a credential chain (`existingSecret`, inline keys, bundled minio, ambient identity)
- `type` uses one vocabulary everywhere: `s3` or `gcs`, with `google_cloud` accepted as an alias. Each template renders whichever spelling its service natively reads, so the app's `google_cloud` / automation's `gcs` split stays internal to the charts
- TLS is inferred from the endpoint URL scheme; the `secure` knob is gone
- the automation subchart carries no minio-specific values; it's plain S3 config, with `createBucket` for stores nothing else provisions
- runtime-api's archive s3 block loses the "empty endpoint means bundled minio" heuristic and its baked-in dev creds

When `minio.enabled` is true and no endpoint or credentials are set, the s3 path targets the bundled instance automatically. That keeps the self-contained install zero-config while the values stay honest.

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

Backwards compatibility is deliberately broken - the old storage values are removed rather than aliased. Migration for consumers:

- `filestore.ephemeral: true` becomes `minio.enabled: true` + `filestore.type: s3`
- `filestore.type: ""` (the old passthrough default) now fails schema validation; set `s3` or `gcs`
- automation subchart: `filestore.ephemeral` + `minio.external.*` become `filestore: {type: s3, endpoint, createBucket, creds}`
- `runtimeFileArchive.s3` needs an explicit endpoint; creds default to ambient identity instead of the minio dev pair

## Additional Notes

Validated end to end on a replicated test instance:

- fresh install: the automation service auto-created its bucket, a package upload landed in minio, and after deleting the automation pod the replacement pod fetched the full tarball - the exact sequence that failed in the ticket
- upgrade path (old layout to this one): minio, its PVC, and stored objects carried through untouched, and a new conversation's events landed in the sessions bucket through the refactored env wiring

The squash title carries `!` on purpose: with `bump-minor-pre-major` this releases as a minor bump.
