### PR TITLE
feat(filestore): PLTF-1250 deploy bundled RustFS consumed by nothing

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -48,11 +48,12 @@
 - name: SANDBOX_CLOSE_DELAY
   value: "1800"
 {{- if eq .Values.filestore.type "s3" }}
-{{- /* Empty endpoint targets the bundled MinIO when it is deployed, otherwise
-       real AWS (boto3 uses the regional endpoint). */}}
+{{- /* Empty endpoint targets the bundled object store (MinIO or RustFS) when
+       one is deployed, otherwise real AWS (boto3 uses the regional endpoint).
+       See templates/_objectstore.tpl for backend selection. */}}
 {{- $endpoint := .Values.filestore.endpoint }}
-{{- if and (not $endpoint) .Values.minio.enabled }}
-{{- $endpoint = printf "http://%s-minio:9000" $.Release.Name }}
+{{- if and (not $endpoint) (include "openhands.objectStore.backend" .) }}
+{{- $endpoint = include "openhands.objectStore.endpoint" . }}
 {{- end }}
 - name: FILE_STORE
   value: s3
@@ -85,13 +86,14 @@
   value: {{ .Values.filestore.accessKey | quote }}
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .Values.filestore.secretKey | quote }}
-{{- else if .Values.minio.enabled }}
-# Bundled MinIO service-account creds — the default when the chart deploys its
-# own MinIO and no explicit credentials are configured.
+{{- else if include "openhands.objectStore.backend" . }}
+# Bundled store service-account creds — the default when the chart deploys its
+# own object store (MinIO or RustFS) and no explicit credentials are configured.
+# Both backends answer to the same pair (see templates/_objectstore.tpl).
 - name: AWS_ACCESS_KEY_ID
-  value: {{ (index .Values.minio.svcaccts 0).accessKey }}
+  value: {{ include "openhands.objectStore.accessKey" . }}
 - name: AWS_SECRET_ACCESS_KEY
-  value: {{ (index .Values.minio.svcaccts 0).secretKey }}
+  value: {{ include "openhands.objectStore.secretKey" . }}
 {{- end }}
 {{- /* No credential env at all: ambient AWS identity (IRSA / Pod Identity /
        instance profile). */}}

--- a/charts/openhands/templates/_objectstore.tpl
+++ b/charts/openhands/templates/_objectstore.tpl
@@ -1,0 +1,53 @@
+{{/*
+Bundled object-store backend selection.
+
+Two bundled backends, in this precedence order:
+
+  minio    the bundled MinIO subchart (minio.enabled)
+  rustfs   the rustfs subchart (rustfs.enabled)
+
+MinIO wins when both are enabled, so enabling RustFS by itself deploys it
+without repointing the app — the same shape templates/_cache.tpl uses for
+redis/valkey, where the incumbent keeps precedence. Deploying RustFS therefore
+never moves a consumer onto an empty store; the migration switch (a later
+release) is what repoints consumers, once it has copied the data across.
+
+Neither backend is bundled when both are disabled: that install uses an
+external store (S3/GCS) or none, and these helpers render nothing.
+
+The endpoint is the only thing that changes between the two backends. Both are
+reached over plain HTTP inside the cluster, and both use the same credentials,
+so switching backends does not rotate anything the app holds.
+*/}}
+
+{{/* "minio", "rustfs", or "" when no bundled store is deployed. */}}
+{{- define "openhands.objectStore.backend" -}}
+{{- if .Values.minio.enabled -}}
+minio
+{{- else if .Values.rustfs.enabled -}}
+rustfs
+{{- end -}}
+{{- end -}}
+
+{{/* In-cluster endpoint of the active bundled store. */}}
+{{- define "openhands.objectStore.endpoint" -}}
+{{- if eq (include "openhands.objectStore.backend" .) "rustfs" -}}
+{{ printf "http://%s-rustfs-svc:9000" .Release.Name }}
+{{- else -}}
+{{ printf "http://%s-minio:9000" .Release.Name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Credentials for the bundled store. Sourced from minio.svcaccts[0] regardless of
+which backend is active: the RustFS values are seeded with the same pair, so the
+app's credentials are identical either way and only the endpoint moves.
+Validation rejects a mismatch (see templates/validations.yaml).
+*/}}
+{{- define "openhands.objectStore.accessKey" -}}
+{{ (index .Values.minio.svcaccts 0).accessKey }}
+{{- end -}}
+
+{{- define "openhands.objectStore.secretKey" -}}
+{{ (index .Values.minio.svcaccts 0).secretKey }}
+{{- end -}}

