### PR TITLE
fix(automation-chart): reject legacy ephemeral GCS storage

### DIFF
--- a/charts/openhands/charts/automation/templates/_env.yaml
+++ b/charts/openhands/charts/automation/templates/_env.yaml
@@ -39,6 +39,9 @@
 # to "gcs", the service's native FILE_STORE value.
 {{- $store := .Values.filestore.type }}
 {{- if eq $store "google_cloud" }}{{- $store = "gcs" }}{{- end }}
+{{- if and .Values.filestore.ephemeral (ne $store "s3") }}
+{{- fail (printf "filestore.type must be \"s3\" when legacy filestore.ephemeral is true; got %q" .Values.filestore.type) }}
+{{- end }}
 - name: FILE_STORE
   value: {{ $store | quote }}
 {{- if eq $store "s3" }}

--- a/charts/openhands/charts/automation/tests/storage_env_test.yaml
+++ b/charts/openhands/charts/automation/tests/storage_env_test.yaml
@@ -134,6 +134,15 @@ tests:
             name: GCS_BUCKET_NAME
             value: automation-data
 
+
+  - it: rejects legacy ephemeral storage when type is not S3
+    set:
+      filestore.ephemeral: true
+      filestore.type: gcs
+    asserts:
+      - failedTemplate:
+          errorPattern: filestore.type must be "s3" when legacy filestore.ephemeral is true
+
   - it: rejects storage backends the service does not support
     set:
       filestore.type: local


### PR DESCRIPTION
## Problem

The legacy automation chart accepted this contradictory configuration:

```yaml
filestore:
  ephemeral: true
  type: gcs
```

The old `ephemeral` rendering path forcibly selected S3/MinIO and ignored `filestore.type`, so the deployment worked while the values claimed GCS. This is the exact inconsistency previously present in saas-deploy feature values.

## Fix

Add one narrowly scoped render-time guard to the automation subchart:

- when legacy `filestore.ephemeral` is `true`, `filestore.type` must be `s3`

Add a regression test for `ephemeral: true` plus `type: gcs`.

No general backend-field validation or unrelated chart validation is included.

## Validation

- Automation chart: **8 tests passed**
- OpenHands chart: **81 tests passed**
- `git diff --check` passed

This PR was created by an AI agent (OpenHands) on behalf of the user.
