### PR TITLE
fix(charts): restore the nested sandbox hostname default

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      # Several suites here assert contracts that span the chart and the
+      # Replicated manifests, so they have to run when either side moves and
+      # not only when the test itself is edited.
+      - 'charts/**'
+      - 'replicated/**'
       - '.github/workflows/publish-release-charts.yml'
       - '.github/workflows/test-scripts.yml'
 
 jobs:
   test-scripts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:
@@ -50,4 +55,5 @@ jobs:
           --with uvicorn
           --with httpx
           --with ruamel.yaml
+          --with PyYAML
           python -m pytest scripts -q

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -374,7 +374,7 @@ keycloak:
 runtime-api:
   ingress:
     enabled: true
-    hostname: runtime.openhands.example.com
+    hostname: runtimes.openhands.example.com
 litellm-helm:
   ingress:
     enabled: true

--- a/charts/openhands/example-values.yaml
+++ b/charts/openhands/example-values.yaml
@@ -34,7 +34,7 @@ keycloak:
   enabled: true
   ingress:
     enabled: false
-    hostname: "auth.example.com"
+    hostname: "auth.app.example.com"
     annotations: {}
     # Value should match your Issuer/ClusterIssuer and uncomment if you're using cert-manager for certificates
     # cert-manager.io/cluster-issuer: letsencrypt
@@ -106,10 +106,9 @@ runtime-api:
     # cert-manager.io/cluster-issuer: letsencrypt
   env:
     RUNTIME_BASE_URL: "runtime.example.com"
-    # Dash keeps each sandbox one label under the base domain
-    # ({id}-runtime.example.com), so one *.example.com wildcard covers them.
-    # Use "." to nest sandboxes under RUNTIME_BASE_URL instead.
-    RUNTIME_URL_SEPARATOR: "-"
+    # Sandboxes nest under RUNTIME_BASE_URL as {id}.runtime.example.com, so this
+    # needs a *.runtime.example.com wildcard. Set RUNTIME_URL_SEPARATOR to "-"
+    # for {id}-runtime.example.com instead, covered by *.example.com.
     # Set to storage class you want to use.
     STORAGE_CLASS: "gp2"
 

--- a/charts/openhands/tests/sandbox_hostname_layout_test.yaml
+++ b/charts/openhands/tests/sandbox_hostname_layout_test.yaml
@@ -1,0 +1,56 @@
+suite: sandbox hostname layout defaults
+# The app builds a sandbox URL from RUNTIME_URL_PATTERN; the runtime-api names
+# the ingress that serves it from RUNTIME_BASE_URL joined by
+# RUNTIME_URL_SEPARATOR. If the chart hands down a separator the deployment did
+# not ask for, those two disagree and every sandbox becomes unreachable, so the
+# chart ships the nested form and leaves the separator to the runtime-api's own
+# default. The flat layout is opt-in, and the Replicated installer opts in by
+# setting the separator explicitly.
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+  - charts/runtime-api/templates/deployment.yaml
+tests:
+  - it: leaves the sandbox hostname separator unset by default
+    set:
+      enabled: true
+      runtime-api.env.RUNTIME_BASE_URL: runtime.example.com
+    asserts:
+      - template: charts/runtime-api/templates/deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: RUNTIME_URL_SEPARATOR
+      - template: charts/runtime-api/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_BASE_URL
+            value: runtime.example.com
+
+  - it: passes an explicitly configured separator through to the runtime-api
+    set:
+      enabled: true
+      runtime-api.env.RUNTIME_BASE_URL: runtime.example.com
+      runtime-api.env.RUNTIME_URL_SEPARATOR: "-"
+    asserts:
+      - template: charts/runtime-api/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_URL_SEPARATOR
+            value: "-"
+
+  - it: defaults the app to the nested sandbox URL form
+    set:
+      enabled: true
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_URL_PATTERN
+            value: "https://{runtime_id}.runtime.app.example.com"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -84,10 +84,10 @@ env:
   DISABLE_WAITLIST: "true"
   SANDBOX_REMOTE_RUNTIME_API_TIMEOUT: "60"
   # How the app addresses a sandbox. Must agree with the runtime-api's
-  # RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR pair, which is what names each
-  # sandbox ingress. The dash separator keeps sandboxes one label under the base
-  # domain so a single wildcard certificate covers them.
-  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.example.com"
+  # RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR pair below, which is what names
+  # each sandbox ingress. The default nests sandboxes under the runtime base,
+  # matching the runtime-api's own "." separator.
+  RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.app.example.com"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 
@@ -444,7 +444,7 @@ keycloak:
   ingress:
     enabled: false
     # REQUIRED: Update to a hostname in a DNS domain you own
