### PR TITLE
feat(filestore): PLTF-1250 migrate bundled object store to RustFS

### DIFF
--- a/charts/openhands/templates/_objectstore.tpl
+++ b/charts/openhands/templates/_objectstore.tpl
@@ -9,8 +9,14 @@ Two bundled backends, in this precedence order:
 MinIO wins when both are enabled, so enabling RustFS by itself deploys it
 without repointing the app — the same shape templates/_cache.tpl uses for
 redis/valkey, where the incumbent keeps precedence. Deploying RustFS therefore
-never moves a consumer onto an empty store; the migration switch (a later
-release) is what repoints consumers, once it has copied the data across.
+never moves a consumer onto an empty store.
+
+The migration switch is what repoints consumers. filestore.migration.enabled
+flips precedence to RustFS: the pre-upgrade hook copies the data across before
+Helm's apply lands, and the apply then renders every consumer pointed at RustFS.
+MinIO stays deployed (minio.enabled) as the rollback source, exactly as the
+CNPG migration keeps the old database server deployed while consumers already
+resolve to the new one.
 
 Neither backend is bundled when both are disabled: that install uses an
 external store (S3/GCS) or none, and these helpers render nothing.
@@ -22,7 +28,9 @@ so switching backends does not rotate anything the app holds.
 
 {{/* "minio", "rustfs", or "" when no bundled store is deployed. */}}
 {{- define "openhands.objectStore.backend" -}}
-{{- if .Values.minio.enabled -}}
+{{- if and .Values.rustfs.enabled .Values.filestore.migration.enabled -}}
+rustfs
+{{- else if .Values.minio.enabled -}}
 minio
 {{- else if .Values.rustfs.enabled -}}
 rustfs

--- a/charts/openhands/templates/objectstore-migration.yaml
+++ b/charts/openhands/templates/objectstore-migration.yaml
@@ -189,6 +189,10 @@ data:
               value: {{ .Values.rustfs.secret.rustfs.secret_key | quote }}
             - name: BUCKETS
               value: {{ $buckets | join " " | quote }}
+            # Substituted by the orchestrator: "check" reports the outstanding
+            # difference read-only, "copy" performs the copy and verifies.
+            - name: MODE
+              value: "__MODE__"
           command: ["/bin/sh", "/migration/copy.sh"]
           volumeMounts:
             - name: scripts
@@ -227,11 +231,28 @@ data:
       mc find "$_alias/$_bucket" 2>/dev/null | cut -c "$_off-" | sort
     }
 
+    # MODE=check lists both stores and reports the outstanding difference without
+    # copying, verifying or mutating anything. The orchestrator runs it that way
+    # BEFORE freezing writers, so an already-complete migration costs one listing
+    # pass instead of an outage, and a marker that no longer reflects reality is
+    # caught instead of trusted.
+    MODE="${MODE:-copy}"
+
     FAIL=0
     SUMMARY=""
+    OUTSTANDING=0
     for b in $BUCKETS; do
       if ! mc ls "src/$b" >/dev/null 2>&1; then
         log "source bucket '$b' absent; nothing to copy"
+        continue
+      fi
+      if [ "$MODE" = "check" ]; then
+        # Read-only: a missing destination bucket just means everything is missing.
+        keys src "$b" > /tmp/src.keys
+        keys dst "$b" > /tmp/dst.keys 2>/dev/null || : > /tmp/dst.keys
+        N=$(comm -23 /tmp/src.keys /tmp/dst.keys | wc -l | tr -d ' ')
+        log "bucket '$b': $N object(s) in source and absent from destination"
+        OUTSTANDING=$(( OUTSTANDING + N ))
         continue
       fi
       mc mb --ignore-existing "dst/$b" >/dev/null 2>&1 || true
@@ -259,6 +280,13 @@ data:
       fi
       SUMMARY="$SUMMARY $b=$COUNT"
     done
+
+    if [ "$MODE" = "check" ]; then
+      # Parsed by the orchestrator to decide whether a freeze is needed at all.
+      echo "CHECK-OUTSTANDING $OUTSTANDING"
+      log "check complete; $OUTSTANDING object(s) outstanding"
+      exit 0
+    fi
 
     if [ "$FAIL" != "0" ]; then
       log "one or more buckets did not verify"
@@ -336,13 +364,23 @@ spec:
 
               log() { echo "[migrate $(date -u +%H:%M:%S)] $*"; }
 
