### PR TITLE
fix(litellm-helm): bump default image tag to 1.94.1 for memory fix

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -625,8 +625,12 @@ litellm-helm:
   # --use_v2_migration_resolver arg passed via the Replicated values and so
   # crashes on startup. Bare semver, no "v" prefix or "-stable" suffix (the
   # format BerriAI uses for 1.84.x+ stable images).
+  #
+  # 1.94.1 picks up the orphaned prisma query-engine reaping fix
+  # (BerriAI/litellm#33424, released in v1.94.0), which addresses the gradual
+  # per-worker memory growth seen on 1.93.0.
   image:
-    tag: "1.93.0"
+    tag: "1.94.1"
   masterkeySecretName: lite-llm-api-key
   masterkeySecretKey: lite-llm-api-key
   environmentSecrets: [litellm-env-secrets]


### PR DESCRIPTION
## Summary

Bumps the chart default LiteLLM image tag in `charts/openhands/values.yaml` (`litellm-helm.image.tag`) from **1.93.0** to **1.94.1**. This is the proper home for the fix — every environment consumes the chart default, so bumping it here lets the change flow through the normal chart-version promotion instead of per-environment image pins in `saas-deploy`.

## Motivation — memory growth

The production `litellm` container climbs steadily in working-set (non-evictable) memory. This is long-standing: 1.84.1 pods also grew to ~4.3–4.5 GiB over ~3 days, so it predates 1.93.0. 1.94.1 targets the underlying cause.

## Why 1.94.1

The load-bearing fix ships in **v1.94.0**:

- `fix(proxy_cli): reap orphaned prisma query-engine processes when a worker dies` — BerriAI/litellm#33424. Orphaned child processes accumulating RSS matches the gradual per-worker creep we observed.

1.94.1 is the latest stable patch in the 1.94 line and carries this fix. `litellm/litellm-database:1.94.1` confirmed present on Docker Hub.

---
_This PR was created by an AI agent (OpenHands) on behalf of @aivong._