--- a/charts/openhands/templates/rustfs-bucket.yaml
+++ b/charts/openhands/templates/rustfs-bucket.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.rustfs.enabled }}
+{{- /*
+Creates the session bucket in RustFS. The upstream RustFS chart ships no bucket
+provisioning of its own (unlike the MinIO chart), so this is ours.
+
+Uses the rustfs image, which carries curl, so nothing extra has to be proxied or
+put in an airgap bundle. A signed PUT is retried until it succeeds: RustFS answers
+403 on /minio/health/live and /health, so there is no usable readiness gate to
+wait on. HTTP 200 means created and 409 means it already exists — both are
+success.
+
+There is deliberately NO delete path here. The bundled MinIO bucket job once
+shipped with purge enabled and erased conversation data on every upgrade; bucket
+provisioning in this chart is create-or-409 only.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-rustfs-bucket
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rustfs-bucket
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: rustfs-bucket
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.rustfs.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      containers:
+        - name: create-bucket
+          image: "{{ .Values.rustfs.image.rustfs.repository }}:{{ .Values.rustfs.image.rustfs.tag }}"
+          imagePullPolicy: {{ .Values.rustfs.image.rustfs.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: ENDPOINT
+              value: {{ printf "http://%s-rustfs-svc:9000" .Release.Name | quote }}
+            - name: BUCKET
+              value: {{ .Values.filestore.bucket | quote }}
+            - name: AK
+              value: {{ include "openhands.objectStore.accessKey" . | quote }}
+            - name: SK
+              value: {{ include "openhands.objectStore.secretKey" . | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              for i in $(seq 1 60); do
+                code=$(curl -s -o /tmp/out -w '%{http_code}' \
+                  --aws-sigv4 "aws:amz:us-east-1:s3" --user "$AK:$SK" \
+                  -X PUT "$ENDPOINT/$BUCKET" || echo 000)
+                case "$code" in
+                  200|409)
+                    echo "bucket '$BUCKET' ready (HTTP $code)"
+                    exit 0
+                    ;;
+                esac
+                echo "attempt $i: HTTP $code, retrying"
+                cat /tmp/out 2>/dev/null || true
+                sleep 5
+              done
+              echo "bucket '$BUCKET' could not be created" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+{{- end }}

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -509,9 +509,11 @@ spec:
               when: ">= 1"
               message: "OpenHands LiteLLM deployment is ready"
     {{- end }}
-    {{- /* Analyze whichever bundled object store is active. RustFS is a
-           StatefulSet, MinIO a Deployment, so the analyzer type follows the
-           backend rather than assuming a Deployment exists. */}}
+    {{- /* Analyze whichever bundled object store is active. Both run as a
+           Deployment in the chart's config — MinIO always, and RustFS in the
+           standalone mode the chart pins (the subchart only uses a StatefulSet
+           in distributed mode). The analyzer follows the backend rather than
+           assuming which store exists. */}}
     {{- if eq (include "openhands.objectStore.backend" .) "minio" }}
     - deploymentStatus:
         name: {{ .Release.Name }}-minio
@@ -525,16 +527,16 @@ spec:
               message: "OpenHands MinIO deployment is ready"
     {{- end }}
     {{- if eq (include "openhands.objectStore.backend" .) "rustfs" }}
-    - statefulsetStatus:
+    - deploymentStatus:
         name: {{ .Release.Name }}-rustfs
         namespace: {{ .Release.Namespace }}
         outcomes:
           - fail:
               when: "< 1"
-              message: "OpenHands RustFS statefulset is not ready"
+              message: "OpenHands RustFS deployment is not ready"
           - pass:
               when: ">= 1"
-              message: "OpenHands RustFS statefulset is ready"
+              message: "OpenHands RustFS deployment is ready"
     {{- end }}
     {{- if index .Values "runtime-api" "enabled" }}
     - deploymentStatus:

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -96,7 +96,10 @@ spec:
         limits:
           maxAge: 336h
     {{- end }}
