### PR TITLE
feat(agent-canvas): bump chart image tag to 1.10.0

### DIFF
--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -13,7 +13,7 @@ image:
   # images via Release Please). Environments that want a specific build can
   # override this, but the default should track a published release so the
   # chart ships a known-good version out of the box.
-  tag: "1.9.0"
+  tag: "1.10.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Bump the `agent-canvas` subchart's default image tag from `1.9.0` to `1.10.0`, so the `openhands` umbrella chart ships the current Agent Canvas release out of the box.

`agent-canvas` [v1.10.0](https://github.com/OpenHands/OpenHands/releases/tag/v1.10.0) was released on 2026-08-05. It is a feature-bearing minor release — manifest-driven automation sub-pages (#16303), a faceted skills rail (#16124), the featured automations landing dashboard (#16266), activity log export (#16234), and the Canvas default model moving to GLM 5.2 (#16146) — plus fixes for MCP credential preservation during Canvas mutations (#16144) and sidebar backend identity (#16243).

This is the same one-line change shape as the 1.9.0 bump in #1009 and the 1.8.0 bump in #998.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

<!-- Any additional information that reviewers should know -->