### PR TITLE
feat(agent-canvas): bump image tag to 1.12.0

### DIFF
--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -13,7 +13,7 @@ image:
   # images via Release Please). Environments that want a specific build can
   # override this, but the default should track a published release so the
   # chart ships a known-good version out of the box.
-  tag: "1.11.0"
+  tag: "1.12.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -13,7 +13,7 @@ image:
   # images via Release Please). Environments that want a specific build can
   # override this, but the default should track a published release so the
   # chart ships a known-good version out of the box.
-  tag: "1.10.0"
+  tag: "1.11.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

Agent Canvas **1.12.0** was released in `OpenHands/OpenHands` (squash-merged via PR #16357, commit `3c562fa6`). This bumps the `openhands` umbrella chart's embedded `agent-canvas` subchart default image tag so the chart ships the new release out of the box.

- File: `charts/openhands/charts/agent-canvas/values.yaml`
- Path: `.image.tag`
- `1.10.0` → `1.12.0`

This mirrors the automated `bump-image-tag` pattern (e.g. PR #1020 for `automation`, PR #864 for `agent-server`). The `openhands` component repo's release workflow does not currently wire up that reusable workflow for `agent-canvas`, so this is a manual bump following the same convention: a `feat(agent-canvas): …` title that release-please folds into the next `openhands` chart release PR (minor bump → `0.41.0` → `0.42.0`).

## Notes for reviewers

- This changes only the **chart default**. Environments that pin the agent-canvas image tag in their own `version.yaml` (e.g. `saas-deploy` staging currently pins `sha-39254fb`) override this default and are **unaffected** until their pin follows. A separate `saas-deploy` PR rolls staging + prod to `1.12.0`.
- The `agent-canvas` subchart is an inert, embedded subchart (`version: 0.0.0`, not published standalone); only its `image.tag` default is versioned here.

## Validation

- Single-line edit; comments, quoting, and blank lines preserved.
- Pending: chart lint / render via the repo's PR checks.

_This PR was created by an AI agent (OpenHands) on behalf of juanmichelini._