-    # hostname: auth.example.com
+    # hostname: auth.app.example.com
     servicePort: 80
     tls: true
     annotations: {}
@@ -968,11 +968,13 @@ runtime-api:
     # {id}{RUNTIME_URL_SEPARATOR}{RUNTIME_BASE_URL}. Must agree with the app's
     # env.RUNTIME_URL_PATTERN above.
     # RUNTIME_BASE_URL: "runtime.example.com"
-    # Joins the sandbox id to the base. "-" (the flat layout) keeps sandboxes one
-    # label under the base domain, so a single wildcard certificate covers them;
-    # "." nests them under RUNTIME_BASE_URL and needs *.RUNTIME_BASE_URL instead.
-    # The runtime-api defaults to "." when this is unset.
-    RUNTIME_URL_SEPARATOR: "-"
+    # Joins the sandbox id to the base. Left unset so the runtime-api applies its
+    # own default of ".", nesting each sandbox under RUNTIME_BASE_URL and needing
+    # a *.RUNTIME_BASE_URL wildcard. Set it to "-" to make sandboxes siblings of
+    # the base instead ({id}-runtime.example.com), which one wildcard a level up
+    # covers. Changing this on a running install moves every sandbox hostname, so
+    # the certificate and DNS records have to move with it.
+    # RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "true"
     MEMORY_REQUEST: "3072Mi"
     MEMORY_LIMIT: "3072Mi"