-    {{- if .Values.minio.enabled }}
+    {{- /* Collect logs from whichever bundled object store is active, keyed off
+           the backend helper rather than minio.enabled so a RustFS-only render
+           collects RustFS instead of a MinIO pod that does not exist. */}}
+    {{- if eq (include "openhands.objectStore.backend" .) "minio" }}
     # MinIO logs (MinIO chart)
     - logs:
         name: app/{{ .Release.Name }}-minio/logs
@@ -104,6 +107,17 @@ spec:
         selector:
           - app=minio
           - release={{ .Release.Name }}
+        limits:
+          maxAge: 336h
+    {{- end }}
+    {{- if eq (include "openhands.objectStore.backend" .) "rustfs" }}
+    # RustFS logs (rustfs chart)
+    - logs:
+        name: app/{{ .Release.Name }}-rustfs/logs
+        namespace: {{ .Release.Namespace }}
+        selector:
+          - app.kubernetes.io/name=rustfs
+          - app.kubernetes.io/instance={{ .Release.Name }}
         limits:
           maxAge: 336h
     {{- end }}
@@ -495,7 +509,10 @@ spec:
               when: ">= 1"
               message: "OpenHands LiteLLM deployment is ready"
     {{- end }}
-    {{- if .Values.minio.enabled }}
+    {{- /* Analyze whichever bundled object store is active. RustFS is a
+           StatefulSet, MinIO a Deployment, so the analyzer type follows the
+           backend rather than assuming a Deployment exists. */}}
+    {{- if eq (include "openhands.objectStore.backend" .) "minio" }}
     - deploymentStatus:
         name: {{ .Release.Name }}-minio
         namespace: {{ .Release.Namespace }}
@@ -506,6 +523,18 @@ spec:
           - pass:
               when: ">= 1"
               message: "OpenHands MinIO deployment is ready"