-              # 1. Idempotency marker. Once written, every later run is a no-op.
-              if $K get configmap "$MARKER" >/dev/null 2>&1; then
-                log "marker '$MARKER' present; object store already migrated."
-                exit 0
-              fi
+              # Run the transient copy Pod in "$1" mode ("check" or "copy") and
+              # wait for it. One manifest serves both; the Pod name is reused, so
+              # delete any predecessor first. Returns non-zero unless it Succeeded.
+              run_copy_pod() {
+                $K delete pod "$COPY_POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+                sed "s|__MODE__|$1|" /migration/copy-pod.yaml | $K apply -f -
+                DEADLINE=$(( $(date +%s) + COPY )); PHASE=""
+                while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                  PHASE=$($K get pod "$COPY_POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+                  { [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; } && break
+                  sleep 5
+                done
+                $K logs "$COPY_POD" 2>/dev/null || true
+                [ "$PHASE" = "Succeeded" ]
+              }
 
-              # 2. Wait for RustFS. It is deployed by an earlier release; this
+              # 1. Wait for RustFS. It is deployed by an earlier release; this
               #    hook never creates it. Its absence is a misconfiguration to
               #    report before anything is frozen.
               if ! $K get deployment "$RUSTFS_DEPLOY" >/dev/null 2>&1; then
@@ -351,6 +389,30 @@ spec:
               fi
               log "waiting for RustFS to be ready"
               $K rollout status deployment "$RUSTFS_DEPLOY" --timeout="${STORE_READY}s"
+
+              # 2. Decide from the outstanding difference, not from the marker.
+              #    The marker records that a copy once completed; it does NOT mean
+              #    the stores still agree. A rollback leaves the marker in place
+              #    while consumers resume writing to the source, so trusting it
+              #    would repoint them onto a store missing everything written since
+              #    (proven: a marker-skipped redeploy left objects behind while the
+              #    apply repointed the app anyway). The copy is incremental and
+              #    additive, so the honest test is the difference itself, and it
+              #    costs one read-only listing pass with nothing frozen.
+              if ! run_copy_pod check; then
+                log "ERROR: difference check did not succeed"
+                exit 1
+              fi
+              OUTSTANDING=$($K logs "$COPY_POD" 2>/dev/null | sed -n 's/^CHECK-OUTSTANDING //p' | tail -1)
+              $K delete pod "$COPY_POD" --ignore-not-found >/dev/null 2>&1 || true
+              if [ "${OUTSTANDING:-1}" = "0" ]; then
+                log "nothing outstanding; stores already agree. No writers frozen."
+                exit 0
+              fi
+              log "$OUTSTANDING object(s) outstanding; continuing with the copy"
+              # A marker left by an earlier completed migration must go, or the
+              # marker write at the end fails as AlreadyExists after a good copy.
+              $K delete configmap "$MARKER" --ignore-not-found >/dev/null 2>&1 || true
 
               # Restore trap. On success the writers are left as the copy found
               # them, for Helm's apply to bring back. On failure — including a
@@ -420,19 +482,11 @@ spec:
                 exit 1
               fi
 
-              # 5. Copy the difference in a transient Pod, then wait for it.
-              $K delete pod "$COPY_POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
-              $K apply -f /migration/copy-pod.yaml
+              # 5. Copy the difference in a transient Pod, then wait for it. Same
+              #    manifest as the check, run in copy mode against a frozen source.
               log "copying objects"
-              DEADLINE=$(( $(date +%s) + COPY )); PHASE=""
-              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-                PHASE=$($K get pod "$COPY_POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-                { [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; } && break
-                sleep 5
-              done
-              $K logs "$COPY_POD" 2>/dev/null || true
-              if [ "$PHASE" != "Succeeded" ]; then
-                log "ERROR: copy did not succeed (phase='$PHASE')"
+              if ! run_copy_pod copy; then
+                log "ERROR: copy did not succeed"
                 exit 1
               fi
 

--- a/charts/openhands/templates/objectstore-migration.yaml
+++ b/charts/openhands/templates/objectstore-migration.yaml
@@ -316,6 +316,8 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: scripts
+              mountPath: /migration
           command:
             - /bin/sh
             - -c
@@ -447,4 +449,10 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: scripts
+          configMap:
+            name: {{ $name }}
+            items:
+              - key: copy-pod.yaml
+                path: copy-pod.yaml
 {{- end }}

--- a/charts/openhands/templates/objectstore-migration.yaml
+++ b/charts/openhands/templates/objectstore-migration.yaml
@@ -100,11 +100,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
-  # Marker and freeze record; no delete — the records are meant to survive a
-  # retry, and the marker makes the next run a no-op.
+  # Marker and freeze record. Delete is required for both: a marker left by an
+  # earlier completed migration is cleared before a fresh copy, or the create at
+  # the end fails as AlreadyExists after the data has already moved; and the
+  # freeze record is torn up on success so a later run records current replicas
+  # rather than reusing these.
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -499,6 +502,12 @@ spec:
                 --from-literal=buckets="$SUMMARY" >/dev/null
               $K delete pod "$COPY_POD" --ignore-not-found >/dev/null 2>&1 || true
               SUCCESS=1
+              # The freeze record exists only to restore writers after a run that
+              # died before its trap could. The copy is done, so keeping it would
+              # just make a later run reuse these replica counts instead of
+              # recording current ones. Writers are still at zero here by design,
+              # for Helm's apply to restore from chart values.
+              $K delete configmap "$FREEZE" --ignore-not-found >/dev/null 2>&1 || true
               log "object-store migration complete"
       volumes:
         - name: tmp

--- a/charts/openhands/templates/objectstore-migration.yaml
+++ b/charts/openhands/templates/objectstore-migration.yaml
@@ -1,0 +1,450 @@
+{{- /*
+One-time copy of the bundled object store from MinIO into RustFS.
+
+Shape borrowed from the CNPG migration (templates in #986): a pre-upgrade
+orchestrator Job (kubectl + shell) that freezes the writers and drives a
+transient copy Pod (mc). The copy runs in a separate Pod because the
+orchestrator must keep control across the whole sequence — it freezes writers
+before the copy and must restore them on failure, which it cannot do from a
+container that has already exited.
+
+Placement is pre-upgrade weight -1, after the CNPG orchestrator's -2, so when
+both migrations ship in one release they share a single freeze window. The
+destination is NOT created here: RustFS is deployed by an earlier release and
+this hook only waits for it. The copy is incremental (it copies the key-set
+difference, not everything) so a retry after a timeout makes progress instead of
+restarting, and verification is the same mechanism — an empty difference against
+a frozen source is the completeness proof.
+
+The one coupling worth stating: Helm does not run post-upgrade hooks when an
+upgrade fails, so if this hook fails the CNPG resume never runs and the writers
+it froze at -2 stay down. That is why step "restore" scales back every writer it
+finds at zero, including ones it did not freeze itself.
+
+Runs on upgrades only (pre-upgrade hooks do not fire on install), and both
+switches are required: rustfs.enabled (destination deployed) and
+filestore.migration.enabled (perform the copy + repoint consumers).
+*/}}
+{{- if and .Values.rustfs.enabled .Values.filestore.migration.enabled }}
+{{- $rel := .Release.Name }}
+{{- $ns := .Release.Namespace }}
+{{- $m := .Values.filestore.migration }}
+{{- $name := printf "%s-objectstore-migration" $rel }}
+{{- $copyPod := printf "%s-copy" $name }}
+{{- $marker := printf "%s-objectstore-migrated" $rel }}
+{{- $freeze := printf "%s-objectstore-migration-freeze" $rel }}
+{{- $srcEndpoint := printf "http://%s-minio:9000" $rel }}
+{{- $dstEndpoint := printf "http://%s-rustfs-svc:9000" $rel }}
+{{- $rustfsDeploy := printf "%s-rustfs" $rel }}
+{{- /* Writers are every workload that holds object-store credentials, derived
+       from the same render conditions the chart uses to deploy them — never a
+       hardcoded list that can drift from what is actually running. */}}
+{{- $writers := list }}
+{{- if .Values.enabled }}
+{{- $writers = concat $writers (list "deployment/openhands" "deployment/openhands-integrations" "deployment/openhands-mcp") }}
+{{- end }}
+{{- if .Values.automation.enabled }}
+{{- $writers = append $writers "deployment/automation" }}
+{{- if .Values.automation.events.enabled }}
+{{- $writers = append $writers "deployment/automation-events" }}
+{{- end }}
+{{- end }}
+{{- $writers = concat $writers $m.extraWriters }}
+{{- /* Buckets to copy: the app's session bucket always, the automation package
+       bucket when automation is deployed. A source bucket that does not exist is
+       skipped by copy.sh, not an error. */}}
+{{- $buckets := list .Values.filestore.bucket }}
+{{- if .Values.automation.enabled }}
+{{- $buckets = append $buckets .Values.automation.filestore.bucket }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- with $m.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  # Freeze and restore writers.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "statefulsets/scale"]
+    verbs: ["get", "patch"]
+  # Wait for RustFS readiness (rollout status reads the Deployment + its pods).
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Marker and freeze record; no delete — the records are meant to survive a
+  # retry, and the marker makes the next run a no-op.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  # Transient copy Pod. Applied by the orchestrator once the writers are frozen.
+  copy-pod.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: {{ $copyPod }}
+      namespace: {{ $ns }}
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: objectstore-migration-copy
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: {{ $m.timeouts.copy }}
+      serviceAccountName: {{ $name }}
+      {{- with $m.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: copy
+          image: "{{ $m.images.mc.repository }}:{{ $m.images.mc.tag }}"
+          imagePullPolicy: {{ $m.images.mc.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+            - name: MC_CONFIG_DIR
+              value: /tmp/.mc
+            - name: SRC_ENDPOINT
+              value: {{ $srcEndpoint | quote }}
+            - name: DST_ENDPOINT
+              value: {{ $dstEndpoint | quote }}
+            - name: SRC_ACCESS_KEY
+              value: {{ (index .Values.minio.svcaccts 0).accessKey | quote }}
+            - name: SRC_SECRET_KEY
+              value: {{ (index .Values.minio.svcaccts 0).secretKey | quote }}
+            - name: DST_ACCESS_KEY
+              value: {{ .Values.rustfs.secret.rustfs.access_key | quote }}
+            - name: DST_SECRET_KEY
+              value: {{ .Values.rustfs.secret.rustfs.secret_key | quote }}
+            - name: BUCKETS
+              value: {{ $buckets | join " " | quote }}
+          command: ["/bin/sh", "/migration/copy.sh"]
+          volumeMounts:
+            - name: scripts
+              mountPath: /migration
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ $name }}
+            items:
+              - key: copy.sh
+                path: copy.sh
+        - name: tmp
+          emptyDir: {}
+  # Copy script. Runs in the copy Pod (mc image: has sh, sort, comm, cut, tr, wc,
+  # head — but NO grep, awk or sed). Incremental and additive: it copies only the
+  # objects present in the source bucket and absent in the destination, then
+  # re-lists to prove the difference is empty. No delete path, ever.
+  copy.sh: |
+    #!/bin/sh
+    set -eu
+
+    log() { echo "[copy $(date -u +%H:%M:%S)] $*"; }
+
+    mc alias set src "$SRC_ENDPOINT" "$SRC_ACCESS_KEY" "$SRC_SECRET_KEY" >/dev/null
+    mc alias set dst "$DST_ENDPOINT" "$DST_ACCESS_KEY" "$DST_SECRET_KEY" >/dev/null
+
+    # Objects list, one key per line, relative to the bucket. `mc find` prints
+    # full "alias/bucket/key" paths; cut by character offset strips the fixed
+    # "src/<bucket>/" prefix and preserves keys that contain spaces (src and dst
+    # aliases are both 3 chars, so the offset is identical).
+    keys() {
+      _alias="$1"; _bucket="$2"
+      _off=$(( $(printf '%s/%s/' "$_alias" "$_bucket" | wc -c) + 1 ))
+      mc find "$_alias/$_bucket" 2>/dev/null | cut -c "$_off-" | sort
+    }
+
+    FAIL=0
+    SUMMARY=""
+    for b in $BUCKETS; do
+      if ! mc ls "src/$b" >/dev/null 2>&1; then
+        log "source bucket '$b' absent; nothing to copy"
+        continue
+      fi
+      mc mb --ignore-existing "dst/$b" >/dev/null 2>&1 || true
+
+      keys src "$b" > /tmp/src.keys
+      keys dst "$b" > /tmp/dst.keys
+      comm -23 /tmp/src.keys /tmp/dst.keys > /tmp/missing.keys
+
+      MISSING=$(wc -l < /tmp/missing.keys | tr -d ' ')
+      log "bucket '$b': $(wc -l < /tmp/src.keys | tr -d ' ') source objects, $MISSING to copy"
+      while IFS= read -r k; do
+        [ -z "$k" ] && continue
+        mc cp --quiet "src/$b/$k" "dst/$b/$k" >/dev/null
+      done < /tmp/missing.keys
+
+      # Verify by recomputing the difference against the (frozen) source.
+      keys dst "$b" > /tmp/dst.keys
+      STILL=$(comm -23 /tmp/src.keys /tmp/dst.keys | wc -l | tr -d ' ')
+      COUNT=$(wc -l < /tmp/src.keys | tr -d ' ')
+      if [ "$STILL" != "0" ]; then
+        log "bucket '$b': FAILED, $STILL objects still missing after copy"
+        FAIL=1
+      else
+        log "bucket '$b': verified, $COUNT objects present in destination"
+      fi
+      SUMMARY="$SUMMARY $b=$COUNT"
+    done
+
+    if [ "$FAIL" != "0" ]; then
+      log "one or more buckets did not verify"
+      exit 1
+    fi
+    # Parsed by the orchestrator for the marker.
+    echo "COPY-SUMMARY$SUMMARY"
+    log "all buckets verified"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ $m.backoffLimit }}
+  activeDeadlineSeconds: {{ $m.timeouts.total }}
+  template:
+    metadata:
+      labels:
+        {{- include "openhands.labels" . | nindent 8 }}
+        app.kubernetes.io/component: objectstore-migration
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $name }}
+      {{- with $m.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: "{{ $m.images.kubectl.repository }}:{{ $m.images.kubectl.tag }}"
+          imagePullPolicy: {{ $m.images.kubectl.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            {{- toYaml $m.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              NS='{{ $ns }}'
+              RUSTFS_DEPLOY='{{ $rustfsDeploy }}'
+              COPY_POD='{{ $copyPod }}'
+              MARKER='{{ $marker }}'
+              FREEZE='{{ $freeze }}'
+              WRITERS='{{ $writers | join " " }}'
+              STORE_READY={{ $m.timeouts.storeReady }}
+              DRAIN={{ $m.timeouts.drain }}
+              COPY={{ $m.timeouts.copy }}
+              K="kubectl -n $NS"
+
+              log() { echo "[migrate $(date -u +%H:%M:%S)] $*"; }
+
+              # 1. Idempotency marker. Once written, every later run is a no-op.
+              if $K get configmap "$MARKER" >/dev/null 2>&1; then
+                log "marker '$MARKER' present; object store already migrated."
+                exit 0
+              fi
+
+              # 2. Wait for RustFS. It is deployed by an earlier release; this
+              #    hook never creates it. Its absence is a misconfiguration to
+              #    report before anything is frozen.
+              if ! $K get deployment "$RUSTFS_DEPLOY" >/dev/null 2>&1; then
+                log "ERROR: RustFS deployment '$RUSTFS_DEPLOY' not found. Deploy RustFS (rustfs.enabled) in an earlier release before enabling the migration."
+                exit 1
+              fi
+              log "waiting for RustFS to be ready"
+              $K rollout status deployment "$RUSTFS_DEPLOY" --timeout="${STORE_READY}s"
+
+              # Restore trap. On success the writers are left as the copy found
+              # them, for Helm's apply to bring back. On failure — including a
+              # failure that leaves CNPG's -2 freeze un-resumed — restore every
+              # writer currently at zero to its recorded replicas (>=1).
+              SUCCESS=0
+              restore() {
+                if [ "$SUCCESS" = "1" ]; then
+                  log "writers left as found; the apply restores them."
+                  return
+                fi
+                log "restoring writers after a failed migration"
+                REC=$($K get configmap "$FREEZE" -o jsonpath='{.data.replicas}' 2>/dev/null || echo "")
+                for w in $WRITERS; do
+                  $K get "$w" >/dev/null 2>&1 || continue
+                  CUR=$($K get "$w" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+                  [ "$CUR" != "0" ] && continue
+                  N=1
+                  for line in $REC; do
+                    case "$line" in
+                      "$w="*) N=${line#*=} ;;
+                    esac
+                  done
+                  [ "$N" = "0" ] && N=1
+                  $K scale "$w" --replicas="$N" >/dev/null 2>&1 || true
+                  log "  restored $w to $N"
+                done
+              }
+              trap restore EXIT
+
+              # 3. Record replicas BEFORE freezing, so a timeout kill that skips
+              #    this trap is still recoverable by a later run. Written once;
+              #    a retry reuses the first record rather than capturing the
+              #    zeros an earlier attempt left behind.
+              if $K get configmap "$FREEZE" >/dev/null 2>&1; then
+                log "reusing freeze record from an earlier attempt"
+              else
+                : > /tmp/replicas
+                for w in $WRITERS; do
+                  CUR=$($K get "$w" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+                  [ -z "$CUR" ] && { log "  $w absent; skipping"; continue; }
+                  echo "$w=$CUR" >> /tmp/replicas
+                done
+                $K create configmap "$FREEZE" --from-file=replicas=/tmp/replicas >/dev/null
+              fi
+
+              # 4. Freeze, unconditionally. When CNPG already scaled these to
+              #    zero at -2 this is a no-op; running it every time means the
+              #    object copy opens its own window when it migrates alone.
+              for w in $WRITERS; do
+                $K get "$w" >/dev/null 2>&1 || continue
+                $K scale "$w" --replicas=0 >/dev/null 2>&1 || true
+              done
+              log "waiting for writers to drain"
+              DEADLINE=$(( $(date +%s) + DRAIN )); REMAIN=-1
+              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                REMAIN=0
+                for w in $WRITERS; do
+                  N=$($K get "$w" -o jsonpath='{.status.replicas}' 2>/dev/null || echo "")
+                  [ -n "$N" ] && [ "$N" != "0" ] && REMAIN=$(( REMAIN + N ))
+                done
+                [ "$REMAIN" = "0" ] && break
+                sleep 5
+              done
+              if [ "$REMAIN" != "0" ]; then
+                log "ERROR: writers did not drain within ${DRAIN}s"
+                exit 1
+              fi
+
+              # 5. Copy the difference in a transient Pod, then wait for it.
+              $K delete pod "$COPY_POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+              $K apply -f /migration/copy-pod.yaml
+              log "copying objects"
+              DEADLINE=$(( $(date +%s) + COPY )); PHASE=""
+              while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                PHASE=$($K get pod "$COPY_POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+                { [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; } && break
+                sleep 5
+              done
+              $K logs "$COPY_POD" 2>/dev/null || true
+              if [ "$PHASE" != "Succeeded" ]; then
+                log "ERROR: copy did not succeed (phase='$PHASE')"
+                exit 1
+              fi
+
+              # 6. Record success. The marker carries the per-bucket object
+              #    counts the copy verified.
+              SUMMARY=$($K logs "$COPY_POD" 2>/dev/null | sed -n 's/^COPY-SUMMARY //p' | tail -1)
+              $K create configmap "$MARKER" \
+                --from-literal=source=minio \
+                --from-literal=destination=rustfs \
+                --from-literal=buckets="$SUMMARY" >/dev/null
+              $K delete pod "$COPY_POD" --ignore-not-found >/dev/null 2>&1 || true
+              SUCCESS=1
+              log "object-store migration complete"
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/openhands/templates/objectstore-migration.yaml
+++ b/charts/openhands/templates/objectstore-migration.yaml
@@ -51,12 +51,29 @@ filestore.migration.enabled (perform the copy + repoint consumers).
 {{- end }}
 {{- $writers = concat $writers $m.extraWriters }}
 {{- /* Buckets to copy: the app's session bucket always, the automation package
-       bucket when automation is deployed. A source bucket that does not exist is
-       skipped by copy.sh, not an error. */}}
+       bucket when automation is deployed, and the sandbox workspace archive when
+       it resolves to the bundled store. A source bucket that does not exist is
+       skipped by copy.sh, not an error, so an over-broad list is cheap while a
+       short one silently strands data.
+
+       The archive lands in the bundled store only when its store type resolves to
+       s3, since the s3 path reuses the app's AWS_S3_* connection env. That
+       derivation mirrors templates/_env.yaml: an empty storeType follows
+       filestore.type. Nothing we ship enables the archive, but a Helm install that
+       sets filestore.type=s3, minio.enabled and runtimeFileArchive.enabled would
+       otherwise have a bucket in the bundled store that this copy skipped while
+       the apply repointed its consumers anyway. */}}
 {{- $buckets := list .Values.filestore.bucket }}
 {{- if .Values.automation.enabled }}
 {{- $buckets = append $buckets .Values.automation.filestore.bucket }}
 {{- end }}
+{{- $archiveStore := .Values.runtimeFileArchive.storeType | default (ternary "s3" "google_cloud" (eq .Values.filestore.type "s3")) }}
+{{- if and .Values.runtimeFileArchive.enabled (eq $archiveStore "s3") .Values.runtimeFileArchive.bucket }}
+{{- $buckets = append $buckets .Values.runtimeFileArchive.bucket }}
+{{- end }}
+{{- /* An operator may point two of these at one bucket; copying it twice is
+       harmless but doubles the outage and the marker summary. */}}
+{{- $buckets = $buckets | uniq }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -45,3 +45,17 @@ with runtime-api and automation and matters even in a server-less release.
 {{- fail "rustfs.secret.rustfs credentials must match minio.svcaccts[0]. The app is given one credential pair for whichever bundled store is active, so a mismatch breaks object access the moment consumers switch to RustFS. Set rustfs.secret.rustfs.access_key/secret_key to the same values as minio.svcaccts[0].accessKey/secretKey." -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Object-store migration guards. The migration copies from the bundled MinIO into
+RustFS and repoints consumers, so both stores have to be deployed: RustFS as the
+destination and MinIO as the source (and rollback point). Leave minio.enabled
+true until a later release retires it.
+*/}}
+{{- if .Values.filestore.migration.enabled -}}
+{{- if not .Values.rustfs.enabled -}}
+{{- fail "filestore.migration.enabled is true but rustfs.enabled is false, so there is no destination to copy into. Set rustfs.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.minio.enabled -}}
+{{- fail "filestore.migration.enabled is true but the bundled MinIO is not deployed, so there is no source to copy from. Leave minio.enabled=true until the migration has completed, then retire MinIO in a later release." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/tests/objectstore_backend_test.yaml
+++ b/charts/openhands/tests/objectstore_backend_test.yaml
@@ -123,3 +123,66 @@ tests:
       rustfs.secret.rustfs.access_key: something-else
     asserts:
       - notFailedTemplate: {}
+
+  # --- migration repoint --------------------------------------------------
+  - it: repoints the app at RustFS once the migration switch is on, MinIO still deployed
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-rustfs-svc:9000
+
+  - it: the migration switch is inert without RustFS deployed, so precedence stays MinIO
+    documentSelector:
+      path: metadata.name
+      value: openhands
+    template: templates/deployment.yaml
+    set:
+      enabled: true
+      filestore.type: s3
+      minio.enabled: true
+      rustfs.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_S3_ENDPOINT
+            value: http://RELEASE-NAME-minio:9000
+
+  # --- migration guards ---------------------------------------------------
+  - it: fails the migration when RustFS is not deployed as the destination
+    template: templates/validations.yaml
+    set:
+      minio.enabled: true
+      rustfs.enabled: false
+      filestore.migration.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "filestore.migration.enabled is true but rustfs.enabled is false, so there is no destination to copy into. Set rustfs.enabled=true."
+
+  - it: fails the migration when MinIO is not deployed as the source
+    template: templates/validations.yaml
+    set:
+      minio.enabled: false
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "filestore.migration.enabled is true but the bundled MinIO is not deployed, so there is no source to copy from. Leave minio.enabled=true until the migration has completed, then retire MinIO in a later release."
+
+  - it: does not guard the migration when the switch is off
+    template: templates/validations.yaml
+    set:
+      minio.enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: false
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/openhands/tests/objectstore_migration_test.yaml
+++ b/charts/openhands/tests/objectstore_migration_test.yaml
@@ -1,0 +1,194 @@
+suite: object-store migration orchestrator
+templates:
+  - templates/objectstore-migration.yaml
+tests:
+  # --- gating -------------------------------------------------------------
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when RustFS is deployed but the migration is off
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the full hook set only when both switches are on
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  # --- hook placement -----------------------------------------------------
+  - it: is a pre-upgrade hook at weight -1, after the CNPG orchestrator's -2
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  # --- images -------------------------------------------------------------
+  - it: runs the orchestrator on a kubectl+shell image
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: migrate
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/alpine/k8s:1.30.0
+
+  - it: copies with the mc image in a transient Pod, not the server image
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: "image: \"quay.io/minio/mc:"
+
+  # --- writer derivation --------------------------------------------------
+  - it: freezes the three app writers when only the app is deployed
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+      automation.enabled: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "WRITERS='deployment/openhands deployment/openhands-integrations deployment/openhands-mcp'"
+
+  - it: adds automation and its events writer when they are deployed
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+      automation.enabled: true
+      automation.events.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/automation deployment/automation-events"
+
+  - it: honours extraWriters
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+      filestore.migration.extraWriters:
+        - deployment/custom-writer
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "deployment/custom-writer"
+
+  # --- buckets ------------------------------------------------------------
+  - it: copies the session bucket, and the automation bucket when automation is on
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+      automation.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: 'value: "openhands-sessions automation-data"'
+
+  - it: copies only the session bucket when automation is absent
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      enabled: true
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+      automation.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["copy-pod.yaml"]
+          pattern: 'value: "openhands-sessions"'
+
+  # --- least-privilege RBAC ----------------------------------------------
+  - it: can scale writers but cannot read secrets
+    documentSelector:
+      path: kind
+      value: Role
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - matchRegex:
+          path: rules[1].resources[0]
+          pattern: "deployments/scale"
+      - notMatchRegexRaw:
+          pattern: "secrets"
+
+  # --- copy script safety -------------------------------------------------
+  - it: copies incrementally by key-set difference and never deletes
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["copy.sh"]
+          pattern: "comm -23"
+      - notMatchRegexRaw:
+          pattern: "(mc rm|--recursive.*rm|rm -rf|mc mirror)"
+      # The mc image lacks these; using them would silently misbehave.
+      - notMatchRegexRaw:
+          pattern: "(grep |awk |sed )"
+
+  # --- destination is not created here ------------------------------------
+  - it: waits for RustFS rather than creating it
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      rustfs.enabled: true
+      filestore.migration.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "rollout status deployment"
+      - notMatchRegexRaw:
+          pattern: "(kubectl apply.*rustfs|mc mb.*only)"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -144,11 +144,19 @@ filestore:
   # what is missing and repeats harmlessly once complete.
   migration:
     enabled: false
-    # The copy runs `mc`, which the RustFS/MinIO server images do not carry.
-    image:
-      repository: quay.io/minio/mc
-      tag: RELEASE.2025-08-13T08-35-41Z
-      pullPolicy: IfNotPresent
+    images:
+      # Orchestrator: freezes writers and drives the copy Pod, so it needs
+      # kubectl and a shell (not rancher/kubectl, which has neither a shell nor
+      # the coreutils the script uses).
+      kubectl:
+        repository: docker.io/alpine/k8s
+        tag: "1.30.0"
+        pullPolicy: IfNotPresent
+      # Copy Pod: runs `mc`, which the RustFS/MinIO server images do not carry.
+      mc:
+        repository: quay.io/minio/mc
+        tag: RELEASE.2025-08-13T08-35-41Z
+        pullPolicy: IfNotPresent
     imagePullSecrets: []
     # Extra "deployment/x" | "statefulset/x" writers to freeze for the copy,
     # beyond the ones the chart derives from its own render conditions.

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -134,6 +134,44 @@ filestore:
   accessKey: ""
   secretKey: ""
 
+  # One-time copy of the bundled object store from MinIO into RustFS, run by a
+  # pre-upgrade hook on the upgrade that switches backends. Requires both stores
+  # deployed (minio.enabled and rustfs.enabled). Enabling it also repoints every
+  # consumer at RustFS when the apply lands (see templates/_objectstore.tpl) —
+  # MinIO stays deployed as the rollback source until a later, deliberate
+  # release turns it off. Never runs on a fresh install. The copy is incremental
+  # by key-set difference and additive (no delete path), so a re-run copies only
+  # what is missing and repeats harmlessly once complete.
+  migration:
+    enabled: false
+    # The copy runs `mc`, which the RustFS/MinIO server images do not carry.
+    image:
+      repository: quay.io/minio/mc
+      tag: RELEASE.2025-08-13T08-35-41Z
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    # Extra "deployment/x" | "statefulset/x" writers to freeze for the copy,
+    # beyond the ones the chart derives from its own render conditions.
+    extraWriters: []
+    timeouts:
+      # Seconds to wait for the RustFS StatefulSet to become ready before
+      # freezing anything. RustFS is deployed by an earlier release, so this is a
+      # readiness wait, not a provisioning one.
+      storeReady: 300
+      # Seconds to wait for frozen writer pods to actually terminate.
+      drain: 300
+      # Seconds for the copy + verify of all buckets.
+      copy: 1800
+      # Overall Job deadline; keep below the helm --timeout.
+      total: 2700
+    backoffLimit: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
   # Optional SHARED_EVENT_STORAGE_PROVIDER override ("aws" | "gcp"); when empty
   # the app derives the provider from FILE_STORE.
   provider: ""

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -8,7 +8,10 @@ spec:
   releaseName: openhands
   namespace: openhands
   weight: 10
-  helmUpgradeFlags: ["--wait", "--timeout", "600s", "--force-conflicts"]
+  # 1800s, not 600s: --timeout bounds each hook Job, and the object-store
+  # migration hook (freeze, copy, verify) runs inside it. Size the maintenance
+  # window against the object count — the copy is bound by it, not by bytes.
+  helmUpgradeFlags: ["--wait", "--timeout", "1800s", "--force-conflicts"]
   values:
     global:
       imageRegistry: 'images.r9.all-hands.dev'
@@ -458,6 +461,20 @@ spec:
     # the app targets the bundled instance automatically.
     filestore:
       type: s3
+      # Copy the bundled object store from MinIO into RustFS and repoint every
+      # consumer at RustFS when the apply lands. MinIO stays deployed below as
+      # the rollback source; a later, deliberate release retires it. The copy is
+      # incremental and additive, so a re-run after a timeout resumes rather than
+      # restarting, and repeats harmlessly once complete.
+      migration:
+        enabled: true
+        images:
+          kubectl:
+            repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/alpine/k8s'
+          mc:
+            repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/minio/mc'
+        imagePullSecrets:
+          - name: '{{repl ImagePullSecretName }}'
     minio:
       enabled: true
       persistence:
@@ -473,10 +490,9 @@ spec:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/quay.io/minio/minio'
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
-    # RustFS is deployed here but consumed by nothing: MinIO keeps precedence
-    # while both are enabled (templates/_objectstore.tpl), so the app stays on
-    # MinIO. This brings the store up empty and running ahead of the migration
-    # release that copies the data across and repoints consumers.
+    # RustFS is the object-store backend once filestore.migration.enabled flips
+    # precedence to it (templates/_objectstore.tpl). MinIO stays deployed as the
+    # rollback source until a later release retires it.
     rustfs:
       enabled: true
       image:
@@ -691,13 +707,17 @@ spec:
           openhandsApiUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           automationBaseUrl: 'https://{{repl ConfigOption "computed_app_hostname" }}'
           # Uploaded automation packages must survive pod replacement, so store
-          # them on the bundled MinIO (persistent here — minio.persistence
-          # above) instead of the pod filesystem.
+          # them on the bundled object store instead of the pod filesystem. This
+          # points at RustFS in lock-step with the app: the migration copies the
+          # automation-data bucket across and both consumers cut over together on
+          # this release. (The parent chart cannot template a subchart's values,
+          # so automation is repointed here rather than through the object-store
+          # helper the app uses.)
           filestore:
             type: s3
-            endpoint: http://openhands-minio:9000
-            # The bundled MinIO's bucket job only creates the parent chart's
-            # buckets, so the service provisions its own on startup.
+            endpoint: http://openhands-rustfs-svc:9000
+            # The bundled store's bucket job only creates the parent chart's
+            # session bucket, so the service provisions its own on startup.
             createBucket: true
             # Matches the parent chart's minio.svcaccts credentials.
             accessKey: default
@@ -760,6 +780,13 @@ spec:
               repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/rustfs'
             initImage:
               repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/busybox'
+        filestore:
+          migration:
+            images:
+              kubectl:
+                repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/k8s'
+              mc:
+                repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/mc'
         litellm-helm:
           image:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/litellm-database'
@@ -1243,6 +1270,11 @@ spec:
       enabled: true
     rustfs:
       enabled: true
+    # Render the object-store migration hook at build time so its kubectl and mc
+    # images land in the airgap bundle.
+    filestore:
+      migration:
+        enabled: true
     postgresql:
       enabled: true
     redis:


### PR DESCRIPTION
## Why

Copies the bundled object store from MinIO into RustFS and cuts consumers over, in the release after RustFS was deployed empty. `filestore.migration.enabled` flips the backend selector and runs a `pre-upgrade` orchestrator: it waits for RustFS (deployed by the earlier release, never created here), compares the two stores read-only, and freezes writers only when something is actually outstanding. It then copies each bucket's key-set difference in a transient `mc` Pod, verifies by recomputing that difference against the frozen source, and lets the apply repoint consumers and bring the writers back. MinIO stays deployed and stops receiving writes, so it is a clean rollback source for the state at cutover until a later release retires it.

Safety rests on three properties. The copy is a `pre-upgrade` hook, so any failure aborts before the apply and consumers are never repointed. The copy is incremental by key-set difference and additive with no delete path, so a retry resumes instead of restarting. And the decision to copy comes from the live difference rather than a completion marker, because a marker outlives a return to the earlier release while consumers keep writing to MinIO, so trusting one would repoint them onto a store missing everything written since. Zero outstanding exits before any writer is frozen, which matters because the switch stays on for every later release.

One coupling is invisible from either template alone. Helm skips `post-upgrade` hooks when an upgrade fails, so a failure here would leave the CNPG migration's freeze un-resumed. The orchestrator therefore restores every writer it finds at zero, including ones it did not freeze itself.

## Validation

- **The migration completes on the shipping surface** — on Embedded Cluster with two populated buckets, the copy Pod ran once per bucket (3028 session objects, 41 automation objects), sorted-key sha256 matched on both stores with an empty key-set difference in each direction, a planted key containing spaces survived intact, MinIO's fingerprint was unchanged afterwards, and all four writers repointed across their main and init containers and returned to 1/1 from the apply. Writers were down 120s, of which the copy was 85s, using 4.7% of the hook's budget.
- **The frozen set is every writer** — an independent scan of all 18 workloads, covering every container, init container and `envFrom`, found the four the orchestrator freezes are the only ones that write to the store. The scheduled jobs that carry the same object-store environment from the shared env template do not use it: the maintenance task every install runs daily works only against the database, and the GitLab webhook installer, off by default, does API and database work.
- **Going back and forward again copies only the delta** — the completion marker survived the return to the earlier release, so the hazard it guards is real on this surface. The check then reported 25 objects outstanding, exactly what had been written while back on the earlier release, copied 25 of 3053 with the automation bucket correctly reporting 0 to copy, rewrote the marker from 3028 to 3053, and left a MinIO-minus-RustFS difference of 0. The retry cost 2s of copying in a 16s hook, against 85s and 91s for the initial migration. Repeating the same upgrade with nothing outstanding froze no writers and finished in 18s with the app Deployment's generation unchanged.
- **Two unrelated failures each abort before anything is repointed** — deploying with RustFS missing aborted at the hook's first action, the readiness check, with a message naming the fix and before the restore trap was even installed. Separately, blocking the copy Pod's network aborted later, at the read-only comparison step, on a DNS timeout. Each left the release failed with healthy workloads, consumers unchanged, no freeze record, no copy Pod, no Deployment generation churn, and the app serving throughout. Two different routes to the same safe outcome, so the guarantee does not rest on one check.
- **The bucket list matches what is actually deployed** — the sandbox workspace archive is the one object-store consumer KOTS never enables, so it was exercised on a Helm install with the archive resolving to s3 through an empty store type: its 61 objects reached RustFS with a key-set difference of 0 in both directions, including one at a path containing spaces, and the marker recorded both buckets. Rendering across six configurations confirms only the cases that should add a bucket do, no empty entry is appended, and a duplicate collapses.

_This PR was drafted by an AI agent on behalf of the user._