--- a/scripts/test_replicated_dns_layout.py
+++ b/scripts/test_replicated_dns_layout.py
@@ -1,0 +1,123 @@
+"""Tests for the sandbox hostname layout contract between chart and installer.
+
+A sandbox is served at {id}{RUNTIME_URL_SEPARATOR}{RUNTIME_BASE_URL}, and the
+app reaches it through RUNTIME_URL_PATTERN. The two are set in different places
+and have to agree, so the chart ships no separator at all (see
+charts/openhands/tests/sandbox_hostname_layout_test.yaml) and every installer
+that wants the flat layout sets one explicitly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
+
+SEPARATOR_OPTION = '{{repl ConfigOption "computed_runtime_hostname_separator" }}'
+BASE_OPTION = '{{repl ConfigOption "computed_runtime_base_hostname" }}'
+
+
+@pytest.fixture(scope="module")
+def helm_chart_cr() -> dict:
+    return yaml.safe_load(REPLICATED_OPENHANDS.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def config_items() -> dict:
+    config = yaml.safe_load(REPLICATED_CONFIG.read_text(encoding="utf-8"))
+    return {
+        item["name"]: item
+        for group in config["spec"]["groups"]
+        for item in group["items"]
+    }
+
+
+def optional_values(chart_cr: dict, marker: str) -> dict:
+    """The optionalValues block whose `when` mentions `marker`."""
+    matches = [
+        block
+        for block in chart_cr["spec"]["optionalValues"]
+        if marker in block.get("when", "")
+    ]
+    assert len(matches) == 1, f"expected one optionalValues block for {marker}"
+    return matches[0]["values"]
+
+
+def test_installer_sets_the_separator_rather_than_inheriting_a_chart_default(
+    helm_chart_cr: dict,
+) -> None:
+    runtime_api_env = helm_chart_cr["spec"]["values"]["runtime-api"]["env"]
+
+    assert runtime_api_env["RUNTIME_URL_SEPARATOR"] == SEPARATOR_OPTION
+    assert runtime_api_env["RUNTIME_BASE_URL"] == BASE_OPTION
+
+
+def test_app_sandbox_url_is_built_from_the_same_separator_and_base(
+    helm_chart_cr: dict,
+) -> None:
+    pattern = helm_chart_cr["spec"]["values"]["env"]["RUNTIME_URL_PATTERN"]
+
+    assert pattern == f"https://{{runtime_id}}{SEPARATOR_OPTION}{BASE_OPTION}"
+
+
+def test_path_routing_overrides_both_sides_to_the_shared_host_form(
+    helm_chart_cr: dict,
+) -> None:
+    values = optional_values(helm_chart_cr, '"runtime_routing_mode" "path"')
+
+    assert values["runtime-api"]["env"]["RUNTIME_URL_SEPARATOR"] == "/"
+    assert values["runtime-api"]["env"]["RUNTIME_ROUTING_MODE"] == "path"
+    assert values["env"]["RUNTIME_URL_PATTERN"] == f"https://{BASE_OPTION}/{{runtime_id}}"
+
+
+def test_only_the_simple_layout_flattens_sandboxes_onto_the_base_domain(
+    config_items: dict,
+) -> None:
+    separator = config_items["computed_runtime_hostname_separator"]
+
+    assert separator["hidden"] is True
+    # A `default:` re-renders on every config change, so an install that never
+    # touched the field still tracks its hostname_mode. A `value:` would pin the
+    # separator on first render and strand it there.
+    assert "value" not in separator
+    assert separator["default"] == (
+        '{{repl if ConfigOptionEquals "hostname_mode" "wildcard" }}-'
+        '{{repl else }}.{{repl end }}'
+    )
+
+
+def test_advertised_certificate_wildcard_tracks_the_separator(
+    config_items: dict,
+) -> None:
+    # A dash makes each sandbox a sibling of the runtime base rather than a
+    # child, so the covering wildcard sits one label above it: the SAN the
+    # operator is told to buy has to move with the separator.
+    wildcard = config_items["computed_sandbox_wildcard"]["default"]
+
+    assert wildcard == (
+        '{{repl if eq (ConfigOption "computed_runtime_hostname_separator") "-" }}'
+        '*.{{repl splitList "." (ConfigOption "computed_runtime_base_hostname")'
+        ' | rest | join "." }}'
+        f'{{{{repl else }}}}*.{BASE_OPTION}{{{{repl end }}}}'
+    )
+
+
+def test_hostname_mode_pins_existing_installs_to_the_legacy_layout(
+    config_items: dict,
+) -> None:
+    # Sequence is 0 only on a fresh install. Using `value:` (not `default:`)
+    # means the choice is written once and never re-rendered, so an upgrade
+    # cannot move an existing install's keycloak and sandbox hostnames off the
+    # names its certificate was issued for.
+    mode = config_items["hostname_mode"]
+
+    assert "default" not in mode
+    assert mode["value"] == (
+        '{{repl if eq Sequence 0 }}wildcard{{repl else }}derive{{repl end }}'
+    )
+    assert {item["name"] for item in mode["items"]} == {"wildcard", "derive", "custom"}


### PR DESCRIPTION
## Description

Chart 0.38.0 shipped `runtime-api.env.RUNTIME_URL_SEPARATOR: "-"` as a default. That was only meant for the replicated installer's Simple hostname layout, but a chart default reaches every consumer.

So the runtime-api started naming each sandbox ingress `{id}-runtime.<base>` while the app's `RUNTIME_URL_PATTERN` still asked for `{id}.<base>`. Those two have to agree or sandboxes never reach RUNNING, and conversations hang waiting for one. That's what took staging down, and it stayed down until saas-deploy pinned the dot form back per environment.

This takes the separator out of chart values entirely, so the runtime-api applies its own `.` default again. `env.RUNTIME_URL_PATTERN` and the `auth.app.<base>` keycloak examples go back to their pre-0.38.0 values too.

## Approach

The replicated installer already sets the separator explicitly from `computed_runtime_hostname_separator`, so Simple keeps the dash and none of the installer's layouts move.

I rendered all three hostname modes through the KOTS config graph and on into `helm template` to confirm that. Simple still gets `-`, with one `*.<base>` covering every ingress host and the sandbox name. Legacy still reproduces the pre-0.38.0 hostnames exactly, including `auth.app.<base>` and the `*.runtime.<base>` sandbox wildcard. Manual and both path-routing modes resolve consistently, and the chart preflight warns about the same SAN the installer tells you to buy in each mode.

Two guards so the chart and the installer can't drift apart again:

1. `charts/openhands/tests/sandbox_hostname_layout_test.yaml` asserts the chart ships no separator. It fails if the default comes back.
2. `scripts/test_replicated_dns_layout.py` asserts the installer sets one, on both the subdomain and path-routing paths.

That second suite only ran on `scripts/**` changes, which would have missed this entirely, so the workflow now triggers on `charts/**` and `replicated/**` as well.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

I kept the `AUTH_WEB_HOST` / `AUTH_URL` wiring and the preflight's separator awareness from #985. Neither is a values default. `keycloak.ingress.enabled` is false out of the box, so the derivation a chart consumer sees is unchanged, and the preflight already falls back to `.`.

All three saas-deploy environments pin `RUNTIME_URL_SEPARATOR: "."` today, so this lands as a no-op for them. Those pins are redundant once it ships.