+    {{- end }}
+    {{- if eq (include "openhands.objectStore.backend" .) "rustfs" }}
+    - statefulsetStatus:
+        name: {{ .Release.Name }}-rustfs
+        namespace: {{ .Release.Namespace }}
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: "OpenHands RustFS statefulset is not ready"
+          - pass:
+              when: ">= 1"
+              message: "OpenHands RustFS statefulset is ready"
     {{- end }}
     {{- if index .Values "runtime-api" "enabled" }}
     - deploymentStatus:

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -29,3 +29,19 @@ external-S3/GCS releases are unaffected by whatever sits in .Values.minio.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Credential-match guard for the bundled object store. The app is handed one
+credential pair for whichever bundled store is active (see
+templates/_objectstore.tpl), sourced from minio.svcaccts[0], so RustFS must
+answer to the same pair or object access breaks the moment consumers switch to
+it. Scoped to both stores being deployed — the state in which a switch is
+imminent — rather than to .Values.enabled, since the bundled store is shared
+with runtime-api and automation and matters even in a server-less release.
+*/}}
+{{- if and .Values.minio.enabled .Values.rustfs.enabled -}}
+{{- $mcAccess := (index .Values.minio.svcaccts 0).accessKey -}}
+{{- $mcSecret := (index .Values.minio.svcaccts 0).secretKey -}}
+{{- if or (ne (.Values.rustfs.secret.rustfs.access_key | toString) ($mcAccess | toString)) (ne (.Values.rustfs.secret.rustfs.secret_key | toString) ($mcSecret | toString)) -}}
+{{- fail "rustfs.secret.rustfs credentials must match minio.svcaccts[0]. The app is given one credential pair for whichever bundled store is active, so a mismatch breaks object access the moment consumers switch to RustFS. Set rustfs.secret.rustfs.access_key/secret_key to the same values as minio.svcaccts[0].accessKey/secretKey." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/tests/objectstore_backend_test.yaml
+++ b/charts/openhands/tests/objectstore_backend_test.yaml
@@ -1,0 +1,125 @@
+suite: bundled object-store backend selection
+templates:
+  - templates/deployment.yaml
+  - templates/rustfs-bucket.yaml
+  - templates/validations.yaml
+  - templates/_objectstore.tpl
+  - templates/_env.yaml
+  - templates/_helpers.tpl
+  # deployment.yaml includes this by path; helm-unittest only resolves templates
+  # the suite lists.
+  - templates/litellm-config-script.yaml
+tests:
+  # --- endpoint selection -------------------------------------------------
+  - it: points the app at the bundled MinIO by default
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-minio:9000
+
+  - it: points the app at RustFS when it is the only bundled store
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: false
+      rustfs.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-rustfs-svc:9000
+
+  - it: keeps MinIO precedence when both are enabled, so deploying RustFS does not repoint
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: true
+      rustfs.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-minio:9000
+
+  - it: hands the app one credential pair regardless of which store is active
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: true
+      rustfs.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            value: default
+
+  # --- bucket provisioning ------------------------------------------------
+  - it: provisions the RustFS bucket, since the upstream chart does not
+    template: templates/rustfs-bucket.yaml
+    set:
+      rustfs.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+
+  - it: never gives the bucket job a delete path
+    template: templates/rustfs-bucket.yaml
+    set:
+      rustfs.enabled: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: (DELETE|rm -r|--force)
+
+  - it: renders no bucket job when RustFS is off
+    template: templates/rustfs-bucket.yaml
+    set:
+      rustfs.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- external store is untouched ---------------------------------------
+  - it: renders no bundled-store bucket for an external S3/GCS install
+    template: templates/rustfs-bucket.yaml
+    set:
+      minio.enabled: false
+      rustfs.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- guards -------------------------------------------------------------
+  - it: fails when the RustFS credentials do not match the MinIO pair
+    template: templates/validations.yaml
+    set:
+      minio.enabled: true
+      rustfs.enabled: true
+      rustfs.secret.rustfs.access_key: something-else
+    asserts:
+      - failedTemplate:
+          errorMessage: "rustfs.secret.rustfs credentials must match minio.svcaccts[0]. The app is given one credential pair for whichever bundled store is active, so a mismatch breaks object access the moment consumers switch to RustFS. Set rustfs.secret.rustfs.access_key/secret_key to the same values as minio.svcaccts[0].accessKey/secretKey."
+
+  - it: does not fire the credential guard when only RustFS is deployed
+    template: templates/validations.yaml
+    set:
+      minio.enabled: false
+      rustfs.enabled: true
+      rustfs.secret.rustfs.access_key: something-else
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -752,7 +752,11 @@ rustfs:
     rustfs:
       log_level: warn
       log_rotation:
-        time: hour
+        # Ceiling on the file count, applied before any size cap. log_rotation.time
+        # is deliberately unset: the server accepts only minutely/hourly/daily and
+        # silently treats anything else as daily, so the subchart's documented
+        # "hour" is worse than its own default of hourly. Cadence is immaterial
+        # anyway, since MAX_SINGLE_FILE_SIZE_BYTES below is what rotation fires on.
         keep_files: 8
   # The byte-based retention keys have no values path in the subchart, and its
   # log_rotation.size renders RUSTFS_OBS_LOG_ROTATION_SIZE_MB, which the server
@@ -765,6 +769,13 @@ rustfs:
     # Rotate on bytes, so the ceiling does not track request volume.
     - name: RUSTFS_OBS_LOG_MAX_SINGLE_FILE_SIZE_BYTES
       value: "10485760"
+    # Gates every cap above: a file younger than this is never eligible for
+    # cleanup, so the default of 3600 lets the directory grow to the write rate
+    # times an hour no matter what the ceilings say. Measured: at debug level with
+    # an 8Mi ceiling the directory still reached 1.27Gi in 92s until this was
+    # lowered.
+    - name: RUSTFS_OBS_LOG_MIN_FILE_AGE_SECONDS
+      value: "60"
     # Cleanup runs on an interval, so the peak overshoots the ceiling by roughly
     # the write rate times this value. Kept short to bound that transient.
     - name: RUSTFS_OBS_LOG_CLEANUP_INTERVAL_SECONDS

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -723,18 +723,42 @@ minio:
       memory: 512Mi
       cpu: 100m
 
-# Opt-in alternative to the bundled MinIO. RustFS speaks S3, so point the app at
-# it with the ordinary filestore values — no separate wiring:
-#   filestore: {type: s3, endpoint: "http://<release>-rustfs-svc:9000",
-#               existingSecret: <s3 keys>}
+# Opt-in bundled object store, deployed alongside MinIO rather than instead of
+# it. Enabling it deploys RustFS but does NOT repoint the app: MinIO keeps
+# precedence while both are enabled (see templates/_objectstore.tpl), so the
+# store comes up empty and consumed by nothing until a later migration copies
+# the data across and repoints consumers. With MinIO disabled, RustFS becomes
+# the sole bundled store and the app targets it through the ordinary filestore
+# values — no separate wiring.
 rustfs:
   enabled: false
+  image:
+    rustfs:
+      repository: rustfs/rustfs
+      # The subchart treats an empty tag as "use my appVersion", but the bucket
+      # Job needs a concrete one. Bump this together with the rustfs chart pin in
+      # Chart.yaml.
+      tag: "1.0.0-beta.10"
+      pullPolicy: IfNotPresent
   # The subchart refuses to render without credentials. These match
   # minio.svcaccts[0] so both bundled stores answer to the same pair.
   secret:
     rustfs:
       access_key: "default"
       secret_key: "notasecret"
+  # Log retention. The subchart rotates logs but ships log_rotation unset, so it
+  # emits no RUSTFS_OBS_LOG_KEEP_FILES and nothing ever prunes the rotated files
+  # (measured at 6.1 GB on a 1Gi PVC). Setting size makes rotation byte-triggered
+  # so the ceiling is size × (keep_files + 1) ≈ 900 MB, independent of read load
+  # and inside the logStorageSize PVC below. log_level: warn because the volume
+  # is 100% INFO span tracing on a healthy store. See rustfs-log-retention-plan.md.
+  config:
+    rustfs:
+      log_level: warn
+      log_rotation:
+        size: 100
+        time: hour
+        keep_files: 8
   replicaCount: 1
   # The subchart defaults this on, publishing its console at a placeholder host.
   # The store is only ever reached in-cluster.

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -746,12 +746,8 @@ rustfs:
     rustfs:
       access_key: "default"
       secret_key: "notasecret"
-  # Log retention. The subchart rotates logs but ships log_rotation unset, so it
-  # emits no RUSTFS_OBS_LOG_KEEP_FILES and nothing ever prunes the rotated files
-  # (measured at 6.1 GB on a 1Gi PVC). Setting size makes rotation byte-triggered
-  # so the ceiling is size × (keep_files + 1) ≈ 900 MB, independent of read load
-  # and inside the logStorageSize PVC below. log_level: warn because the volume
-  # is 100% INFO span tracing on a healthy store. See rustfs-log-retention-plan.md.
+  # The subchart leaves log_rotation unset, so nothing prunes rotated logs. Set
+  # retention to keep the log volume bounded.
   config:
     rustfs:
       log_level: warn

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -765,6 +765,10 @@ rustfs:
     # Rotate on bytes, so the ceiling does not track request volume.
     - name: RUSTFS_OBS_LOG_MAX_SINGLE_FILE_SIZE_BYTES
       value: "10485760"
+    # Cleanup runs on an interval, so the peak overshoots the ceiling by roughly
+    # the write rate times this value. Kept short to bound that transient.
+    - name: RUSTFS_OBS_LOG_CLEANUP_INTERVAL_SECONDS
+      value: "60"
     # Compression is on by default and compressed files are otherwise kept
     # forever.
     - name: RUSTFS_OBS_LOG_COMPRESSED_FILE_RETENTION_DAYS

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -746,15 +746,29 @@ rustfs:
     rustfs:
       access_key: "default"
       secret_key: "notasecret"
-  # The subchart leaves log_rotation unset, so nothing prunes rotated logs. Set
-  # retention to keep the log volume bounded.
+  # The subchart leaves log_rotation unset, so nothing prunes rotated logs and the
+  # volume grows without bound.
   config:
     rustfs:
       log_level: warn
       log_rotation:
-        size: 100
         time: hour
         keep_files: 8
+  # The byte-based retention keys have no values path in the subchart, and its
+  # log_rotation.size renders RUSTFS_OBS_LOG_ROTATION_SIZE_MB, which the server
+  # does not read. Set them directly; env wins over the subchart's envFrom.
+  extraEnv:
+    # Ceiling on the log directory, independent of rotation cadence, compression
+    # ratio and file count. Well inside logStorageSize below.
+    - name: RUSTFS_OBS_LOG_MAX_TOTAL_SIZE_BYTES
+      value: "268435456"
+    # Rotate on bytes, so the ceiling does not track request volume.
+    - name: RUSTFS_OBS_LOG_MAX_SINGLE_FILE_SIZE_BYTES
+      value: "10485760"
+    # Compression is on by default and compressed files are otherwise kept
+    # forever.
+    - name: RUSTFS_OBS_LOG_COMPRESSED_FILE_RETENTION_DAYS
+      value: "1"
   replicaCount: 1
   # The subchart defaults this on, publishing its console at a placeholder host.
   # The store is only ever reached in-cluster.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -473,6 +473,22 @@ spec:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/minio/minio'
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
+    # RustFS is deployed here but consumed by nothing: MinIO keeps precedence
+    # while both are enabled (templates/_objectstore.tpl), so the app stays on
+    # MinIO. This brings the store up empty and running ahead of the migration
+    # release that copies the data across and repoints consumers.
+    rustfs:
+      enabled: true
+      image:
+        rustfs:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/rustfs/rustfs'
+        # RustFS runs a busybox init container even in standalone mode.
+        initImage:
+          repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/busybox'
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
+      storageclass:
+        dataStorageSize: 100Gi
     # sha256 of every secret (password) config value. Changing any secret in the
     # KOTS config changes this hash, which changes the openhands pod-template
     # annotation (checksum/config-secrets) and forces a rollout so secret-backed
@@ -738,6 +754,12 @@ spec:
         minio:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/minio'
+        rustfs:
+          image:
+            rustfs:
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/rustfs'
+            initImage:
+              repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
         litellm-helm:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/litellm-database'
@@ -1218,6 +1240,8 @@ spec:
     litellm-helm:
       enabled: true
     minio:
+      enabled: true
+    rustfs:
       enabled: true
     postgresql:
       enabled: true


### PR DESCRIPTION
## Why

Deploys the RustFS subchart as a bundled object store that nothing consumes. A new backend selector keeps MinIO in precedence while both stores are enabled, so the app's endpoint and credentials do not change and no data can be stranded. RustFS gets its own release because the migration that follows copies data into it from a `pre-upgrade` hook, and Helm refuses to adopt a resource a hook created, so the store has to already exist and already be Helm-managed before that hook runs. Plain Helm installs are unaffected, since the chart default stays `rustfs.enabled: false` and only Replicated installs turn it on. A render guard rejects credentials that differ between the two stores, because the app is handed one pair for whichever store is active. The change also bounds the store's log volume, which the subchart otherwise leaves to grow without limit: the subchart's own `log_rotation` knobs do not work, as the server reads no rotation-size setting and accepts only `minutely`, `hourly` or `daily`, so the documented `hour` silently meant daily. Retention is therefore set with the byte keys the server does read, plus the file-age gate that makes those ceilings take effect at all.

## Validation

- **An upgrade leaves the application where it was** — on a Replicated Helm install, all three consumers still resolve `AWS_S3_ENDPOINT` to MinIO across every container including init containers, every app Deployment's `metadata.generation` and every app pod UID are unchanged, and the MinIO bucket holds the identical object set before and after, compared by count, bytes and a sha256 of the sorted key list.
- **Same result on Embedded Cluster** — RustFS came up with its Service and both PVCs bound at the configured sizes, the bucket Job completed, the app stayed on MinIO with its PV from before the upgrade, both store images resolved through the proxy registry, and all preflights passed.
- **RustFS is Helm-managed, not orphaned** — its Deployment, Service and both PVCs carry `app.kubernetes.io/managed-by: Helm` with the release-name and release-namespace annotations, which is what lets a later release's hook adopt them instead of creating them.
- **At the `warn` level this ships, log volume tracks faults rather than traffic** — 5000 object writes plus 400 client errors produced zero log bytes, because a missing bucket or key is a normal S3 response and only the per-request logging at `info` records those, while a genuine internal fault does reach the file at `warn` at roughly 320 bytes a line. The byte ceilings then only bind because the file-age gate is set: with that gate left at its default, a scaled-down 8 MiB ceiling still let the log directory reach 1.27 GB across 1220 files in 92s, since nothing younger than an hour is eligible for cleanup.

_This PR was drafted by an AI agent on behalf of the user._
